### PR TITLE
Remove trivial copy constructors and operators

### DIFF
--- a/include/IAnimatedMeshMD3.h
+++ b/include/IAnimatedMeshMD3.h
@@ -156,12 +156,6 @@ namespace scene
 			position.X = 0.f;
 		}
 
-		// construct copy constructor
-		SMD3QuaternionTag( const SMD3QuaternionTag & copyMe )
-		{
-			*this = copyMe;
-		}
-
 		// construct for searching
 		SMD3QuaternionTag( const core::stringc& name )
 			: Name ( name ) {}
@@ -181,14 +175,6 @@ namespace scene
 			return Name == other.Name;
 		}
 
-		SMD3QuaternionTag & operator=( const SMD3QuaternionTag & copyMe )
-		{
-			Name = copyMe.Name;
-			position = copyMe.position;
-			rotation = copyMe.rotation;
-			return *this;
-		}
-
 		core::stringc Name;
 		core::vector3df position;
 		core::quaternion rotation;
@@ -200,12 +186,6 @@ namespace scene
 		SMD3QuaternionTagList()
 		{
 			Container.setAllocStrategy(core::ALLOC_STRATEGY_SAFE);
-		}
-
-		// construct copy constructor
-		SMD3QuaternionTagList(const SMD3QuaternionTagList& copyMe)
-		{
-			*this = copyMe;
 		}
 
 		virtual ~SMD3QuaternionTagList() {}
@@ -248,12 +228,6 @@ namespace scene
 		void push_back(const SMD3QuaternionTag& other)
 		{
 			Container.push_back(other);
-		}
-
-		SMD3QuaternionTagList& operator = (const SMD3QuaternionTagList & copyMe)
-		{
-			Container = copyMe.Container;
-			return *this;
 		}
 
 	private:

--- a/include/IQ3Shader.h
+++ b/include/IQ3Shader.h
@@ -639,13 +639,6 @@ namespace quake3
 			: ID ( 0 ), VarGroup ( 0 )  {}
 		virtual ~IShader () {}
 
-		void operator = (const IShader &other )
-		{
-			ID = other.ID;
-			VarGroup = other.VarGroup;
-			name = other.name;
-		}
-
 		bool operator == (const IShader &other ) const
 		{
 			return 0 == strcmp ( name.c_str(), other.name.c_str () );

--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -328,53 +328,6 @@ namespace video
 			*this = other;
 		}
 
-		//! Assignment operator
-		/** \param other Material to copy from. */
-		SMaterial& operator=(const SMaterial& other)
-		{
-			// Check for self-assignment!
-			if (this == &other)
-				return *this;
-
-			MaterialType = other.MaterialType;
-
-			AmbientColor = other.AmbientColor;
-			DiffuseColor = other.DiffuseColor;
-			EmissiveColor = other.EmissiveColor;
-			SpecularColor = other.SpecularColor;
-			Shininess = other.Shininess;
-			MaterialTypeParam = other.MaterialTypeParam;
-			MaterialTypeParam2 = other.MaterialTypeParam2;
-			Thickness = other.Thickness;
-			for (u32 i=0; i<MATERIAL_MAX_TEXTURES_USED; ++i)
-			{
-				TextureLayer[i] = other.TextureLayer[i];
-			}
-
-			Wireframe = other.Wireframe;
-			PointCloud = other.PointCloud;
-			GouraudShading = other.GouraudShading;
-			Lighting = other.Lighting;
-			ZWriteEnable = other.ZWriteEnable;
-			BackfaceCulling = other.BackfaceCulling;
-			FrontfaceCulling = other.FrontfaceCulling;
-			FogEnable = other.FogEnable;
-			NormalizeNormals = other.NormalizeNormals;
-			ZBuffer = other.ZBuffer;
-			AntiAliasing = other.AntiAliasing;
-			ColorMask = other.ColorMask;
-			ColorMaterial = other.ColorMaterial;
-			BlendOperation = other.BlendOperation;
-			BlendFactor = other.BlendFactor;
-			PolygonOffsetFactor = other.PolygonOffsetFactor;
-			PolygonOffsetDirection = other.PolygonOffsetDirection;
-			PolygonOffsetDepthBias = other.PolygonOffsetDepthBias;
-			PolygonOffsetSlopeScale = other.PolygonOffsetSlopeScale;
-			UseMipMaps = other.UseMipMaps;
-
-			return *this;
-		}
-
 		//! Texture layer array.
 		SMaterialLayer TextureLayer[MATERIAL_MAX_TEXTURES];
 

--- a/include/irrMap.h
+++ b/include/irrMap.h
@@ -140,9 +140,6 @@ class map
 			reset();
 		}
 
-		// Copy constructor
-		Iterator(const Iterator& src) : Root(src.Root), Cur(src.Cur) {}
-
 		void reset(bool atLowest=true)
 		{
 			if (atLowest)
@@ -159,13 +156,6 @@ class map
 		Node* getNode() const
 		{
 			return Cur;
-		}
-
-		Iterator& operator=(const Iterator& src)
-		{
-			Root = src.Root;
-			Cur = src.Cur;
-			return (*this);
 		}
 
 		void operator++(int)
@@ -287,8 +277,7 @@ class map
 			reset();
 		}
 
-		// Copy constructor
-		ConstIterator(const ConstIterator& src) : Root(src.Root), Cur(src.Cur) {}
+		// Constructor(Iterator)
 		ConstIterator(const Iterator& src) : Root(src.Root), Cur(src.Cur) {}
 
 		void reset(bool atLowest=true)
@@ -307,13 +296,6 @@ class map
 		const Node* getNode() const
 		{
 			return Cur;
-		}
-
-		ConstIterator& operator=(const ConstIterator& src)
-		{
-			Root = src.Root;
-			Cur = src.Cur;
-			return (*this);
 		}
 
 		void operator++(int)

--- a/include/irrMap.h
+++ b/include/irrMap.h
@@ -435,13 +435,6 @@ class map
 		return Cur;
 	}
 
-	ParentFirstIterator& operator=(const ParentFirstIterator& src)
-	{
-		Root = src.Root;
-		Cur = src.Cur;
-		return (*this);
-	}
-
 	void operator++(int)
 	{
 		inc();
@@ -532,13 +525,6 @@ class map
 		Node* getNode()
 		{
 			return Cur;
-		}
-
-		ParentLastIterator& operator=(const ParentLastIterator& src)
-		{
-			Root = src.Root;
-			Cur = src.Cur;
-			return (*this);
 		}
 
 		void operator++(int)

--- a/include/line2d.h
+++ b/include/line2d.h
@@ -24,8 +24,6 @@ class line2d
 		line2d(T xa, T ya, T xb, T yb) : start(xa, ya), end(xb, yb) {}
 		//! Constructor for line between the two points given as vectors.
 		line2d(const vector2d<T>& start, const vector2d<T>& end) : start(start), end(end) {}
-		//! Copy constructor.
-		line2d(const line2d<T>& other) : start(other.start), end(other.end) {}
 
 		// operators
 

--- a/include/matrix4.h
+++ b/include/matrix4.h
@@ -102,9 +102,6 @@ namespace core
 			//! Simple operator for linearly accessing every element of the matrix.
 			const T& operator[](u32 index) const { return M[index]; }
 
-			//! Sets this matrix equal to the other matrix.
-			inline CMatrix4<T>& operator=(const CMatrix4<T> &other);
-
 			//! Sets all elements of this matrix to the value.
 			inline CMatrix4<T>& operator=(const T& scalar);
 
@@ -1501,19 +1498,6 @@ namespace core
 		}
 
 		return false;
-	}
-
-
-	template <class T>
-	inline CMatrix4<T>& CMatrix4<T>::operator=(const CMatrix4<T> &other)
-	{
-		if (this==&other)
-			return *this;
-		memcpy(M, other.M, 16*sizeof(T));
-#if defined ( USE_MATRIX_TEST )
-		definitelyIdentityMatrix=other.definitelyIdentityMatrix;
-#endif
-		return *this;
 	}
 
 

--- a/include/quaternion.h
+++ b/include/quaternion.h
@@ -55,9 +55,6 @@ class quaternion
 		//! inequality operator
 		bool operator!=(const quaternion& other) const;
 
-		//! Assignment operator
-		inline quaternion& operator=(const quaternion& other);
-
 #ifndef IRR_TEST_BROKEN_QUATERNION_USE
 		//! Matrix assignment operator
 		inline quaternion& operator=(const matrix4& other);
@@ -238,16 +235,6 @@ inline bool quaternion::operator==(const quaternion& other) const
 inline bool quaternion::operator!=(const quaternion& other) const
 {
 	return !(*this == other);
-}
-
-// assignment operator
-inline quaternion& quaternion::operator=(const quaternion& other)
-{
-	X = other.X;
-	Y = other.Y;
-	Z = other.Z;
-	W = other.W;
-	return *this;
 }
 
 #ifndef IRR_TEST_BROKEN_QUATERNION_USE

--- a/include/vector2d.h
+++ b/include/vector2d.h
@@ -27,16 +27,12 @@ public:
 	vector2d(T nx, T ny) : X(nx), Y(ny) {}
 	//! Constructor with the same value for both members
 	explicit vector2d(T n) : X(n), Y(n) {}
-	//! Copy constructor
-	vector2d(const vector2d<T>& other) : X(other.X), Y(other.Y) {}
 
 	vector2d(const dimension2d<T>& other) : X(other.Width), Y(other.Height) {}
 
 	// operators
 
 	vector2d<T> operator-() const { return vector2d<T>(-X, -Y); }
-
-	vector2d<T>& operator=(const vector2d<T>& other) { X = other.X; Y = other.Y; return *this; }
 
 	vector2d<T>& operator=(const dimension2d<T>& other) { X = other.Width; Y = other.Height; return *this; }
 

--- a/include/vector3d.h
+++ b/include/vector3d.h
@@ -28,14 +28,10 @@ namespace core
 		vector3d(T nx, T ny, T nz) : X(nx), Y(ny), Z(nz) {}
 		//! Constructor with the same value for all elements
 		explicit vector3d(T n) : X(n), Y(n), Z(n) {}
-		//! Copy constructor
-		vector3d(const vector3d<T>& other) : X(other.X), Y(other.Y), Z(other.Z) {}
 
 		// operators
 
 		vector3d<T> operator-() const { return vector3d<T>(-X, -Y, -Z); }
-
-		vector3d<T>& operator=(const vector3d<T>& other) { X = other.X; Y = other.Y; Z = other.Z; return *this; }
 
 		vector3d<T> operator+(const vector3d<T>& other) const { return vector3d<T>(X + other.X, Y + other.Y, Z + other.Z); }
 		vector3d<T>& operator+=(const vector3d<T>& other) { X+=other.X; Y+=other.Y; Z+=other.Z; return *this; }


### PR DESCRIPTION
Why? Compilers cannot optimize these away (even with `-O3`)!

<hr />

Consider this minimal example:

```cpp
#include <cstdint>

template <class T>
class vector3d
{
public:
	vector3d() : X(0), Y(0), Z(0) {}
#ifdef COPY
	vector3d(const vector3d<T>& other) : X(other.X), Y(other.Y), Z(other.Z) {}
	vector3d<T>& operator=(const vector3d<T>& other) { X = other.X; Y = other.Y; Z = other.Z; return *this; }
#endif
	T X, Y, Z;
};

extern vector3d<int32_t> g_vec;
vector3d<int32_t> func()
{
	vector3d<int32_t> m_vec = g_vec;
	return m_vec;
}
```

Compiled using `g++ test.cpp -c -S -o- -O3 -DCOPY`:
```asm
	movq	g_vec(%rip), %rdx
	movq	%rdi, %rax
	movq	%rdx, (%rdi)
	movl	8+g_vec(%rip), %edx
	movl	%edx, 8(%rdi)
	ret
```
`g++ test.cpp -c -S -o- -O3`:
```asm
	movl	8+g_vec(%rip), %edx
	movq	g_vec(%rip), %rax
	ret
```
`clang++ test.cpp -c -S -o- -O3 -DCOPY`:
```asm
	movq	%rdi, %rax
	movq	g_vec@GOTPCREL(%rip), %rcx
	movl	(%rcx), %edx
	movl	%edx, (%rdi)
	movl	4(%rcx), %edx
	movl	%edx, 4(%rdi)
	movl	8(%rcx), %ecx
	movl	%ecx, 8(%rdi)
	retq
```
`clang++ test.cpp -c -S -o- -O3`:
```asm
	movq	g_vec@GOTPCREL(%rip), %rcx
	movq	(%rcx), %rax
	movl	8(%rcx), %edx
	retq
```

It is most obvious in Clang's output:
With the copy constructor present, the compiler copies each vector component <b>individually</b>, with the constructor removed it can copy the underlying 12 bytes the most efficient way possible.
GCC is doing better, but still has to copy the vector twice since the vector is treated as a pointer. This is due to a different ABI, the vector can now be passed via registers.

<hr />

<b>Please squash when merging</b>