### PR TITLE
Add support for IMEs on Linux

### DIFF
--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -34,7 +34,11 @@ namespace irr
 		IrrlichtDevice::postEventFromUser. They take the same path as mouse events. */
 		EET_KEY_INPUT_EVENT,
 
-        //! A touch input event.
+		//! A string input event.
+		/** This event is created when multiple characters are sent at a time (e.g. using an IME). */
+		EET_STRING_INPUT_EVENT,
+
+		//! A touch input event.
 		EET_TOUCH_INPUT_EVENT,
 
 		//! A accelerometer event.
@@ -413,7 +417,14 @@ struct SEvent
 		bool Control:1;
 	};
 
-    //! Any kind of touch event.
+	//! String input event.
+	struct SStringInput
+	{
+		//! The string that is entered
+		core::stringw *Str;
+	};
+
+	//! Any kind of touch event.
 	struct STouchInput
 	{
 		// Touch ID.
@@ -581,6 +592,7 @@ struct SEvent
 		struct SGUIEvent GUIEvent;
 		struct SMouseInput MouseInput;
 		struct SKeyInput KeyInput;
+		struct SStringInput StringInput;
 		struct STouchInput TouchInput;
 		struct SAccelerometerEvent AccelerometerEvent;
 		struct SGyroscopeEvent GyroscopeEvent;

--- a/include/IGUIElement.h
+++ b/include/IGUIElement.h
@@ -789,6 +789,13 @@ public:
 	}
 
 
+	//! Returns whether the element takes input from the IME
+	virtual bool acceptsIME()
+	{
+		return false;
+	}
+
+
 	//! Writes attributes of the scene node.
 	/** Implement this to expose the attributes of your scene node for
 	scripting languages, editors, debuggers or xml serialization purposes. */

--- a/source/Irrlicht/CGUIEditBox.h
+++ b/source/Irrlicht/CGUIEditBox.h
@@ -139,6 +139,10 @@ namespace gui
 		//! Updates the absolute position, splits text if required
 		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
 
+		//! Returns whether the element takes input from the IME
+		virtual bool acceptsIME() _IRR_OVERRIDE_;
+
+
 		//! Writes attributes of the element.
 		virtual void serializeAttributes(io::IAttributes* out, io::SAttributeReadWriteOptions* options) const _IRR_OVERRIDE_;
 
@@ -154,6 +158,8 @@ namespace gui
 		s32 getLineFromPos(s32 pos);
 		//! adds a letter to the edit box
 		void inputChar(wchar_t c);
+		//! adds a string to the edit box
+		void inputString(const core::stringw &str);
 		//! calculates the current scroll position
 		void calculateScrollPos();
 		//! calculated the FrameRect

--- a/source/Irrlicht/CGUIEnvironment.cpp
+++ b/source/Irrlicht/CGUIEnvironment.cpp
@@ -656,6 +656,10 @@ bool CGUIEnvironment::postEventFromUser(const SEvent& event)
 			}
 		}
 		break;
+	case EET_STRING_INPUT_EVENT:
+		if (Focus && Focus->OnEvent(event))
+			return true;
+		break;
 	default:
 		break;
 	} // end switch

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -13,6 +13,7 @@
 #include <locale.h>
 #include "IEventReceiver.h"
 #include "ISceneManager.h"
+#include "IGUIElement.h"
 #include "IGUIEnvironment.h"
 #include "os.h"
 #include "CTimer.h"
@@ -705,6 +706,14 @@ bool CIrrDeviceLinux::createInputContext()
 		return false;
 	}
 
+	// Load XMODIFIERS (e.g. for IMEs)
+	if (!XSetLocaleModifiers(""))
+	{
+		setlocale(LC_CTYPE, oldLocale.c_str());
+		os::Printer::log("XSetLocaleModifiers failed. Falling back to non-i18n input.", ELL_WARNING);
+		return false;
+	}
+
 	XInputMethod = XOpenIM(XDisplay, NULL, NULL, NULL);
 	if ( !XInputMethod )
 	{
@@ -820,7 +829,7 @@ bool CIrrDeviceLinux::run()
 		{
 			XEvent event;
 			XNextEvent(XDisplay, &event);
-			if (XFilterEvent(&event, XWindow))
+			if (acceptsIME() && XFilterEvent(&event, None))
 				continue;
 
 			switch (event.type)
@@ -998,18 +1007,29 @@ bool CIrrDeviceLinux::run()
 					SKeyMap mp;
 					if ( XInputContext )
 					{
-						wchar_t buf[8]={0};
+						wchar_t buf[64]={0};
 						Status status;
-						int strLen = XwcLookupString(XInputContext, &event.xkey, buf, sizeof(buf), &mp.X11Key, &status);
+						int strLen = XwcLookupString(XInputContext, &event.xkey, buf, sizeof(buf)/sizeof(wchar_t)-1, &mp.X11Key, &status);
 						if ( status == XBufferOverflow )
 						{
 							os::Printer::log("XwcLookupString needs a larger buffer", ELL_INFORMATION);
 						}
 						if ( strLen > 0 && (status == XLookupChars || status == XLookupBoth) )
 						{
-							if ( strLen > 1 )
-								os::Printer::log("Additional returned characters dropped", ELL_INFORMATION);
-							irrevent.KeyInput.Char = buf[0];
+							if (strLen > 1)
+							{
+								// Multiple characters: send string event
+								irrevent.EventType = irr::EET_STRING_INPUT_EVENT;
+								irrevent.StringInput.Str = new core::stringw(buf);
+								postEventFromUser(irrevent);
+								delete irrevent.StringInput.Str;
+								irrevent.StringInput.Str = NULL;
+								break;
+							}
+							else
+							{
+								irrevent.KeyInput.Char = buf[0];
+							}
 						}
 						else
 						{
@@ -1044,7 +1064,6 @@ bool CIrrDeviceLinux::run()
 					irrevent.KeyInput.Control = (event.xkey.state & ControlMask) != 0;
 					irrevent.KeyInput.Shift = (event.xkey.state & ShiftMask) != 0;
 					irrevent.KeyInput.Key = getKeyCode(event);
-
 					postEventFromUser(irrevent);
 				}
 				break;
@@ -1138,6 +1157,22 @@ bool CIrrDeviceLinux::run()
 			} // end switch
 
 		} // end while
+
+		// Update IME information
+		if (GUIEnvironment)
+		{
+			gui::IGUIElement *elem = GUIEnvironment->getFocus();
+			if (elem && elem->acceptsIME())
+			{
+				core::rect<s32> r = elem->getAbsolutePosition();
+				XPoint p;
+				p.x = (short)r.UpperLeftCorner.X;
+				p.y = (short)r.LowerRightCorner.Y;
+				XVaNestedList l = XVaCreateNestedList(0, XNSpotLocation, &p, NULL);
+				XSetICValues(XInputContext, XNPreeditAttributes, l, NULL);
+				XFree(l);
+			}
+		}
 	}
 #endif //_IRR_COMPILE_WITH_X11_
 

--- a/source/Irrlicht/CIrrDeviceStub.cpp
+++ b/source/Irrlicht/CIrrDeviceStub.cpp
@@ -6,6 +6,7 @@
 #include "ISceneManager.h"
 #include "IEventReceiver.h"
 #include "IFileSystem.h"
+#include "IGUIElement.h"
 #include "IGUIEnvironment.h"
 #include "os.h"
 #include "IrrCompileConfig.h"
@@ -503,6 +504,14 @@ void CIrrDeviceStub::clearSystemMessages()
 {
 }
 
+//! Checks whether the input device should take input from the IME
+bool CIrrDeviceStub::acceptsIME()
+{
+	if (!GUIEnvironment)
+		return false;
+	gui::IGUIElement *elem = GUIEnvironment->getFocus();
+	return elem && elem->acceptsIME();
+}
 
 
 } // end namespace irr

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -194,6 +194,9 @@ namespace irr
 		void calculateGammaRamp ( u16 *ramp, f32 gamma, f32 relativebrightness, f32 relativecontrast );
 		void calculateGammaFromRamp ( f32 &gamma, const u16 *ramp );
 
+		//! Checks whether the input device should take input from the IME
+		bool acceptsIME();
+
 		video::IVideoDriver* VideoDriver;
 		gui::IGUIEnvironment* GUIEnvironment;
 		scene::ISceneManager* SceneManager;


### PR DESCRIPTION
This PR uses `XSetLocaleModifiers` to add support for IMEs.

# To-Do
This pull request is ready for review.
- [x] ~IME support only appears to work with certain locales (e.g. zh_CN) (this was tested with an older version of MT)~
- [x] TODO: Properly implement buffers for entering multiple characters at a time
- [x] Fix: the position of the IME hint appears to be constantly at the bottom of the screen
- [x] Fix: the IME is used in places where this behavior is not desired

# Breaking changes
- There is now a `EET_STRING_INPUT_EVENT` event:
  - The corresponding event field is `event.StringInput`
  - `event.StringInput.Str` contains a reference to the `core::stringw` that contains the entered string
- `IGUIElement` now has a `bool acceptsIME()` method that returns whether the element accepts input from the IME:
  - `true`: keyboard input events are filtered by the IME before being passed to the element
  - `false` (default): keyboard input events are not filtered by the IME

# References
* [https://gist.github.com/baines/5a49f1334281b2685af5dcae81a6fa8a](https://gist.github.com/baines/5a49f1334281b2685af5dcae81a6fa8a) (accessed on 2021-03-30)
* [https://www.x.org/releases/current/doc/libX11/libX11/libX11.pdf](https://www.x.org/releases/current/doc/libX11/libX11/libX11.pdf) (last access on 2021-04-02)