### PR TITLE
Work around bug installing targets created in a subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ project(Irrlicht
 
 message(STATUS "*** Building IrrlichtMt ${PROJECT_VERSION} ***")
 
+include(GNUInstallDirs)
+
 if(ANDROID)
 	set(sysname Android)
 elseif(APPLE)
@@ -34,13 +36,7 @@ if(BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
-# Installation of library and headers.
-include(GNUInstallDirs)
-install(TARGETS ${INSTALL_TARGETS}
-	EXPORT IrrlichtMt-export
-	DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-)
-
+# Installation of headers.
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
 	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/irrlichtmt"
 )
@@ -53,7 +49,7 @@ install(EXPORT IrrlichtMt-export
 )
 
 include(CMakePackageConfigHelpers)
-configure_package_config_file("${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"
+configure_package_config_file("${PROJECT_SOURCE_DIR}/Config.cmake.in"
 	"${CMAKE_CURRENT_BINARY_DIR}/IrrlichtMtConfig.cmake"
 	INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/IrrlichtMt"
 	NO_SET_AND_CHECK_MACRO

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -408,8 +408,6 @@ else()
 	set(INSTALL_TARGETS IrrlichtMt)
 endif()
 
-# Installation of library and headers.
-include(GNUInstallDirs)
 install(TARGETS ${INSTALL_TARGETS}
 	EXPORT IrrlichtMt-export
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -402,6 +402,7 @@ if(WIN32)
 	set_target_properties(IrrlichtMt PROPERTIES PREFIX "") # for DLL name
 endif()
 
+# Installation of library
 if(ANDROID)
 	set(INSTALL_TARGETS IrrlichtMt native_app_glue)
 else()

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -403,7 +403,14 @@ if(WIN32)
 endif()
 
 if(ANDROID)
-	set(INSTALL_TARGETS IrrlichtMt native_app_glue PARENT_SCOPE)
+	set(INSTALL_TARGETS IrrlichtMt native_app_glue)
 else()
-	set(INSTALL_TARGETS IrrlichtMt PARENT_SCOPE)
+	set(INSTALL_TARGETS IrrlichtMt)
 endif()
+
+# Installation of library and headers.
+include(GNUInstallDirs)
+install(TARGETS ${INSTALL_TARGETS}
+	EXPORT IrrlichtMt-export
+	DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)


### PR DESCRIPTION
The objective of this PR is to fix #28 . We need this tested by someone who has a CMake version less than 3.13 to see whether the changes are sufficient.