### PR TITLE
Add verbose flag to CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build
         run: |
           cmake .
-          make -j2
+          make VERBOSE=1 -j2
 
       - name: Package
         run: |

--- a/scripts/ci-build-mingw.sh
+++ b/scripts/ci-build-mingw.sh
@@ -32,5 +32,5 @@ cmake . \
 	-DZLIB_LIBRARY=$libs/zlib/lib/libz.dll.a \
 	-DZLIB_INCLUDE_DIR=$libs/zlib/include
 
-make VERBOSE=1 -j$(nproc)
+make -j$(nproc)
 exit 0

--- a/scripts/ci-build-mingw.sh
+++ b/scripts/ci-build-mingw.sh
@@ -32,5 +32,5 @@ cmake . \
 	-DZLIB_LIBRARY=$libs/zlib/lib/libz.dll.a \
 	-DZLIB_INCLUDE_DIR=$libs/zlib/include
 
-make -j$(nproc)
+make VERBOSE=1 -j$(nproc)
 exit 0


### PR DESCRIPTION
Make is now called with VERBOSITY=1 in the linux GL build in the CI, and in the mingw script which is run by both of the Windows builds in the CI.