### PR TITLE
Use relative include dir to fix subdir usage

### DIFF
--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-	${CMAKE_SOURCE_DIR}/include
+	${CMAKE_CURRENT_SOURCE_DIR}/../../include
 	${CMAKE_CURRENT_SOURCE_DIR}
 )
 add_definitions(-DIRRLICHT_EXPORTS=1)


### PR DESCRIPTION
To make it possible to use IrrlichtMt with `add_subdirectory()` command
use a relative include path instead of using `CMAKE_SOURCE_DIR`. When
using IrrlichtMt as a subdirectory the `CMAKE_SOURCE_DIR` variable points
to the root of the Minetest repo instead of the root of the IrrlichtMt
source directory, which breaks the build because the `IrrCompileConfig.h`
include can't be found.