### PR TITLE
Fix `getViewPort` returning incorrect results

### DIFF
--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -2101,9 +2101,7 @@ COGLES2Driver::~COGLES2Driver()
 
 	void COGLES2Driver::setViewPortRaw(u32 width, u32 height)
 	{
-		if (width > 0 && height > 0)
-			CacheHandler->setViewport(0, 0, width, height);
-
+		CacheHandler->setViewport(0, 0, width, height);
 		ViewPort = core::recti(0, 0, width, height);
 	}
 
@@ -2261,7 +2259,7 @@ COGLES2Driver::~COGLES2Driver()
 	void COGLES2Driver::OnResize(const core::dimension2d<u32>& size)
 	{
 		CNullDriver::OnResize(size);
-		setViewPort(core::recti(0, 0, size.Width, size.Height));
+		CacheHandler->setViewport(0, 0, size.Width, size.Height);
 		Transformation3DChanged = true;
 	}
 

--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -2099,12 +2099,12 @@ COGLES2Driver::~COGLES2Driver()
 	}
 
 
-	void COGLES2Driver::setViewPortRaw(const core::rect<s32>& vp)
+	void COGLES2Driver::setViewPortRaw(u32 width, u32 height)
 	{
-		if (vp.getHeight() > 0 && vp.getWidth() > 0)
-			CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+		if (width > 0 && height > 0)
+			CacheHandler->setViewport(0, 0, width, height);
 
-		ViewPort = vp;
+		ViewPort = core::recti(0, 0, width, height);
 	}
 
 
@@ -2469,7 +2469,7 @@ COGLES2Driver::~COGLES2Driver()
 
 			destRenderTargetSize = renderTarget->getSize();
 
-			setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
+			setViewPortRaw(destRenderTargetSize.Width, destRenderTargetSize.Height);
 		}
 		else
 		{
@@ -2477,7 +2477,7 @@ COGLES2Driver::~COGLES2Driver()
 
 			destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-			setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
+			setViewPortRaw(ScreenSize.Width, ScreenSize.Height);
 		}
 
 		if (CurrentRenderTargetSize != destRenderTargetSize)

--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -2099,6 +2099,15 @@ COGLES2Driver::~COGLES2Driver()
 	}
 
 
+	void COGLES2Driver::setViewPortRaw(const core::rect<s32>& vp)
+	{
+		if (vp.getHeight() > 0 && vp.getWidth() > 0)
+			CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+
+		ViewPort = vp;
+	}
+
+
 	//! Draws a shadow volume into the stencil buffer.
 	void COGLES2Driver::drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible)
 	{
@@ -2252,7 +2261,7 @@ COGLES2Driver::~COGLES2Driver()
 	void COGLES2Driver::OnResize(const core::dimension2d<u32>& size)
 	{
 		CNullDriver::OnResize(size);
-		CacheHandler->setViewport(0, 0, size.Width, size.Height);
+		setViewPort(core::recti(0, 0, size.Width, size.Height));
 		Transformation3DChanged = true;
 	}
 
@@ -2460,7 +2469,7 @@ COGLES2Driver::~COGLES2Driver()
 
 			destRenderTargetSize = renderTarget->getSize();
 
-			CacheHandler->setViewport(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height);
+			setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
 		}
 		else
 		{
@@ -2468,7 +2477,7 @@ COGLES2Driver::~COGLES2Driver()
 
 			destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-			CacheHandler->setViewport(0, 0, ScreenSize.Width, ScreenSize.Height);
+			setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
 		}
 
 		if (CurrentRenderTargetSize != destRenderTargetSize)

--- a/source/Irrlicht/COGLES2Driver.h
+++ b/source/Irrlicht/COGLES2Driver.h
@@ -380,7 +380,7 @@ namespace video
 		bool setMaterialTexture(irr::u32 layerIdx, const irr::video::ITexture* texture);
 
 		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
-		virtual void setViewPortRaw(const core::rect<s32>& vp);
+		virtual void setViewPortRaw(u32 width, u32 height);
 
 		COGLES2CacheHandler* CacheHandler;
 		core::stringw Name;

--- a/source/Irrlicht/COGLES2Driver.h
+++ b/source/Irrlicht/COGLES2Driver.h
@@ -379,6 +379,9 @@ namespace video
 
 		bool setMaterialTexture(irr::u32 layerIdx, const irr::video::ITexture* texture);
 
+		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
+		virtual void setViewPortRaw(const core::rect<s32>& vp);
+
 		COGLES2CacheHandler* CacheHandler;
 		core::stringw Name;
 		core::stringc VendorName;

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -2332,9 +2332,7 @@ void COGLES1Driver::setViewPort(const core::rect<s32>& area)
 
 void COGLES1Driver::setViewPortRaw(u32 width, u32 height)
 {
-	if (width > 0 && height > 0)
-		CacheHandler->setViewport(0, 0, width, height);
-
+	CacheHandler->setViewport(0, 0, width, height);
 	ViewPort = core::recti(0, 0, width, height);
 }
 
@@ -2566,7 +2564,7 @@ void COGLES1Driver::draw3DLine(const core::vector3df& start,
 void COGLES1Driver::OnResize(const core::dimension2d<u32>& size)
 {
 	CNullDriver::OnResize(size);
-	setViewPort(core::recti(0, 0, size.Width, size.Height));
+	CacheHandler->setViewport(0, 0, size.Width, size.Height);
 	Transformation3DChanged = true;
 }
 

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -2330,12 +2330,12 @@ void COGLES1Driver::setViewPort(const core::rect<s32>& area)
 }
 
 
-void COGLES1Driver::setViewPortRaw(const core::rect<s32>& vp)
+void COGLES1Driver::setViewPortRaw(u32 width, u32 height)
 {
-	if (vp.getHeight() > 0 && vp.getWidth() > 0)
-		CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+	if (width > 0 && height > 0)
+		CacheHandler->setViewport(0, 0, width, height);
 
-	ViewPort = vp;
+	ViewPort = core::recti(0, 0, width, height);
 }
 
 
@@ -2788,7 +2788,7 @@ bool COGLES1Driver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = renderTarget->getSize();
 
-		setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
+		setViewPortRaw(destRenderTargetSize.Width, destRenderTargetSize.Height);
 	}
 	else
 	{
@@ -2814,7 +2814,7 @@ bool COGLES1Driver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-		setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
+		setViewPortRaw(ScreenSize.Width, ScreenSize.Height);
 	}
 
 	if (CurrentRenderTargetSize != destRenderTargetSize)

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -2330,6 +2330,15 @@ void COGLES1Driver::setViewPort(const core::rect<s32>& area)
 }
 
 
+void COGLES1Driver::setViewPortRaw(const core::rect<s32>& vp)
+{
+	if (vp.getHeight() > 0 && vp.getWidth() > 0)
+		CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+
+	ViewPort = vp;
+}
+
+
 //! Draws a shadow volume into the stencil buffer.
 void COGLES1Driver::drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible)
 {
@@ -2557,7 +2566,7 @@ void COGLES1Driver::draw3DLine(const core::vector3df& start,
 void COGLES1Driver::OnResize(const core::dimension2d<u32>& size)
 {
 	CNullDriver::OnResize(size);
-	CacheHandler->setViewport(0, 0, size.Width, size.Height);
+	setViewPort(core::recti(0, 0, size.Width, size.Height));
 	Transformation3DChanged = true;
 }
 
@@ -2779,7 +2788,7 @@ bool COGLES1Driver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = renderTarget->getSize();
 
-		CacheHandler->setViewport(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height);
+		setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
 	}
 	else
 	{
@@ -2805,7 +2814,7 @@ bool COGLES1Driver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-		CacheHandler->setViewport(0, 0, ScreenSize.Width, ScreenSize.Height);
+		setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
 	}
 
 	if (CurrentRenderTargetSize != destRenderTargetSize)

--- a/source/Irrlicht/COGLESDriver.h
+++ b/source/Irrlicht/COGLESDriver.h
@@ -343,7 +343,7 @@ namespace video
 		void assignHardwareLight(u32 lightIndex);
 
 		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
-		virtual void setViewPortRaw(const core::rect<s32>& vp);
+		virtual void setViewPortRaw(u32 width, u32 height);
 
 		COGLES1CacheHandler* CacheHandler;
 

--- a/source/Irrlicht/COGLESDriver.h
+++ b/source/Irrlicht/COGLESDriver.h
@@ -342,6 +342,9 @@ namespace video
 		//! \param[in] lightIndex: the index of the requesting light
 		void assignHardwareLight(u32 lightIndex);
 
+		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
+		virtual void setViewPortRaw(const core::rect<s32>& vp);
+
 		COGLES1CacheHandler* CacheHandler;
 
 		core::stringw Name;

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -3240,12 +3240,12 @@ void COpenGLDriver::setViewPort(const core::rect<s32>& area)
 }
 
 
-void COpenGLDriver::setViewPortRaw(const core::rect<s32>& vp)
+void COpenGLDriver::setViewPortRaw(u32 width, u32 height)
 {
-	if (vp.getHeight() > 0 && vp.getWidth() > 0)
-		CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+	if (width > 0 && height > 0)
+		CacheHandler->setViewport(0, 0, width, height);
 
-	ViewPort = vp;
+	ViewPort = core::recti(0, 0, width, height);
 }
 
 
@@ -3881,7 +3881,7 @@ bool COpenGLDriver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = renderTarget->getSize();
 
-		setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
+		setViewPortRaw(destRenderTargetSize.Width, destRenderTargetSize.Height);
 	}
 	else
 	{
@@ -3907,7 +3907,7 @@ bool COpenGLDriver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-		setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
+		setViewPortRaw(ScreenSize.Width, ScreenSize.Height);
 	}
 
 	if (CurrentRenderTargetSize != destRenderTargetSize)

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -3240,6 +3240,15 @@ void COpenGLDriver::setViewPort(const core::rect<s32>& area)
 }
 
 
+void COpenGLDriver::setViewPortRaw(const core::rect<s32>& vp)
+{
+	if (vp.getHeight() > 0 && vp.getWidth() > 0)
+		CacheHandler->setViewport(vp.UpperLeftCorner.X, vp.UpperLeftCorner.Y, vp.LowerRightCorner.X, vp.LowerRightCorner.Y);
+
+	ViewPort = vp;
+}
+
+
 //! Draws a shadow volume into the stencil buffer. To draw a stencil shadow, do
 //! this: First, draw all geometry. Then use this method, to draw the shadow
 //! volume. Next use IVideoDriver::drawStencilShadow() to visualize the shadow.
@@ -3633,7 +3642,7 @@ bool COpenGLDriver::needsTransparentRenderPass(const irr::video::SMaterial& mate
 void COpenGLDriver::OnResize(const core::dimension2d<u32>& size)
 {
 	CNullDriver::OnResize(size);
-	CacheHandler->setViewport(0, 0, size.Width, size.Height);
+	setViewPort(core::recti(0, 0, size.Width, size.Height));
 	Transformation3DChanged = true;
 }
 
@@ -3872,7 +3881,7 @@ bool COpenGLDriver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = renderTarget->getSize();
 
-		CacheHandler->setViewport(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height);
+		setViewPortRaw(core::recti(0, 0, destRenderTargetSize.Width, destRenderTargetSize.Height));
 	}
 	else
 	{
@@ -3898,7 +3907,7 @@ bool COpenGLDriver::setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SCol
 
 		destRenderTargetSize = core::dimension2d<u32>(0, 0);
 
-		CacheHandler->setViewport(0, 0, ScreenSize.Width, ScreenSize.Height);
+		setViewPortRaw(core::recti(0, 0, ScreenSize.Width, ScreenSize.Height));
 	}
 
 	if (CurrentRenderTargetSize != destRenderTargetSize)
@@ -3972,7 +3981,7 @@ IImage* COpenGLDriver::createScreenShot(video::ECOLOR_FORMAT format, video::E_RE
 	if (format==video::ECF_UNKNOWN)
 		format=getColorFormat();
 
-	// TODO: Maybe we could support more formats (floating point and some of those beyond ECF_R8), didn't really try yet 
+	// TODO: Maybe we could support more formats (floating point and some of those beyond ECF_R8), didn't really try yet
 	if (IImage::isCompressedFormat(format) || IImage::isDepthFormat(format) || IImage::isFloatingPointFormat(format) || format >= ECF_R8)
 		return 0;
 

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -3242,9 +3242,7 @@ void COpenGLDriver::setViewPort(const core::rect<s32>& area)
 
 void COpenGLDriver::setViewPortRaw(u32 width, u32 height)
 {
-	if (width > 0 && height > 0)
-		CacheHandler->setViewport(0, 0, width, height);
-
+	CacheHandler->setViewport(0, 0, width, height);
 	ViewPort = core::recti(0, 0, width, height);
 }
 
@@ -3642,7 +3640,7 @@ bool COpenGLDriver::needsTransparentRenderPass(const irr::video::SMaterial& mate
 void COpenGLDriver::OnResize(const core::dimension2d<u32>& size)
 {
 	CNullDriver::OnResize(size);
-	setViewPort(core::recti(0, 0, size.Width, size.Height));
+	CacheHandler->setViewport(0, 0, size.Width, size.Height);
 	Transformation3DChanged = true;
 }
 

--- a/source/Irrlicht/COpenGLDriver.h
+++ b/source/Irrlicht/COpenGLDriver.h
@@ -457,7 +457,7 @@ namespace video
 				scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);
 
 		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
-		virtual void setViewPortRaw(const core::rect<s32>& vp);
+		virtual void setViewPortRaw(u32 width, u32 height);
 
 		COpenGLCacheHandler* CacheHandler;
 

--- a/source/Irrlicht/COpenGLDriver.h
+++ b/source/Irrlicht/COpenGLDriver.h
@@ -428,7 +428,7 @@ namespace video
 		virtual ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) _IRR_OVERRIDE_;
 
 		virtual ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) _IRR_OVERRIDE_;
-		
+
 		//! creates a transposed matrix in supplied GLfloat array to pass to OpenGL
 		inline void getGLMatrix(GLfloat gl_matrix[16], const core::matrix4& m);
 		inline void getGLTextureMatrix(GLfloat gl_matrix[16], const core::matrix4& m);
@@ -455,6 +455,9 @@ namespace video
 		//! helper function doing the actual rendering.
 		void renderArray(const void* indexList, u32 primitiveCount,
 				scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType);
+
+		//! Same as `CacheHandler->setViewport`, but also sets `ViewPort`
+		virtual void setViewPortRaw(const core::rect<s32>& vp);
 
 		COpenGLCacheHandler* CacheHandler;
 


### PR DESCRIPTION
`IVideoDriver::getViewPort` has a bug where it only returns viewports set explicitly by `setViewPort`.  However, `OnResize` and `setRenderTarget(Ex)` also set the viewport since the drawing area has changed, but they only set it for OpenGL, not for `getViewPort`.  This PR fixes that.

Minetest currently doesn't do enough to run into any problems with this, but https://github.com/minetest/minetest/pull/10801 does, and this PR makes it work without a hacky workaround.