### PR TITLE
Add missing gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake
+IrrlichtMtConfig.cmake
+IrrlichtMtConfigVersion.cmake
 Makefile
+libs/*
 *.so*
 *.a
 *.exe
+*.dll
 bin/Linux


### PR DESCRIPTION
- Add to .gitignore all the artifacts generated by the CI build script on mingw