### PR TITLE
Clone .editorconfig from minetest/master

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+end_of_line = lf
+
+[*.{cpp,h,lua,txt,glsl,md,c,cmake,java,gradle}]
+charset = utf8
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,7 @@
 [*]
-end_of_line = lf
+charset = utf-8
 
-[*.{cpp,h,lua,txt,glsl,md,c,cmake,java,gradle}]
-charset = utf8
+[*.{cpp,h,txt,cmake,fsh,vsh}]
 indent_size = 4
 indent_style = tab
 insert_final_newline = true


### PR DESCRIPTION
Irrlicht appears to use the same indent style as we do, so nothing was changed.