### PR TITLE
Export targets to build tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 CMakeFiles
 CMakeCache.txt
 cmake_install.cmake
+install_manifest.txt
 IrrlichtMtConfig.cmake
 IrrlichtMtConfigVersion.cmake
+IrrlichtMtTargets.cmake
 Makefile
 libs/*
 *.so*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ write_basic_package_version_file(
 )
 
 install(FILES
-	"${CMAKE_CURRENT_BINARY_DIR}/IrrlichtMtConfig.cmake"
-	"${CMAKE_CURRENT_BINARY_DIR}/IrrlichtMtConfigVersion.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/cmake/IrrlichtMtConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/cmake/IrrlichtMtConfigVersion.cmake"
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/IrrlichtMt"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,14 @@ if(BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
 
+# Export a file that describes the targets that IrrlichtMt creates.
+# The file is placed in the location FILE points to, where CMake can easily
+# locate it by pointing CMAKE_PREFIX_PATH to this project root.
+export(EXPORT IrrlichtMt-export
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/IrrlichtMtTargets.cmake"
+	NAMESPACE IrrlichtMt::
+)
+
 # Installation of headers.
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
 	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/irrlichtmt"
@@ -50,13 +58,13 @@ install(EXPORT IrrlichtMt-export
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file("${PROJECT_SOURCE_DIR}/Config.cmake.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/IrrlichtMtConfig.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/cmake/IrrlichtMtConfig.cmake"
 	INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/IrrlichtMt"
 	NO_SET_AND_CHECK_MACRO
 	NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 write_basic_package_version_file(
-	"${CMAKE_CURRENT_BINARY_DIR}/IrrlichtMtConfigVersion.cmake"
+	"${CMAKE_CURRENT_BINARY_DIR}/cmake/IrrlichtMtConfigVersion.cmake"
 	COMPATIBILITY AnyNewerVersion
 )
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ e.g. on a Linux system you might want to build for local use like this:
 	cmake . -DBUILD_SHARED_LIBS=OFF
 	make -j$(nproc)
 
-This will put an IrrlichtMtTargets.cmake file into a cmake/ directory in the current build directory, and it can then be imported from another project by pointing find_package() to the source directory of this project, or if you used an out of source build, by setting the CMAKE_PREFIX_PATH variable to that same path.
+This will put an IrrlichtMtTargets.cmake file into a cmake/ directory in the current build directory, and it can then be imported from another project by pointing find_package() to the source directory of this project, or by setting the CMAKE_PREFIX_PATH variable to that same path.
 
 Platforms
 ---------

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ e.g. on a Linux system you might want to build for local use like this:
 	cmake . -DBUILD_SHARED_LIBS=OFF
 	make -j$(nproc)
 
-This will put an IrrlichtMtTargets.cmake file into a cmake/ directory in the current build directory, and it can then be imported from another project by pointing find_package() to the source directory of this project, or by setting the CMAKE_PREFIX_PATH variable to that same path.
+This will put an IrrlichtMtTargets.cmake file into a cmake/ directory in the current build directory, and it can then be imported from another project by pointing find_package() to the source directory of this project, or if you used an out of source build, by setting the CMAKE_PREFIX_PATH variable to that same path.
 
 Platforms
 ---------

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ e.g. on a Linux system you might want to build for local use like this:
 	cmake . -DBUILD_SHARED_LIBS=OFF
 	make -j$(nproc)
 
+This will put an IrrlichtMtTargets.cmake file into a cmake/ directory in the current build directory, and it can then be imported from another project by pointing find_package() to the source directory of this project, or by setting the CMAKE_PREFIX_PATH variable to that same path.
+
 Platforms
 ---------
 


### PR DESCRIPTION
It is insecure and inconvenient to necessitate installing IrrlichtMt to access the target export. A copy of the export is now placed in the build tree during configuration so that it can be directly accessed from any project by pointing find_package() to look at the IrrlichtMt source directory.