### PR TITLE
Fix .x material slot parsing

### DIFF
--- a/source/Irrlicht/CXMeshFileLoader.cpp
+++ b/source/Irrlicht/CXMeshFileLoader.cpp
@@ -89,7 +89,6 @@ IAnimatedMesh* CXMeshFileLoader::createMesh(io::IReadFile* file)
 	P=0;
 	End=0;
 	CurFrame=0;
-	MaterialSlotCount=0;
 
 	delete [] Buffer;
 	Buffer = 0;

--- a/source/Irrlicht/CXMeshFileLoader.cpp
+++ b/source/Irrlicht/CXMeshFileLoader.cpp
@@ -122,6 +122,7 @@ bool CXMeshFileLoader::load(io::IReadFile* file)
 		for (i=0; i<mesh->MaterialSlotCount; ++i)
 		{
 			mesh->Buffers.push_back( AnimatedMesh->addMeshBuffer() );
+			mesh->Buffers.getLast()->Material = video::SMaterial();
 
 			if (!mesh->HasSkinning)
 			{

--- a/source/Irrlicht/CXMeshFileLoader.h
+++ b/source/Irrlicht/CXMeshFileLoader.h
@@ -39,12 +39,6 @@ public:
 	//! See IReferenceCounted::drop() for more information.
 	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
 
-	struct SXTemplateMaterial
-	{
-		core::stringc Name; // template name from Xfile
-		video::SMaterial Material; // material
-	};
-
 	struct SXMesh
 	{
 		SXMesh() : MaxSkinWeightsPerVertex(0), MaxSkinWeightsPerFace(0), BoneCount(0),AttachedJointID(-1),HasSkinning(false), HasVertexColors(false) {}
@@ -71,9 +65,8 @@ public:
 
 		core::array<u32> Indices;
 
+		u32 MaterialSlotCount;
 		core::array<u32> FaceMaterialIndices; // index of material for each face
-
-		core::array<video::SMaterial> Materials; // material array
 
 		core::array<u32> WeightJoint;
 		core::array<u32> WeightNum;
@@ -181,8 +174,6 @@ private:
 	CSkinnedMesh::SJoint *CurFrame;
 
 	core::array<SXMesh*> Meshes;
-
-	core::array<SXTemplateMaterial> TemplateMaterials;
 
 	u32 MajorVersion;
 	u32 MinorVersion;

--- a/source/Irrlicht/CXMeshFileLoader.h
+++ b/source/Irrlicht/CXMeshFileLoader.h
@@ -39,6 +39,12 @@ public:
 	//! See IReferenceCounted::drop() for more information.
 	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
 
+	struct SXTemplateMaterial
+	{
+		core::stringc Name; // template name from Xfile
+		video::SMaterial Material; // material
+	};
+
 	struct SXMesh
 	{
 		SXMesh() : MaxSkinWeightsPerVertex(0), MaxSkinWeightsPerFace(0), BoneCount(0),AttachedJointID(-1),HasSkinning(false), HasVertexColors(false) {}
@@ -65,8 +71,9 @@ public:
 
 		core::array<u32> Indices;
 
-		u32 MaterialSlotCount;
 		core::array<u32> FaceMaterialIndices; // index of material for each face
+
+		core::array<video::SMaterial> Materials; // material array
 
 		core::array<u32> WeightJoint;
 		core::array<u32> WeightNum;
@@ -174,6 +181,8 @@ private:
 	CSkinnedMesh::SJoint *CurFrame;
 
 	core::array<SXMesh*> Meshes;
+
+	core::array<SXTemplateMaterial> TemplateMaterials;
 
 	u32 MajorVersion;
 	u32 MinorVersion;

--- a/source/Irrlicht/CXMeshFileLoader.h
+++ b/source/Irrlicht/CXMeshFileLoader.h
@@ -39,12 +39,6 @@ public:
 	//! See IReferenceCounted::drop() for more information.
 	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
 
-	struct SXTemplateMaterial
-	{
-		core::stringc Name; // template name from Xfile
-		video::SMaterial Material; // material
-	};
-
 	struct SXMesh
 	{
 		SXMesh() : MaxSkinWeightsPerVertex(0), MaxSkinWeightsPerFace(0), BoneCount(0),AttachedJointID(-1),HasSkinning(false), HasVertexColors(false) {}
@@ -181,8 +175,6 @@ private:
 	CSkinnedMesh::SJoint *CurFrame;
 
 	core::array<SXMesh*> Meshes;
-
-	core::array<SXTemplateMaterial> TemplateMaterials;
 
 	u32 MajorVersion;
 	u32 MinorVersion;


### PR DESCRIPTION
Apparently .x files where the materials block isn't stripped are crashing the importer.