### PR TITLE
Expose GL typedefs in the header

### DIFF
--- a/include/mt_opengl.h
+++ b/include/mt_opengl.h
@@ -20,41 +20,40 @@
 	#define GLAPI extern
 #endif
 
+typedef void GLvoid;
+typedef unsigned int GLenum;
+typedef khronos_float_t GLfloat;
+typedef int GLint;
+typedef int GLsizei;
+typedef unsigned int GLbitfield;
+typedef double GLdouble;
+typedef unsigned int GLuint;
+typedef unsigned char GLboolean;
+typedef khronos_uint8_t GLubyte;
+typedef khronos_float_t GLclampf;
+typedef double GLclampd;
+typedef khronos_ssize_t GLsizeiptr;
+typedef khronos_intptr_t GLintptr;
+typedef char GLchar;
+typedef khronos_int16_t GLshort;
+typedef khronos_int8_t GLbyte;
+typedef khronos_uint16_t GLushort;
+typedef khronos_uint16_t GLhalf;
+typedef struct __GLsync *GLsync;
+typedef khronos_uint64_t GLuint64;
+typedef khronos_int64_t GLint64;
+typedef khronos_uint64_t GLuint64EXT;
+typedef void *GLeglImageOES;
+typedef khronos_int64_t GLint64EXT;
+
+typedef void *GLeglClientBufferEXT;
+// The script will miss this particular typedef thinking it's a PFN,
+// so we have to paste it in manually. It's the only such type in OpenGL.
+typedef void (APIENTRY *GLDEBUGPROC)
+	(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
+
 class OpenGLProcedures {
 private:
-	// ./glcorearb.h
-	typedef void GLvoid;
-	typedef unsigned int GLenum;
-	typedef khronos_float_t GLfloat;
-	typedef int GLint;
-	typedef int GLsizei;
-	typedef unsigned int GLbitfield;
-	typedef double GLdouble;
-	typedef unsigned int GLuint;
-	typedef unsigned char GLboolean;
-	typedef khronos_uint8_t GLubyte;
-	typedef khronos_float_t GLclampf;
-	typedef double GLclampd;
-	typedef khronos_ssize_t GLsizeiptr;
-	typedef khronos_intptr_t GLintptr;
-	typedef char GLchar;
-	typedef khronos_int16_t GLshort;
-	typedef khronos_int8_t GLbyte;
-	typedef khronos_uint16_t GLushort;
-	typedef khronos_uint16_t GLhalf;
-	typedef struct __GLsync *GLsync;
-	typedef khronos_uint64_t GLuint64;
-	typedef khronos_int64_t GLint64;
-	typedef khronos_uint64_t GLuint64EXT;
-	typedef void *GLeglImageOES;
-	typedef khronos_int64_t GLint64EXT;
-
-	typedef void *GLeglClientBufferEXT;
-	// The script will miss this particular typedef thinking it's a PFN,
-	// so we have to paste it in manually. It's the only such type in OpenGL.
-	typedef void (APIENTRY *GLDEBUGPROC)
-		(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
-
 	typedef void (APIENTRYP PFNGLCULLFACEPROC_MT) (GLenum mode);
 	typedef void (APIENTRYP PFNGLFRONTFACEPROC_MT) (GLenum mode);
 	typedef void (APIENTRYP PFNGLHINTPROC_MT) (GLenum target, GLenum mode);


### PR DESCRIPTION
This is a minor amendment to the GL binding.

While it would technically be alright to just use matching plain types like `u32`, `float`, etc. as the GL ABI is not likely to change, this makes things easier by actually exposing them in the header, so that you don't have to open the header to look up which type a parameter really is.