### PR TITLE
Fix X11 selections

### DIFF
--- a/include/irrString.h
+++ b/include/irrString.h
@@ -35,8 +35,8 @@ outside the string class for explicit use.
 // forward declarations
 template <typename T, typename TAlloc = irrAllocator<T> >
 class string;
-static size_t multibyteToWString(string<wchar_t> &destination, const char *source, u32 sourceSize);
-static size_t wStringToMultibyte(string<c8> &destination, const wchar_t *source, u32 sourceSize);
+static size_t multibyteToWString(string<wchar_t>& destination, const char* source, u32 sourceSize);
+static size_t wStringToMultibyte(string<c8>& destination, const wchar_t* source, u32 sourceSize);
 inline s32 isdigit(s32 c);
 
 enum eLocaleID
@@ -1424,8 +1424,8 @@ public:
 		return ret.size()-oldSize;
 	}
 
-	friend size_t multibyteToWString(string<wchar_t> &destination, const char *source, u32 sourceSize);
-	friend size_t wStringToMultibyte(string<c8> &destination, const wchar_t *source, u32 sourceSize);
+	friend size_t multibyteToWString(string<wchar_t>& destination, const char* source, u32 sourceSize);
+	friend size_t wStringToMultibyte(string<c8>& destination, const wchar_t* source, u32 sourceSize);
 
 private:
 
@@ -1468,7 +1468,7 @@ What the function does exactly depends on the LC_CTYPE of the current c locale.
 \param destination Wide-character string receiving the converted source
 \param source multibyte string
 \return The number of wide characters written to destination, not including the eventual terminating null character or -1 when conversion failed */
-static inline size_t multibyteToWString(string<wchar_t> &destination, const core::string<c8> &source)
+static inline size_t multibyteToWString(string<wchar_t>& destination, const core::string<c8>& source)
 {
 	return multibyteToWString(destination, source.c_str(), (u32)source.size());
 }
@@ -1479,18 +1479,18 @@ What the function does exactly depends on the LC_CTYPE of the current c locale.
 \param destination Wide-character string receiving the converted source
 \param source multibyte string
 \return The number of wide characters written to destination, not including the eventual terminating null character  or -1 when conversion failed. */
-static inline size_t multibyteToWString(string<wchar_t> &destination, const char *source)
+static inline size_t multibyteToWString(string<wchar_t>& destination, const char* source)
 {
 	const u32 s = source ? (u32)strlen(source) : 0;
 	return multibyteToWString(destination, source, s);
 }
 
 //! Internally used by the other multibyteToWString functions
-static size_t multibyteToWString(string<wchar_t> &destination, const char *source, u32 sourceSize)
+static size_t multibyteToWString(string<wchar_t>& destination, const char* source, u32 sourceSize)
 {
-	if (sourceSize)
+	if ( sourceSize )
 	{
-		destination.reserve(sourceSize + 1);
+		destination.reserve(sourceSize+1);
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4996)	// 'mbstowcs': This function or variable may be unsafe. Consider using mbstowcs_s instead.
@@ -1499,10 +1499,10 @@ static size_t multibyteToWString(string<wchar_t> &destination, const char *sourc
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-		if (written != (size_t)-1)
+		if ( written != (size_t)-1 )
 		{
-			destination.used = (u32)written + 1;
-			destination.array[destination.used - 1] = 0;
+			destination.used = (u32)written+1;
+			destination.array[destination.used-1] = 0;
 		}
 		else
 		{
@@ -1520,24 +1520,24 @@ static size_t multibyteToWString(string<wchar_t> &destination, const char *sourc
 }
 
 //! Same as multibyteToWString, but the other way around
-static inline size_t wStringToMultibyte(string<c8> &destination, const core::string<wchar_t> &source)
+static inline size_t wStringToMultibyte(string<c8>& destination, const core::string<wchar_t>& source)
 {
 	return wStringToMultibyte(destination, source.c_str(), (u32)source.size());
 }
 
 //! Same as multibyteToWString, but the other way around
-static inline size_t wStringToMultibyte(string<c8> &destination, const wchar_t *source)
+static inline size_t wStringToMultibyte(string<c8>& destination, const wchar_t* source)
 {
-	const u32 s = source ? (u32)strlen((const char *)source) : 0;
+	const u32 s = source ? (u32)strlen((const char*)source) : 0;
 	return wStringToMultibyte(destination, source, s);
 }
 
 //! Same as multibyteToWString, but the other way around
-static size_t wStringToMultibyte(string<c8> &destination, const wchar_t *source, u32 sourceSize)
+static size_t wStringToMultibyte(string<c8>& destination, const wchar_t* source, u32 sourceSize)
 {
-	if (sourceSize)
+	if ( sourceSize )
 	{
-		destination.reserve(sourceSize + 1);
+		destination.reserve(sourceSize+1);
 #if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable: 4996)	// 'wcstombs': This function or variable may be unsafe. Consider using wcstombs_s instead.
@@ -1546,10 +1546,10 @@ static size_t wStringToMultibyte(string<c8> &destination, const wchar_t *source,
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
-		if (written != (size_t)-1)
+		if ( written != (size_t)-1 )
 		{
-			destination.used = (u32)written + 1;
-			destination.array[destination.used - 1] = 0;
+			destination.used = (u32)written+1;
+			destination.array[destination.used-1] = 0;
 		}
 		else
 		{

--- a/include/irrString.h
+++ b/include/irrString.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <wchar.h>
 
 namespace irr
 {
@@ -1528,7 +1529,7 @@ static inline size_t wStringToMultibyte(string<c8>& destination, const core::str
 //! Same as multibyteToWString, but the other way around
 static inline size_t wStringToMultibyte(string<c8>& destination, const wchar_t* source)
 {
-	const u32 s = source ? (u32)strlen((const char*)source) : 0;
+	const u32 s = source ? (u32)wcslen(source) : 0;
 	return wStringToMultibyte(destination, source, s);
 }
 

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -300,7 +300,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
 				core::stringc s;
-				s = Text.subString(realmbgn, realmend - realmbgn).c_str(); //TODO
+				wStringToMultibyte(s, Text.subString(realmbgn, realmend - realmbgn));
 				Operator->copyToClipboard(s.c_str());
 			}
 			break;
@@ -313,8 +313,8 @@ bool CGUIEditBox::processKey(const SEvent& event)
 
 				// copy
 				core::stringc sc;
-				sc = Text.subString(realmbgn, realmend - realmbgn).c_str();
-				Operator->copyToClipboard(sc.c_str()); //TODO
+				wStringToMultibyte(sc, Text.subString(realmbgn, realmend - realmbgn));
+				Operator->copyToClipboard(sc.c_str());
 
 				if (isEnabled())
 				{

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -300,7 +300,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
 				core::stringc s;
-				s = Text.subString(realmbgn, realmend - realmbgn).c_str();
+				s = Text.subString(realmbgn, realmend - realmbgn).c_str(); //TODO
 				Operator->copyToClipboard(s.c_str());
 			}
 			break;
@@ -314,7 +314,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				// copy
 				core::stringc sc;
 				sc = Text.subString(realmbgn, realmend - realmbgn).c_str();
-				Operator->copyToClipboard(sc.c_str());
+				Operator->copyToClipboard(sc.c_str()); //TODO
 
 				if (isEnabled())
 				{
@@ -341,8 +341,8 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				const s32 realmbgn = MarkBegin < MarkEnd ? MarkBegin : MarkEnd;
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
-				// add new character
-				const c8* p = Operator->getTextFromClipboard();
+				// add the string
+				const c8 *p = Operator->getTextFromClipboard();
 				if (p)
 				{
 					irr::core::stringw widep;

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -722,6 +722,17 @@ bool CIrrDeviceLinux::run()
 {
 	os::Timer::tick();
 
+	// TODO: remove
+	// results: 16 ms focused, 50 ms unfocused;
+	// one selection request per run(), no run()s between => we make it slow
+	//~ {
+		//~ static u32 old_time = os::Timer::getTime();
+		//~ u32 current_time = os::Timer::getTime();
+		//~ fprintf(stderr, "CIrrDeviceLinux::run: delta time = %u ms\n",
+				//~ current_time - old_time);
+		//~ old_time = current_time;
+	//~ }
+
 #ifdef _IRR_COMPILE_WITH_X11_
 
 	if ( CursorControl )

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -6,7 +6,6 @@
 
 #ifdef _IRR_COMPILE_WITH_X11_DEVICE_
 
-#include <cassert>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/utsname.h>
@@ -1864,10 +1863,10 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 				event->xselection.target == window_pair_target->second);
 	}, (XPointer)&property_arg);
 
-	assert(event_ret.type == SelectionNotify &&
+	_IRR_DEBUG_BREAK_IF(!(event_ret.type == SelectionNotify &&
 			event_ret.xselection.requestor == XWindow &&
 			event_ret.xselection.selection == X_ATOM_CLIPBOARD &&
-			event_ret.xselection.target == X_ATOM_UTF8_STRING);
+			event_ret.xselection.target == X_ATOM_UTF8_STRING));
 
 	Atom property_set = event_ret.xselection.property;
 	if (event_ret.xselection.property == None) {

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1854,14 +1854,12 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 
 	// wait for event via a blocking call
 	XEvent event_ret;
-	std::pair<Window, Atom> property_arg = std::make_pair(XWindow, X_ATOM_UTF8_STRING);
 	XIfEvent(XDisplay, &event_ret, [](Display *_display, XEvent *event, XPointer arg) {
-		auto window_pair_target = (std::pair<Window, Atom> *)arg;
 		return (Bool) (event->type == SelectionNotify &&
-				event->xselection.requestor == window_pair_target->first &&
+				event->xselection.requestor == *(Window *)arg &&
 				event->xselection.selection == X_ATOM_CLIPBOARD &&
-				event->xselection.target == window_pair_target->second);
-	}, (XPointer)&property_arg);
+				event->xselection.target == X_ATOM_UTF8_STRING);
+	}, (XPointer)&XWindow);
 
 	_IRR_DEBUG_BREAK_IF(!(event_ret.type == SelectionNotify &&
 			event_ret.xselection.requestor == XWindow &&

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1051,7 +1051,7 @@ bool CIrrDeviceLinux::run()
 						// Note: this was not tested and might be incorrect
 						os::Printer::log("CIrrDeviceLinux::run: SelectionRequest from obsolete client",
 								ELL_WARNING);
-						XChangeProperty (XDisplay,
+						XChangeProperty(XDisplay,
 								req->requestor,
 								req->target, X_ATOM_UTF8_STRING,
 								8, // format = 8-bit
@@ -1071,10 +1071,9 @@ bool CIrrDeviceLinux::run()
 						};
 						set_property_and_notify(
 								XA_ATOM,
-								8, // sizeof(Atom)*8=64, and max format is 32,
-								   // hence we can not have byte-swapping
+								32, // Atom is long, we need to set 32 for longs
 								&data,
-								sizeof(data)
+								sizeof(data) / sizeof(*data)
 							);
 
 					} else if (req->target == X_ATOM_TEXT ||

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -722,17 +722,6 @@ bool CIrrDeviceLinux::run()
 {
 	os::Timer::tick();
 
-	// TODO: remove
-	// results: 16 ms focused, 50 ms unfocused;
-	// one selection request per run(), no run()s between => we make it slow
-	//~ {
-		//~ static u32 old_time = os::Timer::getTime();
-		//~ u32 current_time = os::Timer::getTime();
-		//~ fprintf(stderr, "CIrrDeviceLinux::run: delta time = %u ms\n",
-				//~ current_time - old_time);
-		//~ old_time = current_time;
-	//~ }
-
 #ifdef _IRR_COMPILE_WITH_X11_
 
 	if ( CursorControl )
@@ -1040,21 +1029,19 @@ bool CIrrDeviceLinux::run()
 					};
 
 					if (req->selection != X_ATOM_CLIPBOARD ||
-							req->owner != XWindow ||
-							false) { // TODO: time
+							req->owner != XWindow) {
 						// we are not the owner, refuse request
 						send_response_refuse();
-						fprintf(stderr, "CIrrDeviceLinux::run: I'm not the owner\n");
 						break;
 					}
 
 					// for debugging:
-					{
-						char *target_name = XGetAtomName(XDisplay, req->target);
-						fprintf(stderr, "CIrrDeviceLinux::run: target: %s (=%ld)\n",
-								target_name, req->target);
-						XFree(target_name);
-					}
+					//~ {
+						//~ char *target_name = XGetAtomName(XDisplay, req->target);
+						//~ fprintf(stderr, "CIrrDeviceLinux::run: target: %s (=%ld)\n",
+								//~ target_name, req->target);
+						//~ XFree(target_name);
+					//~ }
 
 					if (req->property == None) {
 						// req is from obsolete client, use target as property name
@@ -1848,7 +1835,6 @@ bool CIrrDeviceLinux::getGammaRamp( f32 &red, f32 &green, f32 &blue, f32 &bright
 const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 {
 #if defined(_IRR_COMPILE_WITH_X11_)
-	fprintf(stderr, "CIrrDeviceLinux::getTextFromClipboard: called\n");
 	Window ownerWindow = XGetSelectionOwner(XDisplay, X_ATOM_CLIPBOARD);
 	if (ownerWindow == XWindow) {
 		return Clipboard.c_str();
@@ -1863,7 +1849,6 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 	// delete the property to be set beforehand
 	XDeleteProperty(XDisplay, XWindow, XA_PRIMARY);
 
-	// TODO: don't use CurrentTime
 	XConvertSelection(XDisplay, X_ATOM_CLIPBOARD, X_ATOM_UTF8_STRING, XA_PRIMARY,
 			XWindow, CurrentTime);
 	XFlush(XDisplay);
@@ -1912,12 +1897,12 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 	}
 
 	// for debugging:
-	{
-		char *type_name = XGetAtomName(XDisplay, type);
-		fprintf(stderr, "CIrrDeviceLinux::getTextFromClipboard: actual type: %s (=%ld)\n",
-				type_name, type);
-		XFree(type_name);
-	}
+	//~ {
+		//~ char *type_name = XGetAtomName(XDisplay, type);
+		//~ fprintf(stderr, "CIrrDeviceLinux::getTextFromClipboard: actual type: %s (=%ld)\n",
+				//~ type_name, type);
+		//~ XFree(type_name);
+	//~ }
 
 	if (type != X_ATOM_UTF8_STRING && type != X_ATOM_UTF8_MIME_TYPE) {
 		os::Printer::log("CIrrDeviceLinux::getTextFromClipboard: did not get utf-8 string",
@@ -1949,14 +1934,11 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 void CIrrDeviceLinux::copyToClipboard(const c8 *text) const
 {
 #if defined(_IRR_COMPILE_WITH_X11_)
-	fprintf(stderr, "CIrrDeviceLinux::copyToClipboard: called, text=\"%s\"\n", text); // TODO: remove
-
 	// Actually there is no clipboard on X but applications just say they own the clipboard and return text when asked.
 	// Which btw. also means that on X you lose clipboard content when closing applications.
 	Clipboard = text;
-	// TODO: don't use CurrentTime
 	XSetSelectionOwner (XDisplay, X_ATOM_CLIPBOARD, XWindow, CurrentTime);
-	XFlush (XDisplay); // TODO: why flush?
+	XFlush (XDisplay);
 	Window owner = XGetSelectionOwner(XDisplay, X_ATOM_CLIPBOARD);
 	if (owner != XWindow) {
 		os::Printer::log("CIrrDeviceLinux::copyToClipboard: failed to set owner", ELL_WARNING);

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1834,7 +1834,7 @@ bool CIrrDeviceLinux::getGammaRamp( f32 &red, f32 &green, f32 &blue, f32 &bright
 
 
 //! gets text from the clipboard
-//! \return Returns 0 if no string is in there.
+//! \return Returns 0 if no string is in there, otherwise utf-8 text.
 const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 {
 #if defined(_IRR_COMPILE_WITH_X11_)

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1854,7 +1854,7 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 
 	// TODO: don't use CurrentTime
 	XConvertSelection(XDisplay, X_ATOM_CLIPBOARD, XA_STRING, XA_PRIMARY, XWindow, CurrentTime);
-	XSync(XDisplay, False);
+	XFlush(XDisplay);
 
 	// wait for event via a blocking call
 	XEvent event_ret;
@@ -1881,7 +1881,7 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 	Atom type;
 	int format;
 	unsigned long numItems, bytesLeft, dummy;
-	unsigned char *data;
+	unsigned char *data = nullptr;
 	XGetWindowProperty (XDisplay, XWindow,
 			property_set, // property name
 			0, // offset
@@ -1893,13 +1893,17 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 			&numItems, // number items
 			&bytesLeft, // remaining bytes for partial reads
 			&data); // data
+	if (data) {
+		XFree(data);
+		data = nullptr;
+	}
 	if (bytesLeft > 0) {
 		// there is some data to get
 		int result = XGetWindowProperty (XDisplay, XWindow, property_set, 0,
 									bytesLeft, 0, AnyPropertyType, &type, &format,
 									&numItems, &dummy, &data);
 		if (result == Success)
-			Clipboard = (irr::c8*)data;
+			Clipboard = (irr::c8 *)data;
 		XFree (data);
 	}
 

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1872,7 +1872,6 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 	XEvent event_ret;
 	std::pair<Window, Atom> property_arg = std::make_pair(XWindow, X_ATOM_UTF8_STRING);
 	XIfEvent(XDisplay, &event_ret, [](Display *_display, XEvent *event, XPointer arg) {
-		//~ Window *my_window = (Window *)arg;
 		auto window_pair_target = (std::pair<Window, Atom> *)arg;
 		return (Bool) (event->type == SelectionNotify &&
 				event->xselection.requestor == window_pair_target->first &&

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -104,8 +104,8 @@ namespace irr
 		virtual bool getGammaRamp( f32 &red, f32 &green, f32 &blue, f32 &brightness, f32 &contrast ) _IRR_OVERRIDE_;
 
 		//! gets text from the clipboard
-		//! \return Returns 0 if no string is in there.
-		virtual const c8* getTextFromClipboard() const;
+		//! \return Returns 0 if no string is in there, otherwise utf-8 text.
+		virtual const c8 *getTextFromClipboard() const;
 
 		//! copies text to the clipboard
 		//! This sets the clipboard selection and _not_ the primary selection which you have on X on the middle mouse button.

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -109,7 +109,8 @@ namespace irr
 
 		//! copies text to the clipboard
 		//! This sets the clipboard selection and _not_ the primary selection which you have on X on the middle mouse button.
-		virtual void copyToClipboard(const c8* text) const;
+		//! @param text The text in utf-8
+		virtual void copyToClipboard(const c8 *text) const;
 
 		//! Remove all messages pending in the system message loop
 		virtual void clearSystemMessages() _IRR_OVERRIDE_;
@@ -385,6 +386,7 @@ namespace irr
 		XIM XInputMethod;
 		XIC XInputContext;
 		bool HasNetWM;
+		// text is utf-8
 		mutable core::stringc Clipboard;
 #endif
 		u32 Width, Height;

--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -56,7 +56,8 @@ const core::stringc& COSOperator::getOperatingSystemVersion() const
 
 
 //! copies text to the clipboard
-void COSOperator::copyToClipboard(const c8* text) const
+//! \param text: text in utf-8
+void COSOperator::copyToClipboard(const c8 *text) const
 {
 	if (strlen(text)==0)
 		return;

--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -103,7 +103,7 @@ void COSOperator::copyToClipboard(const c8* text) const
 
 
 //! gets text from the clipboard
-//! \return Returns 0 if no string is in there.
+//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 const c8* COSOperator::getTextFromClipboard() const
 {
 #if defined(_IRR_XBOX_PLATFORM_)

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -27,7 +27,8 @@ public:
 	virtual const core::stringc& getOperatingSystemVersion() const _IRR_OVERRIDE_;
 
 	//! copies text to the clipboard
-	virtual void copyToClipboard(const c8* text) const _IRR_OVERRIDE_;
+	//! \param text: text in utf-8
+	virtual void copyToClipboard(const c8 *text) const _IRR_OVERRIDE_;
 
 	//! gets text from the clipboard
 	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -30,7 +30,7 @@ public:
 	virtual void copyToClipboard(const c8* text) const _IRR_OVERRIDE_;
 
 	//! gets text from the clipboard
-	//! \return Returns 0 if no string is in there.
+	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 	virtual const c8* getTextFromClipboard() const _IRR_OVERRIDE_;
 
 	//! gets the total and available system RAM in kB

--- a/tools/GUIEditor/CGUIEditWorkspace.cpp
+++ b/tools/GUIEditor/CGUIEditWorkspace.cpp
@@ -879,7 +879,7 @@ void CGUIEditWorkspace::CopySelectedElementXML()
 	u32 i = memWrite->getData().size()/sizeof(wchar_t);
 	if (wXMLText.size() > i)
 		wXMLText[i] = L'\0';
-	XMLText = wXMLText.c_str();
+	XMLText = wXMLText.c_str(); // TODO
 	memWrite->drop();
 	xml->drop();
 	Environment->getOSOperator()->copyToClipboard(XMLText.c_str());
@@ -888,7 +888,7 @@ void CGUIEditWorkspace::CopySelectedElementXML()
 void CGUIEditWorkspace::PasteXMLToSelectedElement()
 {
 	// get clipboard data
-	const char * p = Environment->getOSOperator()->getTextFromClipboard();
+	const char *p = Environment->getOSOperator()->getTextFromClipboard();
 	irr::core::stringw wXMLText;
 	core::multibyteToWString(wXMLText, p);
 

--- a/tools/GUIEditor/CGUIEditWorkspace.cpp
+++ b/tools/GUIEditor/CGUIEditWorkspace.cpp
@@ -879,7 +879,7 @@ void CGUIEditWorkspace::CopySelectedElementXML()
 	u32 i = memWrite->getData().size()/sizeof(wchar_t);
 	if (wXMLText.size() > i)
 		wXMLText[i] = L'\0';
-	core::wStringToMultibyte(XMLText, wXMLText);
+	XMLText = wXMLText.c_str();
 	memWrite->drop();
 	xml->drop();
 	Environment->getOSOperator()->copyToClipboard(XMLText.c_str());
@@ -888,7 +888,7 @@ void CGUIEditWorkspace::CopySelectedElementXML()
 void CGUIEditWorkspace::PasteXMLToSelectedElement()
 {
 	// get clipboard data
-	const char *p = Environment->getOSOperator()->getTextFromClipboard();
+	const char * p = Environment->getOSOperator()->getTextFromClipboard();
 	irr::core::stringw wXMLText;
 	core::multibyteToWString(wXMLText, p);
 

--- a/tools/GUIEditor/CGUIEditWorkspace.cpp
+++ b/tools/GUIEditor/CGUIEditWorkspace.cpp
@@ -879,7 +879,7 @@ void CGUIEditWorkspace::CopySelectedElementXML()
 	u32 i = memWrite->getData().size()/sizeof(wchar_t);
 	if (wXMLText.size() > i)
 		wXMLText[i] = L'\0';
-	XMLText = wXMLText.c_str(); // TODO
+	core::wStringToMultibyte(XMLText, wXMLText);
 	memWrite->drop();
 	xml->drop();
 	Environment->getOSOperator()->copyToClipboard(XMLText.c_str());


### PR DESCRIPTION
- This PR aims to finally fix all the issues with the X11 selection.
- This PR does not add new features such as primary selection. We are still restricted to the clipboard. So this is left to another PR.
- Here is some documentation about all the stuff:
  ICCCM (= \<some more acronym\> manual): https://www.x.org/releases/current/doc/xorg-docs/icccm/icccm.html#Peer_to_Peer_Communication_by_Means_of_Selections
  libX11 doc: https://www.x.org/releases/current/doc/libX11/libX11/libX11.html
- Please help testing (see below).

## To do

This PR is ready to be reviewed.

The only thing I found that doesn't work perfectly is that pasting out of minetest is sometimes slow.
I am pretty sure the reason for this is that minetest calls the run function less often when unfocused (I've measured the times, it's 16 ms vs. 50 ms delta time). Fixing this would be possible but it would touch much more code, and it needs minetest to change itself.

(Also, the ICCCM says that one should rather use a real timestamp instead of CurrentTime. But I don't think we actually need this.)

<details><summary>Historic texts</summary>

This PR is WIP.
- There are some TODOs left in the code.
- There are debugging statements that need to be removed or at least commented out.

Things that were fixed or not:
- [x] You can paste into more different applications (ie. geany), because we now support more targets. (See also the How to Test if your application still makes problems.)
- [x] You only have to press once now to paste something into minetest.
  The reason this wasn't working is that irrlicht didn't wait for the SelectionNotify event. So it always used the old window property. Pressing twice has only worked because irrlicht didn't delete the property before and after the request ([but you should do that](https://www.x.org/releases/current/doc/xorg-docs/icccm/icccm.html#Requesting_a_Selection)).
- [ ] Pasting into xpad is still pretty slow. I don't know if it's irrlicht's fault.
  xpad first asks for the `GTK_TEXT_BUFFER_CONTENTS` target, maybe I should just write the string there, or maybe not, I found no nice documentation about it.
  Another reason might be minetest doing a slower step when unfocused, maybe, I think. Edit: <-- Yes, this.
  Or it's just xpad's fault. `¯\_(ツ)_/¯`
- [x] Pasting into gnome-terminal doesn't work for some reason. Pasting into kitty or wezterm does work, however. Does gnome-terminal not use the X11 selection somehow?
  Edit: It works now. I had to set the format in the TARGETS target to 32. (Solution found [here](https://github.com/wez/wezterm/blob/827adf3a956ceea17298c2b78e4d1445367a46f5/window/src/os/x11/window.rs#L423).) I didn't do that before because I thought that it's bad with 64 bit longs.

</details>

## How to Test

### Preparation:
- Build this irrlicht version, and use https://github.com/minetest/minetest/pull/11538.
- Use some formspec for testing, ie. a luacontroller. It doesn't matter which formspec field you use, it all uses the very same code.
- The only other place where you can copy is the chat input.

### Testing:
- Do all the things that did not work before for you.
- Tell me about any remaining problems.
- If you comment in some debugging lines: Look at the terminal output (if you paste out of minetest, it prints the requested selection targets).
- Some useful command: `$ xclip -o -t TARGETS -selection clipboard`
- Copy very different texts (ie. unicode stuff, large texts, ...).
- Try out as many programs as possible.