### PR TITLE
Fix absolute paths to compilers not working in mingw build script

### DIFF
--- a/scripts/ci-build-mingw.sh
+++ b/scripts/ci-build-mingw.sh
@@ -3,7 +3,7 @@
 [[ -z "$CC" || -z "$CXX" ]] && exit 255
 
 variant=win32
-[[ "$CXX" == "x86_64-"* ]] && variant=win64
+[[ "$(basename "$CXX")" == "x86_64-"* ]] && variant=win64
 
 libjpeg_version=2.0.6
 libpng_version=1.6.37


### PR DESCRIPTION
The mingw build script for CI would not work with absolute paths for the compiler, because of a check for 32bit vs 64 bit architectures that assumed the compiler to be invoked as a command instead of a path to the compiler. This commit fixes the issue by checking the basename of the given compiler, so the check now treats paths the same way it used to treat commands.

Fixes #40.