### PR TITLE
Set policies through version 3.9 to allow better IPO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-# Policies should be set to NEW behavior whenever possible. This only sets
-# policies up to version 3.9 (for the IPO policies we want) as a way to
-# introduce the feature more gradually and see how it works.
+# Set policies up to 3.9 since we want to enable the IPO option
 if(${CMAKE_VERSION} VERSION_LESS 3.9)
 	cmake_policy(VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR})
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,13 @@
-cmake_minimum_required(VERSION 3.5...3.9)
+cmake_minimum_required(VERSION 3.5)
+
+# Policies should be set to NEW behavior whenever possible. This only sets
+# policies up to version 3.9 (for the IPO policies we want) as a way to
+# introduce the feature more gradually and see how it works.
+if(${CMAKE_VERSION} VERSION_LESS 3.9)
+	cmake_policy(VERSION ${CMAKE_VERSION_MAJOR}.${CMAKE_VERSION_MINOR})
+else()
+	cmake_policy(VERSION 3.9)
+endif()
 
 project(Irrlicht
 	VERSION 1.9.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.9)
 
 project(Irrlicht
 	VERSION 1.9.0


### PR DESCRIPTION
The OLD behavior of a CMake policy is deprecated by default, so a version range can be used to set all policies to NEW on the appropriate versions. It is difficult to test this extensively, but it is unlikely to cause a problem, and could fix some bugs for people using newer versions. I picked 3.9 as the top of the version range to minimize the effects, because 3.9 will set CMP0069 to NEW, which is the focus of this commit.

If a version is newer than the top of the range, its policies will be set based on the highest version in the range.

Fixes #54.