### PR TITLE
Fix updating of vertex normals for animated meshes

### DIFF
--- a/include/ISkinnedMesh.h
+++ b/include/ISkinnedMesh.h
@@ -80,7 +80,7 @@ namespace scene
 		virtual bool setHardwareSkinning(bool on) = 0;
 
 		//! Refreshes vertex data cached in joints such as positions and normals
-		virtual void refreshJointCache() {}
+		virtual void refreshJointCache() = 0;
 
 		//! A vertex weight
 		struct SWeight

--- a/include/ISkinnedMesh.h
+++ b/include/ISkinnedMesh.h
@@ -79,6 +79,9 @@ namespace scene
 		/* This feature is not implemented in Irrlicht yet */
 		virtual bool setHardwareSkinning(bool on) = 0;
 
+		//! Refreshes vertex data cached in joints such as positions and normals
+		virtual void refreshJointCache() {}
+
 		//! A vertex weight
 		struct SWeight
 		{

--- a/source/Irrlicht/CMeshManipulator.cpp
+++ b/source/Irrlicht/CMeshManipulator.cpp
@@ -151,8 +151,9 @@ void CMeshManipulator::recalculateNormals(scene::IMesh* mesh, bool smooth, bool 
 	for ( u32 b=0; b<bcount; ++b)
 		recalculateNormals(mesh->getMeshBuffer(b), smooth, angleWeighted);
 
-	if (mesh->getMeshType() == scene::E_ANIMATED_MESH_TYPE::EAMT_SKINNED) {
-		scene::ISkinnedMesh *smesh = reinterpret_cast<scene::ISkinnedMesh *>(mesh);
+	if (mesh->getMeshType() == EAMT_SKINNED)
+	{
+		ISkinnedMesh *smesh = (ISkinnedMesh *) mesh;
 		smesh->refreshJointCache();
 	}
 }

--- a/source/Irrlicht/CMeshManipulator.cpp
+++ b/source/Irrlicht/CMeshManipulator.cpp
@@ -3,6 +3,7 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "CMeshManipulator.h"
+#include "ISkinnedMesh.h"
 #include "SMesh.h"
 #include "CMeshBuffer.h"
 #include "SAnimatedMesh.h"
@@ -149,6 +150,11 @@ void CMeshManipulator::recalculateNormals(scene::IMesh* mesh, bool smooth, bool 
 	const u32 bcount = mesh->getMeshBufferCount();
 	for ( u32 b=0; b<bcount; ++b)
 		recalculateNormals(mesh->getMeshBuffer(b), smooth, angleWeighted);
+
+	if (mesh->getMeshType() == scene::E_ANIMATED_MESH_TYPE::EAMT_SKINNED) {
+		scene::ISkinnedMesh *smesh = reinterpret_cast<scene::ISkinnedMesh *>(mesh);
+		smesh->refreshJointCache();
+	}
 }
 
 

--- a/source/Irrlicht/CSkinnedMesh.cpp
+++ b/source/Irrlicht/CSkinnedMesh.cpp
@@ -813,6 +813,21 @@ bool CSkinnedMesh::setHardwareSkinning(bool on)
 	return HardwareSkinning;
 }
 
+void CSkinnedMesh::refreshJointCache()
+{
+	//copy cache from the mesh...
+	for (u32 i=0; i<AllJoints.size(); ++i)
+	{
+		SJoint *joint=AllJoints[i];
+		for (u32 j=0; j<joint->Weights.size(); ++j)
+		{
+			const u16 buffer_id=joint->Weights[j].buffer_id;
+			const u32 vertex_id=joint->Weights[j].vertex_id;
+			joint->Weights[j].StaticPos = LocalBuffers[buffer_id]->getVertex(vertex_id)->Pos;
+			joint->Weights[j].StaticNormal = LocalBuffers[buffer_id]->getVertex(vertex_id)->Normal;
+		}
+	}
+}
 
 void CSkinnedMesh::calculateGlobalMatrices(SJoint *joint,SJoint *parentJoint)
 {

--- a/source/Irrlicht/CSkinnedMesh.h
+++ b/source/Irrlicht/CSkinnedMesh.h
@@ -113,6 +113,9 @@ namespace scene
 		//! (This feature is not implemented in irrlicht yet)
 		virtual bool setHardwareSkinning(bool on) _IRR_OVERRIDE_;
 
+		//! Refreshes vertex data cached in joints such as positions and normals
+		virtual void refreshJointCache() _IRR_OVERRIDE_;
+
 		//Interface for the mesh loaders (finalize should lock these functions, and they should have some prefix like loader_
 		//these functions will use the needed arrays, set values, etc to help the loaders
 


### PR DESCRIPTION
This PR makes CMeshManipulator::recalculateNormals() work on ISkinnedMesh implementations.

Two parts of the PR are:
* Add ISkinnedMesh::updateJointCache() / CSkinnedMesh::updateJointCache() method to copy vertex positions and normals into the weights of the animated joints
* Use updateJointCache() when CMeshManipulator detects an ISkinnedMesh implementation.

As a side effect, any manipulations on the mesh buffers when a skinned mesh is in static pose, followed by ISkinnedMesh::updateJointCache() will correctly update the animated mesh.
