### PR TITLE
use SSE registers for fp operations [affects mintest & irrlict] (fixes minetest issue 11810)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ if(NOT CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type: Debug or Release" FORCE)
 endif()
 
+# use SSE for floating-point operations to avoid issues with improper fp-rounding and loss of precision
+# when moving fp-data to incompatible or less-precise registers/storage locations
+# see https://gcc.gnu.org/wiki/FloatingPointMath and https://gcc.gnu.org/wiki/x87note
+add_compile_options(-mfpmath=sse -msse2)
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 add_subdirectory(source/Irrlicht)
 


### PR DESCRIPTION
This pull request fixes a minetest issue dealting with floating-point operations and it affects both minetest and irrlicht.
See: https://github.com/minetest/minetest/issues/11810

On a x86 system (could affect other platforms that handle floats this way) the x87 fp unit
stores floats with 80-bit precision, but when those floats are moved to other registers they suffer from
loss of precision and double rounding.

see
https://gcc.gnu.org/wiki/FloatingPointMath 
https://gcc.gnu.org/wiki/x87note

The solution to correct those two issues: (1) loss of precision and (2) double rounding, is to have all floating-point operations occur in sse registers.

That solution can be enabled by adding the following cmake options (in CMakeLists.txt):
```
add_compile_options(-mfpmath=sse -msse2)
```

This definately fixes the issue on i386 (the original issue involved Debian 10 Buster) but should affect all i386 and later systems.
On x86_64 (amd64) the issue wasn't present and the implemented solution (above) didn't affect the outcome.

The only potential pitfall (by enabling sse registers by default) would be on systems that don't have sse support.
However, I don't know if that is really an issue today (cpus that don't have sse support).