### PR TITLE
Reset mesh animation state before recalculating normals

### DIFF
--- a/include/ISkinnedMesh.h
+++ b/include/ISkinnedMesh.h
@@ -82,6 +82,9 @@ namespace scene
 		//! Refreshes vertex data cached in joints such as positions and normals
 		virtual void refreshJointCache() = 0;
 
+		//! Moves the mesh into static position.
+		virtual void resetAnimation() = 0;
+
 		//! A vertex weight
 		struct SWeight
 		{

--- a/source/Irrlicht/CMeshManipulator.cpp
+++ b/source/Irrlicht/CMeshManipulator.cpp
@@ -147,6 +147,12 @@ void CMeshManipulator::recalculateNormals(scene::IMesh* mesh, bool smooth, bool 
 	if (!mesh)
 		return;
 
+	if (mesh->getMeshType() == EAMT_SKINNED)
+	{
+		ISkinnedMesh *smesh = (ISkinnedMesh *) mesh;
+		smesh->resetAnimation();
+	}
+
 	const u32 bcount = mesh->getMeshBufferCount();
 	for ( u32 b=0; b<bcount; ++b)
 		recalculateNormals(mesh->getMeshBuffer(b), smooth, angleWeighted);

--- a/source/Irrlicht/CSkinnedMesh.cpp
+++ b/source/Irrlicht/CSkinnedMesh.cpp
@@ -829,6 +829,24 @@ void CSkinnedMesh::refreshJointCache()
 	}
 }
 
+void CSkinnedMesh::resetAnimation()
+{
+	//copy from the cache to the mesh...
+	for (u32 i=0; i<AllJoints.size(); ++i)
+	{
+		SJoint *joint=AllJoints[i];
+		for (u32 j=0; j<joint->Weights.size(); ++j)
+		{
+			const u16 buffer_id=joint->Weights[j].buffer_id;
+			const u32 vertex_id=joint->Weights[j].vertex_id;
+			LocalBuffers[buffer_id]->getVertex(vertex_id)->Pos = joint->Weights[j].StaticPos;
+			LocalBuffers[buffer_id]->getVertex(vertex_id)->Normal = joint->Weights[j].StaticNormal;
+		}
+	}
+	SkinnedLastFrame = false;
+	LastAnimatedFrame = -1;
+}
+
 void CSkinnedMesh::calculateGlobalMatrices(SJoint *joint,SJoint *parentJoint)
 {
 	if (!joint && parentJoint) // bit of protection from endless loops

--- a/source/Irrlicht/CSkinnedMesh.h
+++ b/source/Irrlicht/CSkinnedMesh.h
@@ -116,6 +116,9 @@ namespace scene
 		//! Refreshes vertex data cached in joints such as positions and normals
 		virtual void refreshJointCache() _IRR_OVERRIDE_;
 
+		//! Moves the mesh into static position.
+		virtual void resetAnimation() _IRR_OVERRIDE_;
+
 		//Interface for the mesh loaders (finalize should lock these functions, and they should have some prefix like loader_
 		//these functions will use the needed arrays, set values, etc to help the loaders
 


### PR DESCRIPTION
Fixes #88 and minetest/minetest#11908.

Reset mesh to static position before calculating normals. This guarantees using correct vertex positions even if the mesh has been previously animated.

How to test
=========

* Build minetest/minetest#11747
* Install nssm mod with dependencies.
* Create a Minetest Game world and enable nssm mod and dependencies.
* Start the world and spawn a few Mantis mobs.
* Mobs should keep their shape and animation when new mobs are spawned.