### PR TITLE
Create OpenGL context using glXCreateContextAttribsARB

### DIFF
--- a/source/Irrlicht/CGLXManager.cpp
+++ b/source/Irrlicht/CGLXManager.cpp
@@ -320,7 +320,21 @@ bool CGLXManager::generateContext()
 		if (GlxWin)
 		{
 			// create glx context
-			context = glXCreateNewContext((Display*)CurrentContext.OpenGLLinux.X11Display, (GLXFBConfig)glxFBConfig, GLX_RGBA_TYPE, NULL, True);
+			typedef GLXContext (*glXCreateContextAttribsARBProc)(Display*, GLXFBConfig, GLXContext, Bool, const int*);
+			glXCreateContextAttribsARBProc glXCreateContextAttribsARB = 0;
+			glXCreateContextAttribsARB = (glXCreateContextAttribsARBProc)glXGetProcAddressARB((const GLubyte *) "glXCreateContextAttribsARB");
+			if (!glXCreateContextAttribsARB) {
+				os::Printer::log("Could not get glXCreateContextAttribsARB", ELL_WARNING);
+				return false;
+			}
+			int context_attribs[] =
+			{
+				GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
+				GLX_CONTEXT_MINOR_VERSION_ARB, 0,
+				//GLX_CONTEXT_FLAGS_ARB        , GLX_CONTEXT_FORWARD_COMPATIBLE_BIT_ARB,
+				None
+			};
+			context = glXCreateContextAttribsARB((Display*)CurrentContext.OpenGLLinux.X11Display, (GLXFBConfig)glxFBConfig, 0, True, context_attribs);
 			if (!context)
 			{
 				os::Printer::log("Could not create GLX rendering context.", ELL_WARNING);


### PR DESCRIPTION
Adds basic compatibility of Minetest with RenderDoc under Linux.

Allows capturing frames, but does not support replay.

This PR is ready for review.

How to test
=========

* Start Minetest and launch any world - Minetest should work as usual
* Start RenderDoc and launch Minetest under it - observe the frames being captured for examination