### PR TITLE
Use CGWarpMouseCursorPosition

### DIFF
--- a/source/Irrlicht/CIrrDeviceOSX.mm
+++ b/source/Irrlicht/CIrrDeviceOSX.mm
@@ -1172,9 +1172,8 @@ void CIrrDeviceMacOSX::setMouseLocation(int x,int y)
 	c.x = p.x;
 	c.y = p.y;
 
-    CGEventRef ev = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved, c, kCGMouseButtonLeft);
-    CGEventPost(kCGHIDEventTap, ev);
-    CFRelease(ev);
+	CGWarpMouseCursorPosition(c);
+	CGAssociateMouseAndMouseCursorPosition(YES);
 }
 
 


### PR DESCRIPTION
Sending a global mouse event is no longer permitted by default. It requires an app to have special Accessibility permissions.

Instead, use CGWarpMouseCursorPosition to set the position locally. This is followed by CGAssociateMouseAndMouseCursorPosition to re-enable hardware events immediately. (this was previously done with CGSetLocalEventsSuppressionInterval, now deprecated).

Fixes https://github.com/minetest/minetest/issues/11541 (on MacOS)