### PR TITLE
Reset blend operation in 2d mode

### DIFF
--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -2851,6 +2851,7 @@ void COpenGLDriver::setRenderStates2DMode(bool alpha, bool texture, bool alphaCh
 		}
 
 		CacheHandler->setBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		CacheHandler->setBlendEquation(GL_FUNC_ADD);
 
 #ifdef GL_EXT_clip_volume_hint
 		if (FeatureAvailable[IRR_EXT_clip_volume_hint])


### PR DESCRIPTION
This fixes flicker in HUD when blend function is not GL_FUNC_ADD after 3D operations, for example, when rendering particles with blend = "sub" in minetest/minetest#11545 with changes from velartrill/minetest#3