### PR TITLE
Reset blend equation in 2D mode in OGLES1 and OGLES2 drivers

### DIFF
--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -1963,6 +1963,7 @@ COGLES2Driver::~COGLES2Driver()
 		{
 			CacheHandler->setBlend(true);
 			CacheHandler->setBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+			CacheHandler->setBlendEquation(GL_FUNC_ADD);
 		}
 		else
 			CacheHandler->setBlend(false);

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -2057,6 +2057,7 @@ void COGLES1Driver::setRenderStates2DMode(bool alpha, bool texture, bool alphaCh
 	{
 		CacheHandler->setBlend(true);
 		CacheHandler->setBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		CacheHandler->setBlendEquation(GL_FUNC_ADD);
 		glEnable(GL_ALPHA_TEST);
 		glAlphaFunc(GL_GREATER, 0.f);
 	}


### PR DESCRIPTION
The same as #112 but for OGLES1 and OGLES2 drivers.

Tested with the same velartrill/minetest#3.