### PR TITLE
Fix null dereferences reported by coverity

### DIFF
--- a/source/Irrlicht/CAnimatedMeshSceneNode.cpp
+++ b/source/Irrlicht/CAnimatedMeshSceneNode.cpp
@@ -276,6 +276,7 @@ void CAnimatedMeshSceneNode::render()
 		#ifdef _DEBUG
 			os::Printer::log("Animated Mesh returned no mesh to render.", Mesh->getDebugName(), ELL_WARNING);
 		#endif
+		return;
 	}
 
 	driver->setTransform(video::ETS_WORLD, AbsoluteTransformation);

--- a/source/Irrlicht/CFileSystem.cpp
+++ b/source/Irrlicht/CFileSystem.cpp
@@ -783,7 +783,7 @@ EFileSystemType CFileSystem::setFileListSystem(EFileSystemType listType)
 //! Creates a list of files and directories in the current working directory
 IFileList* CFileSystem::createFileList()
 {
-	CFileList* r = 0;
+	CFileList* r = nullptr;
 	io::path Path = getWorkingDirectory();
 	Path.replace('\\', '/');
 	if (!Path.empty() && Path.lastChar() != '/')
@@ -817,11 +817,9 @@ IFileList* CFileSystem::createFileList()
 			_findclose( hFile );
 		}
 
-		#endif
-
 		// --------------------------------------------
 		//! Linux version
-		#if (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_))
+		#elif (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_))
 
 
 		r = new CFileList(Path, false, false);
@@ -861,6 +859,9 @@ IFileList* CFileSystem::createFileList()
 			}
 			closedir(dirHandle);
 		}
+		#else
+			// no native filesystem enabled
+			return nullptr;
 		#endif
 	}
 	else
@@ -893,8 +894,7 @@ IFileList* CFileSystem::createFileList()
 		}
 	}
 
-	if (r)
-		r->sort();
+	r->sort();
 	return r;
 }
 

--- a/source/Irrlicht/CFileSystem.cpp
+++ b/source/Irrlicht/CFileSystem.cpp
@@ -783,7 +783,7 @@ EFileSystemType CFileSystem::setFileListSystem(EFileSystemType listType)
 //! Creates a list of files and directories in the current working directory
 IFileList* CFileSystem::createFileList()
 {
-	CFileList* r = nullptr;
+	CFileList* r = 0;
 	io::path Path = getWorkingDirectory();
 	Path.replace('\\', '/');
 	if (!Path.empty() && Path.lastChar() != '/')
@@ -817,9 +817,11 @@ IFileList* CFileSystem::createFileList()
 			_findclose( hFile );
 		}
 
+		#endif
+
 		// --------------------------------------------
 		//! Linux version
-		#elif (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_))
+		#if (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_))
 
 
 		r = new CFileList(Path, false, false);
@@ -859,9 +861,6 @@ IFileList* CFileSystem::createFileList()
 			}
 			closedir(dirHandle);
 		}
-		#else
-			// no native filesystem enabled
-			return nullptr;
 		#endif
 	}
 	else
@@ -894,7 +893,8 @@ IFileList* CFileSystem::createFileList()
 		}
 	}
 
-	r->sort();
+	if (r)
+		r->sort();
 	return r;
 }
 


### PR DESCRIPTION
One of these was caused by a null check missing a return; the other was
a false positive, but I thought the code readability would benefit from
a little rewording, which should also quiet Coverity. There's a third one reported, but it's also clearly a false positive. I think I could simplify the logic and quiet that one as well, but I don't want to break the logic by mistake, so I'm leaving it out.