### PR TITLE
Remove dead code detected by Coverity

### DIFF
--- a/source/Irrlicht/CImage.cpp
+++ b/source/Irrlicht/CImage.cpp
@@ -298,8 +298,6 @@ void CImage::copyToScalingBoxFilter(IImage* target, s32 bias, bool blend)
 	const f32 sourceXStep = (f32) Size.Width / (f32) destSize.Width;
 	const f32 sourceYStep = (f32) Size.Height / (f32) destSize.Height;
 
-	target->getData();
-
 	s32 fx = core::ceil32( sourceXStep );
 	s32 fy = core::ceil32( sourceYStep );
 	f32 sx;

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -4001,22 +4001,7 @@ IImage* COpenGLDriver::createScreenShot(video::ECOLOR_FORMAT format, video::E_RE
 		pixels = static_cast<u8*>(newImage->getData());
 	if (pixels)
 	{
-		GLenum tgt=GL_FRONT;
-		switch (target)
-		{
-		case video::ERT_FRAME_BUFFER:
-			break;
-		case video::ERT_STEREO_LEFT_BUFFER:
-			tgt=GL_FRONT_LEFT;
-			break;
-		case video::ERT_STEREO_RIGHT_BUFFER:
-			tgt=GL_FRONT_RIGHT;
-			break;
-		default:
-			tgt=GL_AUX0+(target-video::ERT_AUX_BUFFER0);
-			break;
-		}
-		glReadBuffer(tgt);
+		glReadBuffer(GL_FRONT);
 		glReadPixels(0, 0, ScreenSize.Width, ScreenSize.Height, fmt, type, pixels);
 		testGLError(__LINE__);
 		glReadBuffer(GL_BACK);


### PR DESCRIPTION
This removes all of the unreachable code reported by Coverity. The options for various screenshot rendering targets being handled in the switch, but disallowed earlier in the function, is suspicious, but they clearly aren't doing anything right now, so there's no bug introduced by removing them.