### PR TITLE
Added Alt and CapsLock key states to key events.

### DIFF
--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -381,6 +381,12 @@ struct SEvent
 
 		//! True if ctrl was also pressed
 		bool Control:1;
+
+		//! True if alt was also pressed
+		bool Alt:1;
+
+		//! True if caps lock is toggled
+		bool CapsLock:1;
 	};
 
 	//! String input event.

--- a/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
@@ -444,12 +444,7 @@ s32 CIrrDeviceAndroid::handleInput(android_app* app, AInputEvent* androidEvent)
 				// but don't see yet how to handle this correctly.
 			}
 
-			/* no use for meta keys so far.
-			if (   keyMetaState & AMETA_ALT_ON
-				|| keyMetaState & AMETA_ALT_LEFT_ON
-				|| keyMetaState & AMETA_ALT_RIGHT_ON )
-				;
-			// what is a sym?
+			/* what is a sym?
 			if (   keyMetaState & AMETA_SYM_ON )
 				;
 			*/
@@ -459,7 +454,25 @@ s32 CIrrDeviceAndroid::handleInput(android_app* app, AInputEvent* androidEvent)
 				event.KeyInput.Shift = true;
 			else
 				event.KeyInput.Shift = false;
-			event.KeyInput.Control = false;
+			
+			if (   keyMetaState & AMETA_ALT_ON
+				|| keyMetaState & AMETA_ALT_LEFT_ON
+				|| keyMetaState & AMETA_ALT_RIGHT_ON )
+				event.KeyInput.Alt = true;
+			else
+				event.KeyInput.Alt = false;
+
+			if (   keyMetaState & AMETA_CTRL_ON
+				|| keyMetaState & AMETA_CTRL_LEFT_ON
+				|| keyMetaState & AMETA_CTRL_RIGHT_ON )
+				event.KeyInput.Control = true;
+			else
+				event.KeyInput.Control = false;
+
+			if ( keyMetaState & AMETA_CAPS_LOCK_ON )
+				event.KeyInput.CapsLock = true;
+			else
+				event.KeyInput.CapsLock = false;
 
 			// Having memory allocations + going through JNI for each key-press is pretty bad (slow).
 			// So we do it only for those keys which are likely text-characters and avoid it for all other keys.

--- a/source/Irrlicht/CIrrDeviceConsole.cpp
+++ b/source/Irrlicht/CIrrDeviceConsole.cpp
@@ -227,6 +227,8 @@ bool CIrrDeviceConsole::run()
 			e.KeyInput.PressedDown = (in.Event.KeyEvent.bKeyDown == TRUE);
 			e.KeyInput.Control     = (in.Event.KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)) != 0;
 			e.KeyInput.Shift       = (in.Event.KeyEvent.dwControlKeyState & SHIFT_PRESSED) != 0;
+			e.KeyInput.Alt         = (in.Event.KeyEvent.dwControlKeyState & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED)) != 0;
+			e.KeyInput.CapsLock    = (in.Event.KeyEvent.dwControlKeyState & CAPSLOCK_ON) != 0;
 			e.KeyInput.Key         = EKEY_CODE(in.Event.KeyEvent.wVirtualKeyCode);
 			e.KeyInput.Char        = in.Event.KeyEvent.uChar.UnicodeChar;
 			postEventFromUser(e);

--- a/source/Irrlicht/CIrrDeviceFB.cpp
+++ b/source/Irrlicht/CIrrDeviceFB.cpp
@@ -300,6 +300,13 @@ bool CIrrDeviceFB::run()
 				case KEY_LEFTSHIFT:
 					irrevent.KeyInput.Shift = true;
 				break;
+				case KEY_RIGHTALT:
+				case KEY_LEFTALT:
+					irrevent.KeyInput.Alt = true;
+				break;
+				case KEY_CAPSLOCK:
+					irrevent.KeyInput.CapsLock = true;
+				break;
 				case KEY_ESC:
 					irrevent.KeyInput.Key = (EKEY_CODE)0x1B;
 				break;

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -920,6 +920,8 @@ bool CIrrDeviceLinux::run()
 				irrevent.KeyInput.Char = 0;	// on release that's undefined
 				irrevent.KeyInput.Control = (event.xkey.state & ControlMask) != 0;
 				irrevent.KeyInput.Shift = (event.xkey.state & ShiftMask) != 0;
+				irrevent.KeyInput.Alt = (event.xkey.state & Mod1Mask) != 0;
+				irrevent.KeyInput.CapsLock = (event.xkey.state & LockMask) != 0;
 				irrevent.KeyInput.Key = getKeyCode(event);
 
 				postEventFromUser(irrevent);
@@ -986,6 +988,8 @@ bool CIrrDeviceLinux::run()
 					irrevent.KeyInput.PressedDown = true;
 					irrevent.KeyInput.Control = (event.xkey.state & ControlMask) != 0;
 					irrevent.KeyInput.Shift = (event.xkey.state & ShiftMask) != 0;
+					irrevent.KeyInput.Alt = (event.xkey.state & Mod1Mask) != 0;
+					irrevent.KeyInput.CapsLock = (event.xkey.state & LockMask) != 0;
 					irrevent.KeyInput.Key = getKeyCode(event);
 					postEventFromUser(irrevent);
 				}

--- a/source/Irrlicht/CIrrDeviceOSX.mm
+++ b/source/Irrlicht/CIrrDeviceOSX.mm
@@ -1063,6 +1063,8 @@ void CIrrDeviceMacOSX::postKeyEvent(void *event,irr::SEvent &ievent,bool pressed
 		ievent.KeyInput.PressedDown = pressed;
 		ievent.KeyInput.Shift = ([(NSEvent *)event modifierFlags] & NSShiftKeyMask) != 0;
 		ievent.KeyInput.Control = ([(NSEvent *)event modifierFlags] & NSControlKeyMask) != 0;
+		ievent.KeyInput.Alt = ([(NSEvent *)event modifierFlags] & NSAlternateKeyMask) != 0;
+		ievent.KeyInput.CapsLock = ([(NSEvent *)event modifierFlags] & NSAlphaShiftKeyMask) != 0;
 		ievent.KeyInput.Char = mchar;
 
 		if (skipCommand)

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -679,7 +679,9 @@ bool CIrrDeviceSDL::run()
 				irrevent.KeyInput.Key = key;
 				irrevent.KeyInput.PressedDown = (SDL_event.type == SDL_KEYDOWN);
 				irrevent.KeyInput.Shift = (SDL_event.key.keysym.mod & KMOD_SHIFT) != 0;
-				irrevent.KeyInput.Control = (SDL_event.key.keysym.mod & KMOD_CTRL ) != 0;
+				irrevent.KeyInput.Control = (SDL_event.key.keysym.mod & KMOD_CTRL) != 0;
+				irrevent.KeyInput.Alt = (SDL_event.key.keysym.mod & KMOD_ALT) != 0;
+				irrevent.KeyInput.CapsLock = (SDL_event.key.keysym.mod & KMOD_CAPS) != 0;
 
 				// SDL2 no longer provides unicode character in the key event so we ensure the character is in the correct case
 				// TODO: Unicode input doesn't work like this, should probably use SDL_TextInputEvent

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -701,6 +701,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 			event.KeyInput.Shift = ((allKeys[VK_SHIFT] & 0x80)!=0);
 			event.KeyInput.Control = ((allKeys[VK_CONTROL] & 0x80)!=0);
+			event.KeyInput.Alt = ((allKeys[VK_MENU] & 0x80)!=0);
+			event.KeyInput.CapsLock = (GetKeyState(VK_CAPITAL) & 0x0001)!=0;
 
 			// Handle unicode and deadkeys
 			WCHAR keyChars[2];


### PR DESCRIPTION
Alt and CapsLock key states added in preparation for key, mouse and touch events to on_receive_fields callback in Minetest engine.

Notes:
Could only test Linux X platform.

The following is not directly related to this addition but can affect the events.

All platforms map to key codes in Keycodes.h, which appears to be a reiteration of virtual keys from win 32 SDK.

The Android code maps a lot of keys to KEY_UNKNOWN but some of them may have a relevant key in win 32.

I couldn't see any key event code in ios code. I've never used this platform but does it implement an on screen keyboard?

The frame buffer platform does not appear to be correct. I couldn't see any mouse events. I just added a couple of extra case clauses consistent with what is there, but the key events don't look as though they would operate correctly. The event struct is allocated on the stack at every event but not initialized. Only some fields are set, and the rest contain junk (what ever was on the stack). The Shift and Control fields (which I extended with Alt and CapsLock) are set to true when an event is trapped for these keys, whether pressed or released. And not set for any other keys. The event data from the system doesn't contain a character field, and is never set or cleared.

These events are already consumed by various IGUIElements. If there are any deficits they are already present in the engine.