### PR TITLE
CGUITabControl: Center selected tab whenever possible

### DIFF
--- a/source/Irrlicht/CGUITabControl.h
+++ b/source/Irrlicht/CGUITabControl.h
@@ -153,8 +153,11 @@ namespace gui
 
 		void scrollLeft();
 		void scrollRight();
-		bool needScrollControl( s32 startIndex=0, bool withScrollControl=false );
-		s32 calcTabWidth(s32 pos, IGUIFont* font, const wchar_t* text, bool withScrollControl ) const;
+		//! Indicates whether the tabs overflow in X direction
+		bool needScrollControl( s32 startIndex=0, bool withScrollControl=false, s32 *pos_rightmost=nullptr );
+		//! Left index calculation based on the selected tab
+		s32 calculateScrollIndexFromActive();
+		s32 calcTabWidth(IGUIFont* font, const wchar_t* text) const;
 		core::rect<s32> calcTabPos();
 		void setVisibleTab(s32 idx);
 		void removeTabButNotChild(s32 idx);


### PR DESCRIPTION
This greatly improves the navigation speed by clicking through the tabs
without losing track of the current scroll position.

How to test: `/test_formspec` in devtest. Compare master/PR and notice how different it is.