### PR TITLE
Add setRelativeMode for SDL driver

### DIFF
--- a/include/ICursorControl.h
+++ b/include/ICursorControl.h
@@ -160,6 +160,9 @@ namespace gui
 		\param rect: A pointer to an reference rectangle or 0 to disable the reference rectangle.*/
 		virtual void setReferenceRect(core::rect<s32>* rect=0) = 0;
 
+		//! Sets or unsets relative mouse mode
+		/** Specific to SDL */
+		virtual void setRelativeMode(bool relative) {};
 
 		//! Sets the active cursor icon
 		/** Setting cursor icons is so far only supported on Win32 and Linux */

--- a/include/ICursorControl.h
+++ b/include/ICursorControl.h
@@ -160,7 +160,7 @@ namespace gui
 		\param rect: A pointer to an reference rectangle or 0 to disable the reference rectangle.*/
 		virtual void setReferenceRect(core::rect<s32>* rect=0) = 0;
 
-		//! Sets or unsets relative mouse mode
+		//! Internally fixes the mouse position, and reports relative mouse movement compared to the old position 
 		/** Specific to SDL */
 		virtual void setRelativeMode(bool relative) {};
 

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -146,6 +146,12 @@ namespace irr
 			virtual void setPosition(s32 x, s32 y) _IRR_OVERRIDE_
 			{
 				SDL_WarpMouseInWindow(Device->Window, x, y);
+
+				if (SDL_GetRelativeMouseMode()) {
+					// There won't be an event for this warp (details on libsdl-org/SDL/issues/6034)
+					Device->MouseX = x;
+					Device->MouseY = y;
+				}
 			}
 
 			//! Returns the current position of the mouse cursor.

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -169,6 +169,17 @@ namespace irr
 			{
 			}
 
+			virtual void setRelativeMode(bool relative) _IRR_OVERRIDE_
+			{
+				// Only change it when necessary, as it flushes mouse motion when enabled
+				if ( relative != SDL_GetRelativeMouseMode()) {
+					if ( relative )
+						SDL_SetRelativeMouseMode( SDL_TRUE );
+					else
+						SDL_SetRelativeMouseMode( SDL_FALSE );
+				}
+			}
+
 		private:
 
 			void updateCursorPos()


### PR DESCRIPTION
I found a way to fix the screen view spinning rapidly out of control on the SDL driver. This seems to be the most practical way to do it, bar any changes upstream to the minetest repository, even if it is inelegant.

I am not sure why there is still some jitter even with relative mouse mode, but this is definitely a significant improvement over how it was previously.