### PR TITLE
Fix crash on Android

### DIFF
--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -270,6 +270,7 @@ bool COGLES1Driver::updateVertexHardwareBuffer(SHWBufferLink_opengl *HWBuffer)
 
 	//buffer vertex data, and convert colours...
 	core::array<c8> buffer(vertexSize * vertexCount);
+	buffer.set_used(vertexSize * vertexCount);
 	memcpy(buffer.pointer(), vertices, vertexSize * vertexCount);
 
 	// in order to convert the colors into opengl format (RGBA)


### PR DESCRIPTION
FIx #127 and minetest/minetest#12658
`core::array` only reserves space in constructor, that's why `m_data.empty()` returns `true` and `pointer()` returns `nullptr`. To resize the underlying vector we need to call `set_used()`.