### PR TITLE
[nosquash] Implement X11 primary selection, and add clipboard support for SDL

### DIFF
--- a/include/IOSOperator.h
+++ b/include/IOSOperator.h
@@ -26,11 +26,22 @@ public:
 	}
 
 	//! Copies text to the clipboard
+	//! \param text: text in utf-8
 	virtual void copyToClipboard(const c8* text) const = 0;
 
+	//! Copies text to the primary selection
+	//! This is a no-op on some platforms.
+	//! \param text: text in utf-8
+	virtual void copyToPrimarySelection(const c8* text) const = 0;
+
 	//! Get text from the clipboard
-	/** \return Returns 0 if no string is in there. */
+	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 	virtual const c8* getTextFromClipboard() const = 0;
+
+	//! Get text from the primary selection
+	//! This is a no-op on some platforms.
+	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
+	virtual const c8* getTextFromPrimarySelection() const = 0;
 
 	//! Get the total and available system RAM
 	/** \param totalBytes: will contain the total system memory in Kilobytes (1024 B)

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -1136,6 +1136,34 @@ bool CGUIEditBox::processMouse(const SEvent& event)
 				return true;
 			}
 		}
+	case EMIE_MMOUSE_PRESSED_DOWN: {
+		if (!AbsoluteClippingRect.isPointInside(core::position2d<s32>(
+					event.MouseInput.X, event.MouseInput.Y)))
+			return false;
+
+		if (!Environment->hasFocus(this)) {
+			BlinkStartTime = os::Timer::getTime();
+		}
+
+		// move cursor and disable marking
+		CursorPos = getCursorPos(event.MouseInput.X, event.MouseInput.Y);
+		MouseMarking = false;
+		setTextMarkers(CursorPos, CursorPos);
+
+		// paste from the primary selection
+		inputString([&] {
+			irr::core::stringw inserted_text;
+			if (!Operator)
+				return inserted_text;
+			const c8 *inserted_text_utf8 = Operator->getTextFromPrimarySelection();
+			if (!inserted_text_utf8)
+				return inserted_text;
+			core::multibyteToWString(inserted_text, inserted_text_utf8);
+			return inserted_text;
+		}());
+
+		return true;
+	}
 	default:
 		break;
 	}
@@ -1625,6 +1653,17 @@ void CGUIEditBox::setTextMarkers(s32 begin, s32 end)
 	{
 		MarkBegin = begin;
 		MarkEnd = end;
+
+		if (!PasswordBox && Operator && MarkBegin != MarkEnd) {
+			// copy to primary selection
+			const s32 realmbgn = MarkBegin < MarkEnd ? MarkBegin : MarkEnd;
+			const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
+
+			core::stringc s;
+			wStringToMultibyte(s, Text.subString(realmbgn, realmend - realmbgn));
+			Operator->copyToPrimarySelection(s.c_str());
+		}
+
 		sendGuiEvent(EGET_EDITBOX_MARKING_CHANGED);
 	}
 }

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1044,12 +1044,15 @@ bool CIrrDeviceLinux::run()
 						send_response(req->property);
 					};
 
-					if (req->selection != X_ATOM_CLIPBOARD ||
+					if ((req->selection != X_ATOM_CLIPBOARD &&
+							req->selection != XA_PRIMARY) ||
 							req->owner != XWindow) {
 						// we are not the owner, refuse request
 						send_response_refuse();
 						break;
 					}
+					const core::stringc &text_buffer = req->selection == X_ATOM_CLIPBOARD ?
+							Clipboard : PrimarySelection;
 
 					// for debugging:
 					//~ {
@@ -1070,8 +1073,8 @@ bool CIrrDeviceLinux::run()
 								req->target, X_ATOM_UTF8_STRING,
 								8, // format = 8-bit
 								PropModeReplace,
-								(unsigned char *)Clipboard.c_str(),
-								Clipboard.size());
+								(unsigned char *)text_buffer.c_str(),
+								text_buffer.size());
 						send_response(req->target);
 						break;
 					}
@@ -1096,8 +1099,8 @@ bool CIrrDeviceLinux::run()
 						set_property_and_notify(
 								X_ATOM_UTF8_STRING,
 								8,
-								Clipboard.c_str(),
-								Clipboard.size()
+								text_buffer.c_str(),
+								text_buffer.size()
 							);
 
 					} else {
@@ -1763,47 +1766,49 @@ void CIrrDeviceLinux::pollJoysticks()
 }
 
 
+#if defined(_IRR_COMPILE_WITH_X11_)
 //! gets text from the clipboard
 //! \return Returns 0 if no string is in there, otherwise utf-8 text.
-const c8 *CIrrDeviceLinux::getTextFromClipboard() const
+const c8 *CIrrDeviceLinux::getTextFromSelection(Atom selection, core::stringc &text_buffer) const
 {
-#if defined(_IRR_COMPILE_WITH_X11_)
-	Window ownerWindow = XGetSelectionOwner(XDisplay, X_ATOM_CLIPBOARD);
+	Window ownerWindow = XGetSelectionOwner(XDisplay, selection);
 	if (ownerWindow == XWindow) {
-		return Clipboard.c_str();
+		return text_buffer.c_str();
 	}
 
-	Clipboard = "";
+	text_buffer = "";
 
 	if (ownerWindow == None) {
-		return Clipboard.c_str();
+		return text_buffer.c_str();
 	}
 
 	// delete the property to be set beforehand
 	XDeleteProperty(XDisplay, XWindow, XA_PRIMARY);
 
-	XConvertSelection(XDisplay, X_ATOM_CLIPBOARD, X_ATOM_UTF8_STRING, XA_PRIMARY,
+	XConvertSelection(XDisplay, selection, X_ATOM_UTF8_STRING, XA_PRIMARY,
 			XWindow, CurrentTime);
 	XFlush(XDisplay);
 
 	// wait for event via a blocking call
 	XEvent event_ret;
+	std::pair<Window, Atom> args(XWindow, selection);
 	XIfEvent(XDisplay, &event_ret, [](Display *_display, XEvent *event, XPointer arg) {
+		auto p = reinterpret_cast<std::pair<Window, Atom> *>(arg);
 		return (Bool) (event->type == SelectionNotify &&
-				event->xselection.requestor == *(Window *)arg &&
-				event->xselection.selection == X_ATOM_CLIPBOARD &&
+				event->xselection.requestor == p->first &&
+				event->xselection.selection == p->second &&
 				event->xselection.target == X_ATOM_UTF8_STRING);
-	}, (XPointer)&XWindow);
+	}, (XPointer)&args);
 
 	_IRR_DEBUG_BREAK_IF(!(event_ret.type == SelectionNotify &&
 			event_ret.xselection.requestor == XWindow &&
-			event_ret.xselection.selection == X_ATOM_CLIPBOARD &&
+			event_ret.xselection.selection == selection &&
 			event_ret.xselection.target == X_ATOM_UTF8_STRING));
 
 	Atom property_set = event_ret.xselection.property;
 	if (event_ret.xselection.property == None) {
 		// request failed => empty string
-		return Clipboard.c_str();
+		return text_buffer.c_str();
 	}
 
 	// check for data
@@ -1830,15 +1835,15 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 	// for debugging:
 	//~ {
 		//~ char *type_name = XGetAtomName(XDisplay, type);
-		//~ fprintf(stderr, "CIrrDeviceLinux::getTextFromClipboard: actual type: %s (=%ld)\n",
+		//~ fprintf(stderr, "CIrrDeviceLinux::getTextFromSelection: actual type: %s (=%ld)\n",
 				//~ type_name, type);
 		//~ XFree(type_name);
 	//~ }
 
 	if (type != X_ATOM_UTF8_STRING && type != X_ATOM_UTF8_MIME_TYPE) {
-		os::Printer::log("CIrrDeviceLinux::getTextFromClipboard: did not get utf-8 string",
+		os::Printer::log("CIrrDeviceLinux::getTextFromSelection: did not get utf-8 string",
 				ELL_WARNING);
-		return Clipboard.c_str();
+		return text_buffer.c_str();
 	}
 
 	if (bytesLeft > 0) {
@@ -1847,19 +1852,48 @@ const c8 *CIrrDeviceLinux::getTextFromClipboard() const
 									bytesLeft, 0, AnyPropertyType, &type, &format,
 									&numItems, &dummy, &data);
 		if (result == Success)
-			Clipboard = (irr::c8 *)data;
+			text_buffer = (irr::c8 *)data;
 		XFree (data);
 	}
 
 	// delete the property again, to inform the owner about the successful transfer
 	XDeleteProperty(XDisplay, XWindow, property_set);
 
-	return Clipboard.c_str();
+	return text_buffer.c_str();
+}
+#endif
 
+//! gets text from the clipboard
+//! \return Returns 0 if no string is in there, otherwise utf-8 text.
+const c8 *CIrrDeviceLinux::getTextFromClipboard() const
+{
+#if defined(_IRR_COMPILE_WITH_X11_)
+	return getTextFromSelection(X_ATOM_CLIPBOARD, Clipboard);
 #else
 	return nullptr;
 #endif
 }
+
+//! gets text from the primary selection
+//! \return Returns 0 if no string is in there, otherwise utf-8 text.
+const c8 *CIrrDeviceLinux::getTextFromPrimarySelection() const
+{
+#if defined(_IRR_COMPILE_WITH_X11_)
+	return getTextFromSelection(XA_PRIMARY, PrimarySelection);
+#else
+	return nullptr;
+#endif
+}
+
+#if defined(_IRR_COMPILE_WITH_X11_)
+bool CIrrDeviceLinux::becomeSelectionOwner(Atom selection) const
+{
+	XSetSelectionOwner (XDisplay, selection, XWindow, CurrentTime);
+	XFlush (XDisplay);
+	Window owner = XGetSelectionOwner(XDisplay, selection);
+	return owner == XWindow;
+}
+#endif
 
 //! copies text to the clipboard
 void CIrrDeviceLinux::copyToClipboard(const c8 *text) const
@@ -1868,11 +1902,19 @@ void CIrrDeviceLinux::copyToClipboard(const c8 *text) const
 	// Actually there is no clipboard on X but applications just say they own the clipboard and return text when asked.
 	// Which btw. also means that on X you lose clipboard content when closing applications.
 	Clipboard = text;
-	XSetSelectionOwner (XDisplay, X_ATOM_CLIPBOARD, XWindow, CurrentTime);
-	XFlush (XDisplay);
-	Window owner = XGetSelectionOwner(XDisplay, X_ATOM_CLIPBOARD);
-	if (owner != XWindow) {
+	if (!becomeSelectionOwner(X_ATOM_CLIPBOARD)) {
 		os::Printer::log("CIrrDeviceLinux::copyToClipboard: failed to set owner", ELL_WARNING);
+	}
+#endif
+}
+
+//! copies text to the primary selection
+void CIrrDeviceLinux::copyToPrimarySelection(const c8 *text) const
+{
+#if defined(_IRR_COMPILE_WITH_X11_)
+	PrimarySelection = text;
+	if (!becomeSelectionOwner(XA_PRIMARY)) {
+		os::Printer::log("CIrrDeviceLinux::copyToPrimarySelection: failed to set owner", ELL_WARNING);
 	}
 #endif
 }

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -99,10 +99,19 @@ namespace irr
 		//! \return Returns 0 if no string is in there, otherwise utf-8 text.
 		virtual const c8 *getTextFromClipboard() const;
 
+		//! gets text from the primary selection
+		//! \return Returns 0 if no string is in there, otherwise utf-8 text.
+		virtual const c8 *getTextFromPrimarySelection() const;
+
 		//! copies text to the clipboard
-		//! This sets the clipboard selection and _not_ the primary selection which you have on X on the middle mouse button.
+		//! This sets the clipboard selection and _not_ the primary selection.
 		//! @param text The text in utf-8
 		virtual void copyToClipboard(const c8 *text) const;
+
+		//! copies text to the primary selection
+		//! This sets the primary selection which you have on X on the middle mouse button.
+		//! @param text The text in utf-8
+		virtual void copyToPrimarySelection(const c8 *text) const;
 
 		//! Remove all messages pending in the system message loop
 		void clearSystemMessages() override;
@@ -143,6 +152,9 @@ namespace irr
 		bool createInputContext();
 		void destroyInputContext();
 		EKEY_CODE getKeyCode(XEvent &event);
+
+		const c8 *getTextFromSelection(Atom selection, core::stringc &text_buffer) const;
+		bool becomeSelectionOwner(Atom selection) const;
 #endif
 
 		//! Implementation of the linux cursor control
@@ -416,6 +428,7 @@ namespace irr
 		bool HasNetWM;
 		// text is utf-8
 		mutable core::stringc Clipboard;
+		mutable core::stringc PrimarySelection;
 #endif
 		u32 Width, Height;
 		bool WindowHasFocus;

--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -17,7 +17,9 @@
 #endif
 #endif
 
-#if defined(_IRR_COMPILE_WITH_X11_DEVICE_)
+#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+#include <SDL_clipboard.h>
+#elif defined(_IRR_COMPILE_WITH_X11_DEVICE_)
 #include "CIrrDeviceLinux.h"
 #endif
 #if defined(_IRR_COMPILE_WITH_OSX_DEVICE_)
@@ -59,8 +61,10 @@ void COSOperator::copyToClipboard(const c8 *text) const
 	if (strlen(text)==0)
 		return;
 
-// Windows version
-#if defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+	SDL_SetClipboardText(text);
+
+#elif defined(_IRR_WINDOWS_API_)
 	if (!OpenClipboard(NULL) || text == 0)
 		return;
 
@@ -117,7 +121,14 @@ void COSOperator::copyToPrimarySelection(const c8 *text) const
 //! gets text from the clipboard
 const c8* COSOperator::getTextFromClipboard() const
 {
-#if defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+	static char *text = nullptr;
+	if (text)
+		SDL_free(text);
+	text = SDL_GetClipboardText();
+	return text;
+
+#elif defined(_IRR_WINDOWS_API_)
 	if (!OpenClipboard(NULL))
 		return 0;
 

--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -54,7 +54,6 @@ const core::stringc& COSOperator::getOperatingSystemVersion() const
 
 
 //! copies text to the clipboard
-//! \param text: text in utf-8
 void COSOperator::copyToClipboard(const c8 *text) const
 {
 	if (strlen(text)==0)
@@ -102,8 +101,20 @@ void COSOperator::copyToClipboard(const c8 *text) const
 }
 
 
+//! copies text to the primary selection
+void COSOperator::copyToPrimarySelection(const c8 *text) const
+{
+	if (strlen(text)==0)
+		return;
+
+#if defined(_IRR_COMPILE_WITH_X11_DEVICE_)
+    if ( IrrDeviceLinux )
+        IrrDeviceLinux->copyToPrimarySelection(text);
+#endif
+}
+
+
 //! gets text from the clipboard
-//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 const c8* COSOperator::getTextFromClipboard() const
 {
 #if defined(_IRR_WINDOWS_API_)
@@ -138,6 +149,21 @@ const c8* COSOperator::getTextFromClipboard() const
 #elif defined(_IRR_COMPILE_WITH_X11_DEVICE_)
     if ( IrrDeviceLinux )
         return IrrDeviceLinux->getTextFromClipboard();
+    return 0;
+
+#else
+
+	return 0;
+#endif
+}
+
+
+//! gets text from the primary selection
+const c8* COSOperator::getTextFromPrimarySelection() const
+{
+#if defined(_IRR_COMPILE_WITH_X11_DEVICE_)
+    if ( IrrDeviceLinux )
+        return IrrDeviceLinux->getTextFromPrimarySelection();
     return 0;
 
 #else

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -27,12 +27,16 @@ public:
 	const core::stringc& getOperatingSystemVersion() const override;
 
 	//! copies text to the clipboard
-	//! \param text: text in utf-8
 	void copyToClipboard(const c8 *text) const override;
 
+	//! copies text to the primary selection
+	void copyToPrimarySelection(const c8 *text) const override;
+
 	//! gets text from the clipboard
-	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 	const c8* getTextFromClipboard() const override;
+
+	//! gets text from the primary selection
+	const c8* getTextFromPrimarySelection() const override;
 
 	//! gets the total and available system RAM in kB
 	//! \param Total: will contain the total system memory


### PR DESCRIPTION
As #55 was merged, supporting primary selection is just a matter of using a different X11 Atom and using a separate string to store primary selection texts.
And this is exactly what the first commit does.

The second commit does exactly the same as the commit in the minetest repo PR, but with other member variable and utf8 to stringw function names.

## To Do

PR is ready for review.
Commits are best reviewed separately.

Don't squash.

## How to test

* Use X11.
* Place a sign in minetest.
* Mark text.
* Middle click.
* Do the same in other programs.