### PR TITLE
Fix typo s/tranfrom/transform/

### DIFF
--- a/source/Irrlicht/CXMeshFileLoader.cpp
+++ b/source/Irrlicht/CXMeshFileLoader.cpp
@@ -1106,7 +1106,7 @@ bool CXMeshFileLoader::parseDataObjectSkinWeights(SXMesh &mesh)
 
 	if (!getNextTokenAsString(TransformNodeName))
 	{
-		os::Printer::log("Unknown syntax while reading transfrom node name string in .x file", ELL_WARNING);
+		os::Printer::log("Unknown syntax while reading transform node name string in .x file", ELL_WARNING);
 		os::Printer::log("Line", core::stringc(Line).c_str(), ELL_WARNING);
 		return false;
 	}


### PR DESCRIPTION
This patch was provided form J. Puydt to Debian.
Origin: https://salsa.debian.org/games-team/minetest/-/blob/master/debian/patches/fix-typos.patch