### PR TITLE
Replace _IRR_OVERRIDE_ macro with override keyword

### DIFF
--- a/include/CIndexBuffer.h
+++ b/include/CIndexBuffer.h
@@ -39,46 +39,46 @@ namespace scene
 		public:
 			core::array<T> Indices;
 
-			virtual u32 stride() const _IRR_OVERRIDE_ {return sizeof(T);}
+			u32 stride() const override {return sizeof(T);}
 
-			virtual u32 size() const _IRR_OVERRIDE_ {return Indices.size();}
+			u32 size() const override {return Indices.size();}
 
-			virtual void push_back(const u32 &element) _IRR_OVERRIDE_
+			void push_back(const u32 &element) override
 			{
 				// push const ref due to compiler problem with gcc 4.6, big endian
 				Indices.push_back((const T&)element);
 			}
 
-			virtual u32 operator [](u32 index) const _IRR_OVERRIDE_
+			u32 operator [](u32 index) const override
 			{
 				return (u32)(Indices[index]);
 			}
 
-			virtual u32 getLast() _IRR_OVERRIDE_ {return (u32)Indices.getLast();}
+			u32 getLast() override {return (u32)Indices.getLast();}
 
-			virtual void setValue(u32 index, u32 value) _IRR_OVERRIDE_
+			void setValue(u32 index, u32 value) override
 			{
 				Indices[index]=(T)value;
 			}
 
-			virtual void set_used(u32 usedNow) _IRR_OVERRIDE_
+			void set_used(u32 usedNow) override
 			{
 				Indices.set_used(usedNow);
 			}
 
-			virtual void reallocate(u32 new_size) _IRR_OVERRIDE_
+			void reallocate(u32 new_size) override
 			{
 				Indices.reallocate(new_size);
 			}
 
-			virtual u32 allocated_size() const _IRR_OVERRIDE_
+			u32 allocated_size() const override
 			{
 				return Indices.allocated_size();
 			}
 
-			virtual void* pointer() _IRR_OVERRIDE_  {return Indices.pointer();}
+			void* pointer() override  {return Indices.pointer();}
 
-			virtual video::E_INDEX_TYPE getType() const _IRR_OVERRIDE_
+			video::E_INDEX_TYPE getType() const override
 			{
 				if (sizeof(T)==sizeof(u16))
 					return video::EIT_16BIT;
@@ -110,7 +110,7 @@ namespace scene
 		}
 
 		//virtual void setType(video::E_INDEX_TYPE IndexType);
-		virtual void setType(video::E_INDEX_TYPE IndexType) _IRR_OVERRIDE_
+		void setType(video::E_INDEX_TYPE IndexType) override
 		{
 			IIndexList *NewIndices=0;
 
@@ -141,78 +141,78 @@ namespace scene
 			Indices=NewIndices;
 		}
 
-		virtual void* getData() _IRR_OVERRIDE_ {return Indices->pointer();}
+		void* getData() override {return Indices->pointer();}
 
-		virtual video::E_INDEX_TYPE getType() const _IRR_OVERRIDE_ {return Indices->getType();}
+		video::E_INDEX_TYPE getType() const override {return Indices->getType();}
 
-		virtual u32 stride() const _IRR_OVERRIDE_ {return Indices->stride();}
+		u32 stride() const override {return Indices->stride();}
 
-		virtual u32 size() const _IRR_OVERRIDE_
+		u32 size() const override
 		{
 			return Indices->size();
 		}
 
-		virtual void push_back(const u32 &element) _IRR_OVERRIDE_
+		void push_back(const u32 &element) override
 		{
 			Indices->push_back(element);
 		}
 
-		virtual u32 operator [](u32 index) const _IRR_OVERRIDE_
+		u32 operator [](u32 index) const override
 		{
 			return (*Indices)[index];
 		}
 
-		virtual u32 getLast() _IRR_OVERRIDE_
+		u32 getLast() override
 		{
 			return Indices->getLast();
 		}
 
-		virtual void setValue(u32 index, u32 value) _IRR_OVERRIDE_
+		void setValue(u32 index, u32 value) override
 		{
 			Indices->setValue(index, value);
 		}
 
-		virtual void set_used(u32 usedNow) _IRR_OVERRIDE_
+		void set_used(u32 usedNow) override
 		{
 			Indices->set_used(usedNow);
 		}
 
-		virtual void reallocate(u32 new_size) _IRR_OVERRIDE_
+		void reallocate(u32 new_size) override
 		{
 			Indices->reallocate(new_size);
 		}
 
-		virtual u32 allocated_size() const _IRR_OVERRIDE_
+		u32 allocated_size() const override
 		{
 			return Indices->allocated_size();
 		}
 
-		virtual void* pointer() _IRR_OVERRIDE_
+		void* pointer() override
 		{
 			return Indices->pointer();
 		}
 
 		//! get the current hardware mapping hint
-		virtual E_HARDWARE_MAPPING getHardwareMappingHint() const _IRR_OVERRIDE_
+		E_HARDWARE_MAPPING getHardwareMappingHint() const override
 		{
 			return MappingHint;
 		}
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint ) _IRR_OVERRIDE_
+		void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint ) override
 		{
 			MappingHint=NewMappingHint;
 		}
 
 		//! flags the mesh as changed, reloads hardware buffers
-		virtual void setDirty() _IRR_OVERRIDE_
+		void setDirty() override
 		{
 			++ChangedID;
 		}
 
 		//! Get the currently used ID for identification of changes.
 		/** This shouldn't be used for anything outside the VideoDriver. */
-		virtual u32 getChangedID() const _IRR_OVERRIDE_ {return ChangedID;}
+		u32 getChangedID() const override {return ChangedID;}
 
 		E_HARDWARE_MAPPING MappingHint;
 		u32 ChangedID;

--- a/include/CMeshBuffer.h
+++ b/include/CMeshBuffer.h
@@ -32,7 +32,7 @@ namespace scene
 
 		//! Get material of this meshbuffer
 		/** \return Material of this buffer */
-		virtual const video::SMaterial& getMaterial() const _IRR_OVERRIDE_
+		const video::SMaterial& getMaterial() const override
 		{
 			return Material;
 		}
@@ -40,7 +40,7 @@ namespace scene
 
 		//! Get material of this meshbuffer
 		/** \return Material of this buffer */
-		virtual video::SMaterial& getMaterial() _IRR_OVERRIDE_
+		video::SMaterial& getMaterial() override
 		{
 			return Material;
 		}
@@ -48,7 +48,7 @@ namespace scene
 
 		//! Get pointer to vertices
 		/** \return Pointer to vertices. */
-		virtual const void* getVertices() const _IRR_OVERRIDE_
+		const void* getVertices() const override
 		{
 			return Vertices.const_pointer();
 		}
@@ -56,7 +56,7 @@ namespace scene
 
 		//! Get pointer to vertices
 		/** \return Pointer to vertices. */
-		virtual void* getVertices() _IRR_OVERRIDE_
+		void* getVertices() override
 		{
 			return Vertices.pointer();
 		}
@@ -64,21 +64,21 @@ namespace scene
 
 		//! Get number of vertices
 		/** \return Number of vertices. */
-		virtual u32 getVertexCount() const _IRR_OVERRIDE_
+		u32 getVertexCount() const override
 		{
 			return Vertices.size();
 		}
 
 		//! Get type of index data which is stored in this meshbuffer.
 		/** \return Index type of this buffer. */
-		virtual video::E_INDEX_TYPE getIndexType() const _IRR_OVERRIDE_
+		video::E_INDEX_TYPE getIndexType() const override
 		{
 			return video::EIT_16BIT;
 		}
 
 		//! Get pointer to indices
 		/** \return Pointer to indices. */
-		virtual const u16* getIndices() const _IRR_OVERRIDE_
+		const u16* getIndices() const override
 		{
 			return Indices.const_pointer();
 		}
@@ -86,7 +86,7 @@ namespace scene
 
 		//! Get pointer to indices
 		/** \return Pointer to indices. */
-		virtual u16* getIndices() _IRR_OVERRIDE_
+		u16* getIndices() override
 		{
 			return Indices.pointer();
 		}
@@ -94,7 +94,7 @@ namespace scene
 
 		//! Get number of indices
 		/** \return Number of indices. */
-		virtual u32 getIndexCount() const _IRR_OVERRIDE_
+		u32 getIndexCount() const override
 		{
 			return Indices.size();
 		}
@@ -102,7 +102,7 @@ namespace scene
 
 		//! Get the axis aligned bounding box
 		/** \return Axis aligned bounding box of this buffer. */
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_
+		const core::aabbox3d<f32>& getBoundingBox() const override
 		{
 			return BoundingBox;
 		}
@@ -111,7 +111,7 @@ namespace scene
 		//! Set the axis aligned bounding box
 		/** \param box New axis aligned bounding box for this buffer. */
 		//! set user axis aligned bounding box
-		virtual void setBoundingBox(const core::aabbox3df& box) _IRR_OVERRIDE_
+		void setBoundingBox(const core::aabbox3df& box) override
 		{
 			BoundingBox = box;
 		}
@@ -119,7 +119,7 @@ namespace scene
 
 		//! Recalculate the bounding box.
 		/** should be called if the mesh changed. */
-		virtual void recalculateBoundingBox() _IRR_OVERRIDE_
+		void recalculateBoundingBox() override
 		{
 			if (!Vertices.empty())
 			{
@@ -136,43 +136,43 @@ namespace scene
 
 		//! Get type of vertex data stored in this buffer.
 		/** \return Type of vertex data. */
-		virtual video::E_VERTEX_TYPE getVertexType() const _IRR_OVERRIDE_
+		video::E_VERTEX_TYPE getVertexType() const override
 		{
 			return T::getType();
 		}
 
 		//! returns position of vertex i
-		virtual const core::vector3df& getPosition(u32 i) const _IRR_OVERRIDE_
+		const core::vector3df& getPosition(u32 i) const override
 		{
 			return Vertices[i].Pos;
 		}
 
 		//! returns position of vertex i
-		virtual core::vector3df& getPosition(u32 i) _IRR_OVERRIDE_
+		core::vector3df& getPosition(u32 i) override
 		{
 			return Vertices[i].Pos;
 		}
 
 		//! returns normal of vertex i
-		virtual const core::vector3df& getNormal(u32 i) const _IRR_OVERRIDE_
+		const core::vector3df& getNormal(u32 i) const override
 		{
 			return Vertices[i].Normal;
 		}
 
 		//! returns normal of vertex i
-		virtual core::vector3df& getNormal(u32 i) _IRR_OVERRIDE_
+		core::vector3df& getNormal(u32 i) override
 		{
 			return Vertices[i].Normal;
 		}
 
 		//! returns texture coord of vertex i
-		virtual const core::vector2df& getTCoords(u32 i) const _IRR_OVERRIDE_
+		const core::vector2df& getTCoords(u32 i) const override
 		{
 			return Vertices[i].TCoords;
 		}
 
 		//! returns texture coord of vertex i
-		virtual core::vector2df& getTCoords(u32 i) _IRR_OVERRIDE_
+		core::vector2df& getTCoords(u32 i) override
 		{
 			return Vertices[i].TCoords;
 		}
@@ -183,7 +183,7 @@ namespace scene
 		or the main buffer is of standard type. Otherwise, behavior is
 		undefined.
 		*/
-		virtual void append(const void* const vertices, u32 numVertices, const u16* const indices, u32 numIndices) _IRR_OVERRIDE_
+		void append(const void* const vertices, u32 numVertices, const u16* const indices, u32 numIndices) override
 		{
 			if (vertices == getVertices())
 				return;
@@ -212,7 +212,7 @@ namespace scene
 		undefined.
 		\param other Meshbuffer to be appended to this one.
 		*/
-		virtual void append(const IMeshBuffer* const other) _IRR_OVERRIDE_
+		void append(const IMeshBuffer* const other) override
 		{
 			/*
 			if (this==other)
@@ -238,19 +238,19 @@ namespace scene
 
 
 		//! get the current hardware mapping hint
-		virtual E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const _IRR_OVERRIDE_
+		E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const override
 		{
 			return MappingHint_Vertex;
 		}
 
 		//! get the current hardware mapping hint
-		virtual E_HARDWARE_MAPPING getHardwareMappingHint_Index() const _IRR_OVERRIDE_
+		E_HARDWARE_MAPPING getHardwareMappingHint_Index() const override
 		{
 			return MappingHint_Index;
 		}
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX ) _IRR_OVERRIDE_
+		void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX ) override
 		{
 			if (Buffer==EBT_VERTEX_AND_INDEX || Buffer==EBT_VERTEX)
 				MappingHint_Vertex=NewMappingHint;
@@ -259,19 +259,19 @@ namespace scene
 		}
 
 		//! Describe what kind of primitive geometry is used by the meshbuffer
-		virtual void setPrimitiveType(E_PRIMITIVE_TYPE type) _IRR_OVERRIDE_
+		void setPrimitiveType(E_PRIMITIVE_TYPE type) override
 		{
 			PrimitiveType = type;
 		}
 
 		//! Get the kind of primitive geometry which is used by the meshbuffer
-		virtual E_PRIMITIVE_TYPE getPrimitiveType() const _IRR_OVERRIDE_
+		E_PRIMITIVE_TYPE getPrimitiveType() const override
 		{
 			return PrimitiveType;
 		}
 
 		//! flags the mesh as changed, reloads hardware buffers
-		virtual void setDirty(E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_
+		void setDirty(E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX) override
 		{
 			if (Buffer==EBT_VERTEX_AND_INDEX ||Buffer==EBT_VERTEX)
 				++ChangedID_Vertex;
@@ -281,17 +281,17 @@ namespace scene
 
 		//! Get the currently used ID for identification of changes.
 		/** This shouldn't be used for anything outside the VideoDriver. */
-		virtual u32 getChangedID_Vertex() const _IRR_OVERRIDE_ {return ChangedID_Vertex;}
+		u32 getChangedID_Vertex() const override {return ChangedID_Vertex;}
 
 		//! Get the currently used ID for identification of changes.
 		/** This shouldn't be used for anything outside the VideoDriver. */
-		virtual u32 getChangedID_Index() const _IRR_OVERRIDE_ {return ChangedID_Index;}
+		u32 getChangedID_Index() const override {return ChangedID_Index;}
 
-		virtual void setHWBuffer(void *ptr) const _IRR_OVERRIDE_ {
+		void setHWBuffer(void *ptr) const override {
 			HWBuffer = ptr;
 		}
 
-		virtual void *getHWBuffer() const _IRR_OVERRIDE_ {
+		void *getHWBuffer() const override {
 			return HWBuffer;
 		}
 

--- a/include/CVertexBuffer.h
+++ b/include/CVertexBuffer.h
@@ -40,33 +40,33 @@ namespace scene
 		public:
 			core::array<T> Vertices;
 
-			virtual u32 stride() const _IRR_OVERRIDE_ {return sizeof(T);}
+			u32 stride() const override {return sizeof(T);}
 
-			virtual u32 size() const _IRR_OVERRIDE_ {return Vertices.size();}
+			u32 size() const override {return Vertices.size();}
 
-			virtual void push_back (const video::S3DVertex &element) _IRR_OVERRIDE_
+			void push_back (const video::S3DVertex &element) override
 			{Vertices.push_back((T&)element);}
 
-			virtual video::S3DVertex& operator [](const u32 index) const _IRR_OVERRIDE_
+			video::S3DVertex& operator [](const u32 index) const override
 			{return (video::S3DVertex&)Vertices[index];}
 
-			virtual video::S3DVertex& getLast() _IRR_OVERRIDE_
+			video::S3DVertex& getLast() override
 			{return (video::S3DVertex&)Vertices.getLast();}
 
-			virtual void set_used(u32 usedNow) _IRR_OVERRIDE_
+			void set_used(u32 usedNow) override
 			{Vertices.set_used(usedNow);}
 
-			virtual void reallocate(u32 new_size) _IRR_OVERRIDE_
+			void reallocate(u32 new_size) override
 			{Vertices.reallocate(new_size);}
 
-			virtual u32 allocated_size() const _IRR_OVERRIDE_
+			u32 allocated_size() const override
 			{
 				return Vertices.allocated_size();
 			}
 
-			virtual video::S3DVertex* pointer() _IRR_OVERRIDE_ {return Vertices.pointer();}
+			video::S3DVertex* pointer() override {return Vertices.pointer();}
 
-			virtual video::E_VERTEX_TYPE getType() const _IRR_OVERRIDE_ {return T::getType();}
+			video::E_VERTEX_TYPE getType() const override {return T::getType();}
 		};
 
 	public:
@@ -95,7 +95,7 @@ namespace scene
 		}
 
 
-		virtual void setType(video::E_VERTEX_TYPE vertexType) _IRR_OVERRIDE_
+		void setType(video::E_VERTEX_TYPE vertexType) override
 		{
 			IVertexList *NewVertices=0;
 
@@ -130,73 +130,73 @@ namespace scene
 			Vertices=NewVertices;
 		}
 
-		virtual void* getData() _IRR_OVERRIDE_ {return Vertices->pointer();}
+		void* getData() override {return Vertices->pointer();}
 
-		virtual video::E_VERTEX_TYPE getType() const _IRR_OVERRIDE_ {return Vertices->getType();}
+		video::E_VERTEX_TYPE getType() const override {return Vertices->getType();}
 
-		virtual u32 stride() const _IRR_OVERRIDE_ {return Vertices->stride();}
+		u32 stride() const override {return Vertices->stride();}
 
-		virtual u32 size() const _IRR_OVERRIDE_
+		u32 size() const override
 		{
 			return Vertices->size();
 		}
 
-		virtual void push_back (const video::S3DVertex &element) _IRR_OVERRIDE_
+		void push_back (const video::S3DVertex &element) override
 		{
 			Vertices->push_back(element);
 		}
 
-		virtual video::S3DVertex& operator [](const u32 index) const _IRR_OVERRIDE_
+		video::S3DVertex& operator [](const u32 index) const override
 		{
 			return (*Vertices)[index];
 		}
 
-		virtual video::S3DVertex& getLast() _IRR_OVERRIDE_
+		video::S3DVertex& getLast() override
 		{
 			return Vertices->getLast();
 		}
 
-		virtual void set_used(u32 usedNow) _IRR_OVERRIDE_
+		void set_used(u32 usedNow) override
 		{
 			Vertices->set_used(usedNow);
 		}
 
-		virtual void reallocate(u32 new_size) _IRR_OVERRIDE_
+		void reallocate(u32 new_size) override
 		{
 			Vertices->reallocate(new_size);
 		}
 
-		virtual u32 allocated_size() const _IRR_OVERRIDE_
+		u32 allocated_size() const override
 		{
 			return Vertices->allocated_size();
 		}
 
-		virtual video::S3DVertex* pointer() _IRR_OVERRIDE_
+		video::S3DVertex* pointer() override
 		{
 			return Vertices->pointer();
 		}
 
 		//! get the current hardware mapping hint
-		virtual E_HARDWARE_MAPPING getHardwareMappingHint() const _IRR_OVERRIDE_
+		E_HARDWARE_MAPPING getHardwareMappingHint() const override
 		{
 			return MappingHint;
 		}
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint ) _IRR_OVERRIDE_
+		void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint ) override
 		{
 			MappingHint=NewMappingHint;
 		}
 
 		//! flags the mesh as changed, reloads hardware buffers
-		virtual void setDirty() _IRR_OVERRIDE_
+		void setDirty() override
 		{
 			++ChangedID;
 		}
 
 		//! Get the currently used ID for identification of changes.
 		/** This shouldn't be used for anything outside the VideoDriver. */
-		virtual u32 getChangedID() const _IRR_OVERRIDE_  {return ChangedID;}
+		u32 getChangedID() const override  {return ChangedID;}
 
 		E_HARDWARE_MAPPING MappingHint;
 		u32 ChangedID;

--- a/include/IAnimatedMesh.h
+++ b/include/IAnimatedMesh.h
@@ -61,7 +61,7 @@ namespace scene
 		if getMeshType() returns EAMT_MD2 it's safe to cast the
 		IAnimatedMesh to IAnimatedMeshMD2.
 		\returns Type of the mesh. */
-		virtual E_ANIMATED_MESH_TYPE getMeshType() const _IRR_OVERRIDE_
+		E_ANIMATED_MESH_TYPE getMeshType() const override
 		{
 			return EAMT_UNKNOWN;
 		}

--- a/include/IBoneSceneNode.h
+++ b/include/IBoneSceneNode.h
@@ -74,17 +74,17 @@ namespace scene
 		virtual E_BONE_ANIMATION_MODE getAnimationMode() const = 0;
 
 		//! Get the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_ = 0;
+		const core::aabbox3d<f32>& getBoundingBox() const override = 0;
 
 		//! Returns the relative transformation of the scene node.
 		//virtual core::matrix4 getRelativeTransformation() const = 0;
 
 		//! The animation method.
-		virtual void OnAnimate(u32 timeMs) _IRR_OVERRIDE_ =0;
+		void OnAnimate(u32 timeMs) override =0;
 
 		//! The render method.
 		/** Does nothing as bones are not visible. */
-		virtual void render() _IRR_OVERRIDE_ { }
+		void render() override { }
 
 		//! How the relative transformation of the bone is used
 		virtual void setSkinningSpace( E_BONE_SKINNING_SPACE space ) =0;

--- a/include/ICameraSceneNode.h
+++ b/include/ICameraSceneNode.h
@@ -72,7 +72,7 @@ namespace scene
 		ISceneManager::addCameraSceneNodeFPS, may want to get
 		this input for changing their position, look at target or
 		whatever. */
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_ =0;
+		bool OnEvent(const SEvent& event) override =0;
 
 		//! Sets the look at target of the camera
 		/** If the camera's target and rotation are bound ( @see
@@ -90,7 +90,7 @@ namespace scene
 		bindTargetAndRotation() ) then calling this will also change
 		the camera's target to match the rotation.
 		\param rotation New rotation of the node in degrees. */
-		virtual void setRotation(const core::vector3df& rotation) _IRR_OVERRIDE_ =0;
+		void setRotation(const core::vector3df& rotation) override =0;
 
 		//! Gets the current look at target of the camera
 		/** \return The current look at target of the camera, in world co-ordinates */

--- a/include/IGUIElement.h
+++ b/include/IGUIElement.h
@@ -545,7 +545,7 @@ public:
 
 
 	//! Called if an event happened.
-	virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_
+	bool OnEvent(const SEvent& event) override
 	{
 		return Parent ? Parent->OnEvent(event) : false;
 	}

--- a/include/IGUIFontBitmap.h
+++ b/include/IGUIFontBitmap.h
@@ -19,7 +19,7 @@ class IGUIFontBitmap : public IGUIFont
 public:
 
 	//! Returns the type of this font
-	virtual EGUI_FONT_TYPE getType() const _IRR_OVERRIDE_ { return EGFT_BITMAP; }
+	EGUI_FONT_TYPE getType() const override { return EGFT_BITMAP; }
 
 	//! returns the parsed Symbol Information
 	virtual IGUISpriteBank* getSpriteBank() const = 0;
@@ -36,7 +36,7 @@ public:
 	kerning value. For example, EGFT_BITMAP will add the right kerning value of previousLetter to the
 	left side kerning value of thisLetter, then add the global value.
 	*/
-	virtual s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const _IRR_OVERRIDE_ = 0;
+	s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const override = 0;
 };
 
 } // end namespace gui

--- a/include/SAnimatedMesh.h
+++ b/include/SAnimatedMesh.h
@@ -38,14 +38,14 @@ namespace scene
 
 		//! Gets the frame count of the animated mesh.
 		/** \return Amount of frames. If the amount is 1, it is a static, non animated mesh. */
-		virtual u32 getFrameCount() const _IRR_OVERRIDE_
+		u32 getFrameCount() const override
 		{
 			return Meshes.size();
 		}
 
 		//! Gets the default animation speed of the animated mesh.
 		/** \return Amount of frames per second. If the amount is 0, it is a static, non animated mesh. */
-		virtual f32 getAnimationSpeed() const _IRR_OVERRIDE_
+		f32 getAnimationSpeed() const override
 		{
 			return FramesPerSecond;
 		}
@@ -53,7 +53,7 @@ namespace scene
 		//! Gets the frame count of the animated mesh.
 		/** \param fps Frames per second to play the animation with. If the amount is 0, it is not animated.
 		The actual speed is set in the scene node the mesh is instantiated in.*/
-		virtual void setAnimationSpeed(f32 fps) _IRR_OVERRIDE_
+		void setAnimationSpeed(f32 fps) override
 		{
 			FramesPerSecond=fps;
 		}
@@ -66,7 +66,7 @@ namespace scene
 		\param startFrameLoop: start frame
 		\param endFrameLoop: end frame
 		\return The animated mesh based on a detail level. */
-		virtual IMesh* getMesh(s32 frame, s32 detailLevel=255, s32 startFrameLoop=-1, s32 endFrameLoop=-1) _IRR_OVERRIDE_
+		IMesh* getMesh(s32 frame, s32 detailLevel=255, s32 startFrameLoop=-1, s32 endFrameLoop=-1) override
 		{
 			if (Meshes.empty())
 				return 0;
@@ -86,13 +86,13 @@ namespace scene
 
 		//! Returns an axis aligned bounding box of the mesh.
 		/** \return A bounding box of this mesh is returned. */
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_
+		const core::aabbox3d<f32>& getBoundingBox() const override
 		{
 			return Box;
 		}
 
 		//! set user axis aligned bounding box
-		virtual void setBoundingBox(const core::aabbox3df& box) _IRR_OVERRIDE_
+		void setBoundingBox(const core::aabbox3df& box) override
 		{
 			Box = box;
 		}
@@ -112,13 +112,13 @@ namespace scene
 		}
 
 		//! Returns the type of the animated mesh.
-		virtual E_ANIMATED_MESH_TYPE getMeshType() const _IRR_OVERRIDE_
+		E_ANIMATED_MESH_TYPE getMeshType() const override
 		{
 			return Type;
 		}
 
 		//! returns amount of mesh buffers.
-		virtual u32 getMeshBufferCount() const _IRR_OVERRIDE_
+		u32 getMeshBufferCount() const override
 		{
 			if (Meshes.empty())
 				return 0;
@@ -127,7 +127,7 @@ namespace scene
 		}
 
 		//! returns pointer to a mesh buffer
-		virtual IMeshBuffer* getMeshBuffer(u32 nr) const _IRR_OVERRIDE_
+		IMeshBuffer* getMeshBuffer(u32 nr) const override
 		{
 			if (Meshes.empty())
 				return 0;
@@ -139,7 +139,7 @@ namespace scene
 		/** \param material: material to search for
 		\return Returns the pointer to the mesh buffer or
 		NULL if there is no such mesh buffer. */
-		virtual IMeshBuffer* getMeshBuffer( const video::SMaterial &material) const _IRR_OVERRIDE_
+		IMeshBuffer* getMeshBuffer( const video::SMaterial &material) const override
 		{
 			if (Meshes.empty())
 				return 0;
@@ -148,21 +148,21 @@ namespace scene
 		}
 
 		//! Set a material flag for all meshbuffers of this mesh.
-		virtual void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) _IRR_OVERRIDE_
+		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override
 		{
 			for (u32 i=0; i<Meshes.size(); ++i)
 				Meshes[i]->setMaterialFlag(flag, newvalue);
 		}
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) _IRR_OVERRIDE_
+		void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) override
 		{
 			for (u32 i=0; i<Meshes.size(); ++i)
 				Meshes[i]->setHardwareMappingHint(newMappingHint, buffer);
 		}
 
 		//! flags the meshbuffer as changed, reloads hardware buffers
-		virtual void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_
+		void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) override
 		{
 			for (u32 i=0; i<Meshes.size(); ++i)
 				Meshes[i]->setDirty(buffer);

--- a/include/SMesh.h
+++ b/include/SMesh.h
@@ -44,20 +44,20 @@ namespace scene
 
 
 		//! returns amount of mesh buffers.
-		virtual u32 getMeshBufferCount() const _IRR_OVERRIDE_
+		u32 getMeshBufferCount() const override
 		{
 			return MeshBuffers.size();
 		}
 
 		//! returns pointer to a mesh buffer
-		virtual IMeshBuffer* getMeshBuffer(u32 nr) const _IRR_OVERRIDE_
+		IMeshBuffer* getMeshBuffer(u32 nr) const override
 		{
 			return MeshBuffers[nr];
 		}
 
 		//! returns a meshbuffer which fits a material
 		/** reverse search */
-		virtual IMeshBuffer* getMeshBuffer( const video::SMaterial & material) const _IRR_OVERRIDE_
+		IMeshBuffer* getMeshBuffer( const video::SMaterial & material) const override
 		{
 			for (s32 i = (s32)MeshBuffers.size()-1; i >= 0; --i)
 			{
@@ -69,13 +69,13 @@ namespace scene
 		}
 
 		//! returns an axis aligned bounding box
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_
+		const core::aabbox3d<f32>& getBoundingBox() const override
 		{
 			return BoundingBox;
 		}
 
 		//! set user axis aligned bounding box
-		virtual void setBoundingBox( const core::aabbox3df& box) _IRR_OVERRIDE_
+		void setBoundingBox( const core::aabbox3df& box) override
 		{
 			BoundingBox = box;
 		}
@@ -118,21 +118,21 @@ namespace scene
 		}
 
 		//! sets a flag of all contained materials to a new value
-		virtual void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) _IRR_OVERRIDE_
+		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override
 		{
 			for (u32 i=0; i<MeshBuffers.size(); ++i)
 				MeshBuffers[i]->getMaterial().setFlag(flag, newvalue);
 		}
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) _IRR_OVERRIDE_
+		void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) override
 		{
 			for (u32 i=0; i<MeshBuffers.size(); ++i)
 				MeshBuffers[i]->setHardwareMappingHint(newMappingHint, buffer);
 		}
 
 		//! flags the meshbuffer as changed, reloads hardware buffers
-		virtual void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_
+		void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) override
 		{
 			for (u32 i=0; i<MeshBuffers.size(); ++i)
 				MeshBuffers[i]->setDirty(buffer);

--- a/include/SSkinMeshBuffer.h
+++ b/include/SSkinMeshBuffer.h
@@ -32,13 +32,13 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Get Material of this buffer.
-	virtual const video::SMaterial& getMaterial() const _IRR_OVERRIDE_
+	const video::SMaterial& getMaterial() const override
 	{
 		return Material;
 	}
 
 	//! Get Material of this buffer.
-	virtual video::SMaterial& getMaterial() _IRR_OVERRIDE_
+	video::SMaterial& getMaterial() override
 	{
 		return Material;
 	}
@@ -58,7 +58,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Get pointer to vertex array
-	virtual const void* getVertices() const _IRR_OVERRIDE_
+	const void* getVertices() const override
 	{
 		switch (VertexType)
 		{
@@ -72,7 +72,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Get pointer to vertex array
-	virtual void* getVertices() _IRR_OVERRIDE_
+	void* getVertices() override
 	{
 		switch (VertexType)
 		{
@@ -86,7 +86,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Get vertex count
-	virtual u32 getVertexCount() const _IRR_OVERRIDE_
+	u32 getVertexCount() const override
 	{
 		switch (VertexType)
 		{
@@ -101,43 +101,43 @@ struct SSkinMeshBuffer : public IMeshBuffer
 
 	//! Get type of index data which is stored in this meshbuffer.
 	/** \return Index type of this buffer. */
-	virtual video::E_INDEX_TYPE getIndexType() const _IRR_OVERRIDE_
+	video::E_INDEX_TYPE getIndexType() const override
 	{
 		return video::EIT_16BIT;
 	}
 
 	//! Get pointer to index array
-	virtual const u16* getIndices() const _IRR_OVERRIDE_
+	const u16* getIndices() const override
 	{
 		return Indices.const_pointer();
 	}
 
 	//! Get pointer to index array
-	virtual u16* getIndices() _IRR_OVERRIDE_
+	u16* getIndices() override
 	{
 		return Indices.pointer();
 	}
 
 	//! Get index count
-	virtual u32 getIndexCount() const _IRR_OVERRIDE_
+	u32 getIndexCount() const override
 	{
 		return Indices.size();
 	}
 
 	//! Get bounding box
-	virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_
+	const core::aabbox3d<f32>& getBoundingBox() const override
 	{
 		return BoundingBox;
 	}
 
 	//! Set bounding box
-	virtual void setBoundingBox( const core::aabbox3df& box) _IRR_OVERRIDE_
+	void setBoundingBox( const core::aabbox3df& box) override
 	{
 		BoundingBox = box;
 	}
 
 	//! Recalculate bounding box
-	virtual void recalculateBoundingBox() _IRR_OVERRIDE_
+	void recalculateBoundingBox() override
 	{
 		if(!BoundingBoxNeedsRecalculated)
 			return;
@@ -186,7 +186,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Get vertex type
-	virtual video::E_VERTEX_TYPE getVertexType() const _IRR_OVERRIDE_
+	video::E_VERTEX_TYPE getVertexType() const override
 	{
 		return VertexType;
 	}
@@ -244,7 +244,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns position of vertex i
-	virtual const core::vector3df& getPosition(u32 i) const _IRR_OVERRIDE_
+	const core::vector3df& getPosition(u32 i) const override
 	{
 		switch (VertexType)
 		{
@@ -258,7 +258,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns position of vertex i
-	virtual core::vector3df& getPosition(u32 i) _IRR_OVERRIDE_
+	core::vector3df& getPosition(u32 i) override
 	{
 		switch (VertexType)
 		{
@@ -272,7 +272,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns normal of vertex i
-	virtual const core::vector3df& getNormal(u32 i) const _IRR_OVERRIDE_
+	const core::vector3df& getNormal(u32 i) const override
 	{
 		switch (VertexType)
 		{
@@ -286,7 +286,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns normal of vertex i
-	virtual core::vector3df& getNormal(u32 i) _IRR_OVERRIDE_
+	core::vector3df& getNormal(u32 i) override
 	{
 		switch (VertexType)
 		{
@@ -300,7 +300,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns texture coords of vertex i
-	virtual const core::vector2df& getTCoords(u32 i) const _IRR_OVERRIDE_
+	const core::vector2df& getTCoords(u32 i) const override
 	{
 		switch (VertexType)
 		{
@@ -314,7 +314,7 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! returns texture coords of vertex i
-	virtual core::vector2df& getTCoords(u32 i) _IRR_OVERRIDE_
+	core::vector2df& getTCoords(u32 i) override
 	{
 		switch (VertexType)
 		{
@@ -328,25 +328,25 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! append the vertices and indices to the current buffer
-	virtual void append(const void* const vertices, u32 numVertices, const u16* const indices, u32 numIndices) _IRR_OVERRIDE_ {}
+	void append(const void* const vertices, u32 numVertices, const u16* const indices, u32 numIndices) override {}
 
 	//! append the meshbuffer to the current buffer
-	virtual void append(const IMeshBuffer* const other) _IRR_OVERRIDE_ {}
+	void append(const IMeshBuffer* const other) override {}
 
 	//! get the current hardware mapping hint for vertex buffers
-	virtual E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const _IRR_OVERRIDE_
+	E_HARDWARE_MAPPING getHardwareMappingHint_Vertex() const override
 	{
 		return MappingHint_Vertex;
 	}
 
 	//! get the current hardware mapping hint for index buffers
-	virtual E_HARDWARE_MAPPING getHardwareMappingHint_Index() const _IRR_OVERRIDE_
+	E_HARDWARE_MAPPING getHardwareMappingHint_Index() const override
 	{
 		return MappingHint_Index;
 	}
 
 	//! set the hardware mapping hint, for driver
-	virtual void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX ) _IRR_OVERRIDE_
+	void setHardwareMappingHint( E_HARDWARE_MAPPING NewMappingHint, E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX ) override
 	{
 		if (Buffer==EBT_VERTEX)
 			MappingHint_Vertex=NewMappingHint;
@@ -360,19 +360,19 @@ struct SSkinMeshBuffer : public IMeshBuffer
 	}
 
 	//! Describe what kind of primitive geometry is used by the meshbuffer
-	virtual void setPrimitiveType(E_PRIMITIVE_TYPE type) _IRR_OVERRIDE_
+	void setPrimitiveType(E_PRIMITIVE_TYPE type) override
 	{
 		PrimitiveType = type;
 	}
 
 	//! Get the kind of primitive geometry which is used by the meshbuffer
-	virtual E_PRIMITIVE_TYPE getPrimitiveType() const _IRR_OVERRIDE_
+	E_PRIMITIVE_TYPE getPrimitiveType() const override
 	{
 		return PrimitiveType;
 	}
 
 	//! flags the mesh as changed, reloads hardware buffers
-	virtual void setDirty(E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_
+	void setDirty(E_BUFFER_TYPE Buffer=EBT_VERTEX_AND_INDEX) override
 	{
 		if (Buffer==EBT_VERTEX_AND_INDEX || Buffer==EBT_VERTEX)
 			++ChangedID_Vertex;
@@ -380,15 +380,15 @@ struct SSkinMeshBuffer : public IMeshBuffer
 			++ChangedID_Index;
 	}
 
-	virtual u32 getChangedID_Vertex() const _IRR_OVERRIDE_ {return ChangedID_Vertex;}
+	u32 getChangedID_Vertex() const override {return ChangedID_Vertex;}
 
-	virtual u32 getChangedID_Index() const _IRR_OVERRIDE_ {return ChangedID_Index;}
+	u32 getChangedID_Index() const override {return ChangedID_Index;}
 
-	virtual void setHWBuffer(void *ptr) const _IRR_OVERRIDE_ {
+	void setHWBuffer(void *ptr) const override {
 		HWBuffer = ptr;
 	}
 
-	virtual void *getHWBuffer() const _IRR_OVERRIDE_ {
+	void *getHWBuffer() const override {
 		return HWBuffer;
 	}
 

--- a/include/irrTypes.h
+++ b/include/irrTypes.h
@@ -112,12 +112,9 @@ For functions:		template<class T> _IRR_DEPRECATED_ void test4(void) {}
 #define _IRR_DEPRECATED_
 #endif
 
-//! Defines an override macro, to protect virtual functions from typos and other mismatches
-/** Usage in a derived class:
-virtual void somefunc() _IRR_OVERRIDE_;
-*/
+//! deprecated macro for virtual function override
+/** prefer to use the override keyword for new code */
 #define _IRR_OVERRIDE_ override
-
 
 //! creates four CC codes used in Irrlicht for simple ids
 /** some compilers can create those by directly writing the

--- a/source/Irrlicht/Android/CAndroidAssetFileArchive.h
+++ b/source/Irrlicht/Android/CAndroidAssetFileArchive.h
@@ -54,7 +54,7 @@ namespace io
 		virtual void addDirectoryToFileList(const io::path &filename);
 
 		//! return the name (id) of the file Archive
-		virtual const io::path& getArchiveName() const _IRR_OVERRIDE_ {return Path;}
+		const io::path& getArchiveName() const override {return Path;}
 
 	protected:
 		//! Android's asset manager

--- a/source/Irrlicht/CAnimatedMeshSceneNode.h
+++ b/source/Irrlicht/CAnimatedMeshSceneNode.h
@@ -31,114 +31,114 @@ namespace scene
 		virtual ~CAnimatedMeshSceneNode();
 
 		//! sets the current frame. from now on the animation is played from this frame.
-		virtual void setCurrentFrame(f32 frame) _IRR_OVERRIDE_;
+		void setCurrentFrame(f32 frame) override;
 
 		//! frame
-		virtual void OnRegisterSceneNode() _IRR_OVERRIDE_;
+		void OnRegisterSceneNode() override;
 
 		//! OnAnimate() is called just before rendering the whole scene.
-		virtual void OnAnimate(u32 timeMs) _IRR_OVERRIDE_;
+		void OnAnimate(u32 timeMs) override;
 
 		//! renders the node.
-		virtual void render() _IRR_OVERRIDE_;
+		void render() override;
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! sets the frames between the animation is looped.
 		//! the default is 0 - MaximalFrameCount of the mesh.
 		//! NOTE: setMesh will also change this value and set it to the full range of animations of the mesh
-		virtual bool setFrameLoop(s32 begin, s32 end) _IRR_OVERRIDE_;
+		bool setFrameLoop(s32 begin, s32 end) override;
 
 		//! Sets looping mode which is on by default. If set to false,
 		//! animations will not be looped.
-		virtual void setLoopMode(bool playAnimationLooped) _IRR_OVERRIDE_;
+		void setLoopMode(bool playAnimationLooped) override;
 
 		//! returns the current loop mode
-		virtual bool getLoopMode() const _IRR_OVERRIDE_;
+		bool getLoopMode() const override;
 
 		//! Sets a callback interface which will be called if an animation
 		//! playback has ended. Set this to 0 to disable the callback again.
-		virtual void setAnimationEndCallback(IAnimationEndCallBack* callback=0) _IRR_OVERRIDE_;
+		void setAnimationEndCallback(IAnimationEndCallBack* callback=0) override;
 
 		//! sets the speed with which the animation is played
 		//! NOTE: setMesh will also change this value and set it to the default speed of the mesh
-		virtual void setAnimationSpeed(f32 framesPerSecond) _IRR_OVERRIDE_;
+		void setAnimationSpeed(f32 framesPerSecond) override;
 
 		//! gets the speed with which the animation is played
-		virtual f32 getAnimationSpeed() const _IRR_OVERRIDE_;
+		f32 getAnimationSpeed() const override;
 
 		//! returns the material based on the zero based index i. To get the amount
 		//! of materials used by this scene node, use getMaterialCount().
 		//! This function is needed for inserting the node into the scene hierarchy on a
 		//! optimal position for minimizing renderstate changes, but can also be used
 		//! to directly modify the material of a scene node.
-		virtual video::SMaterial& getMaterial(u32 i) _IRR_OVERRIDE_;
+		video::SMaterial& getMaterial(u32 i) override;
 
 		//! returns amount of materials used by this scene node.
-		virtual u32 getMaterialCount() const _IRR_OVERRIDE_;
+		u32 getMaterialCount() const override;
 
 		//! Returns a pointer to a child node, which has the same transformation as
 		//! the corresponding joint, if the mesh in this scene node is a skinned mesh.
-		virtual IBoneSceneNode* getJointNode(const c8* jointName) _IRR_OVERRIDE_;
+		IBoneSceneNode* getJointNode(const c8* jointName) override;
 
 		//! same as getJointNode(const c8* jointName), but based on id
-		virtual IBoneSceneNode* getJointNode(u32 jointID) _IRR_OVERRIDE_;
+		IBoneSceneNode* getJointNode(u32 jointID) override;
 
 		//! Gets joint count.
-		virtual u32 getJointCount() const _IRR_OVERRIDE_;
+		u32 getJointCount() const override;
 
 		//! Removes a child from this scene node.
 		//! Implemented here, to be able to remove the shadow properly, if there is one,
 		//! or to remove attached child.
-		virtual bool removeChild(ISceneNode* child) _IRR_OVERRIDE_;
+		bool removeChild(ISceneNode* child) override;
 
 		//! Returns the current displayed frame number.
-		virtual f32 getFrameNr() const _IRR_OVERRIDE_;
+		f32 getFrameNr() const override;
 		//! Returns the current start frame number.
-		virtual s32 getStartFrame() const _IRR_OVERRIDE_;
+		s32 getStartFrame() const override;
 		//! Returns the current end frame number.
-		virtual s32 getEndFrame() const _IRR_OVERRIDE_;
+		s32 getEndFrame() const override;
 
 		//! Sets if the scene node should not copy the materials of the mesh but use them in a read only style.
 		/* In this way it is possible to change the materials a mesh causing all mesh scene nodes
 		referencing this mesh to change too. */
-		virtual void setReadOnlyMaterials(bool readonly) _IRR_OVERRIDE_;
+		void setReadOnlyMaterials(bool readonly) override;
 
 		//! Returns if the scene node should not copy the materials of the mesh but use them in a read only style
-		virtual bool isReadOnlyMaterials() const _IRR_OVERRIDE_;
+		bool isReadOnlyMaterials() const override;
 
 		//! Sets a new mesh
-		virtual void setMesh(IAnimatedMesh* mesh) _IRR_OVERRIDE_;
+		void setMesh(IAnimatedMesh* mesh) override;
 
 		//! Returns the current mesh
-		virtual IAnimatedMesh* getMesh(void) _IRR_OVERRIDE_ { return Mesh; }
+		IAnimatedMesh* getMesh(void) override { return Mesh; }
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_ANIMATED_MESH; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_ANIMATED_MESH; }
 
 		//! updates the absolute position based on the relative and the parents position
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 
 		//! Set the joint update mode (0-unused, 1-get joints only, 2-set joints only, 3-move and set)
-		virtual void setJointMode(E_JOINT_UPDATE_ON_RENDER mode) _IRR_OVERRIDE_;
+		void setJointMode(E_JOINT_UPDATE_ON_RENDER mode) override;
 
 		//! Sets the transition time in seconds (note: This needs to enable joints, and setJointmode maybe set to 2)
 		//! you must call animateJoints(), or the mesh will not animate
-		virtual void setTransitionTime(f32 Time) _IRR_OVERRIDE_;
+		void setTransitionTime(f32 Time) override;
 
 		//! updates the joint positions of this mesh
-		virtual void animateJoints(bool CalculateAbsolutePositions=true) _IRR_OVERRIDE_;
+		void animateJoints(bool CalculateAbsolutePositions=true) override;
 
 		//! render mesh ignoring its transformation. Used with ragdolls. (culling is unaffected)
-		virtual void setRenderFromIdentity( bool On ) _IRR_OVERRIDE_;
+		void setRenderFromIdentity( bool On ) override;
 
 		//! Creates a clone of this scene node and its children.
 		/** \param newParent An optional new parent.
 		\param newManager An optional new scene manager.
 		\return The newly created clone of this node. */
-		virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+		ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 	private:
 

--- a/source/Irrlicht/CAttributeImpl.h
+++ b/source/Irrlicht/CAttributeImpl.h
@@ -27,42 +27,42 @@ public:
 		setBool(value);
 	}
 
-	virtual s32 getInt() const _IRR_OVERRIDE_
+	s32 getInt() const override
 	{
 		return BoolValue ? 1 : 0;
 	}
 
-	virtual f32 getFloat() const _IRR_OVERRIDE_
+	f32 getFloat() const override
 	{
 		return BoolValue ? 1.0f : 0.0f;
 	}
 
-	virtual bool getBool() const _IRR_OVERRIDE_
+	bool getBool() const override
 	{
 		return BoolValue;
 	}
 
-	virtual void setInt(s32 intValue) _IRR_OVERRIDE_
+	void setInt(s32 intValue) override
 	{
 		BoolValue = (intValue != 0);
 	}
 
-	virtual void setFloat(f32 floatValue) _IRR_OVERRIDE_
+	void setFloat(f32 floatValue) override
 	{
 		BoolValue = (floatValue != 0);
 	}
 
-	virtual void setBool(bool boolValue) _IRR_OVERRIDE_
+	void setBool(bool boolValue) override
 	{
 		BoolValue = boolValue;
 	}
 
-	virtual E_ATTRIBUTE_TYPE getType() const _IRR_OVERRIDE_
+	E_ATTRIBUTE_TYPE getType() const override
 	{
 		return EAT_BOOL;
 	}
 
-	virtual const wchar_t* getTypeString() const _IRR_OVERRIDE_
+	const wchar_t* getTypeString() const override
 	{
 		return L"bool";
 	}
@@ -81,32 +81,32 @@ public:
 		setInt(value);
 	}
 
-	virtual s32 getInt() const _IRR_OVERRIDE_
+	s32 getInt() const override
 	{
 		return Value;
 	}
 
-	virtual f32 getFloat() const _IRR_OVERRIDE_
+	f32 getFloat() const override
 	{
 		return (f32)Value;
 	}
 
-	virtual void setInt(s32 intValue) _IRR_OVERRIDE_
+	void setInt(s32 intValue) override
 	{
 		Value = intValue;
 	}
 
-	virtual void setFloat(f32 floatValue) _IRR_OVERRIDE_
+	void setFloat(f32 floatValue) override
 	{
 		Value = (s32)floatValue;
 	};
 
-	virtual E_ATTRIBUTE_TYPE getType() const _IRR_OVERRIDE_
+	E_ATTRIBUTE_TYPE getType() const override
 	{
 		return EAT_INT;
 	}
 
-	virtual const wchar_t* getTypeString() const _IRR_OVERRIDE_
+	const wchar_t* getTypeString() const override
 	{
 		return L"int";
 	}
@@ -125,32 +125,32 @@ public:
 		setFloat(value);
 	}
 
-	virtual s32 getInt() const _IRR_OVERRIDE_
+	s32 getInt() const override
 	{
 		return (s32)Value;
 	}
 
-	virtual f32 getFloat() const _IRR_OVERRIDE_
+	f32 getFloat() const override
 	{
 		return Value;
 	}
 
-	virtual void setInt(s32 intValue) _IRR_OVERRIDE_
+	void setInt(s32 intValue) override
 	{
 		Value = (f32)intValue;
 	}
 
-	virtual void setFloat(f32 floatValue) _IRR_OVERRIDE_
+	void setFloat(f32 floatValue) override
 	{
 		Value = floatValue;
 	}
 
-	virtual E_ATTRIBUTE_TYPE getType() const _IRR_OVERRIDE_
+	E_ATTRIBUTE_TYPE getType() const override
 	{
 		return EAT_FLOAT;
 	}
 
-	virtual const wchar_t* getTypeString() const _IRR_OVERRIDE_
+	const wchar_t* getTypeString() const override
 	{
 		return L"float";
 	}

--- a/source/Irrlicht/CAttributes.h
+++ b/source/Irrlicht/CAttributes.h
@@ -30,37 +30,37 @@ public:
 	~CAttributes();
 
 	//! Returns amount of attributes in this collection of attributes.
-	virtual u32 getAttributeCount() const _IRR_OVERRIDE_;
+	u32 getAttributeCount() const override;
 
 	//! Returns attribute name by index.
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual const c8* getAttributeName(s32 index) const _IRR_OVERRIDE_;
+	const c8* getAttributeName(s32 index) const override;
 
 	//! Returns the type of an attribute
 	//! \param attributeName: Name for the attribute
-	virtual E_ATTRIBUTE_TYPE getAttributeType(const c8* attributeName) const _IRR_OVERRIDE_;
+	E_ATTRIBUTE_TYPE getAttributeType(const c8* attributeName) const override;
 
 	//! Returns attribute type by index.
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual E_ATTRIBUTE_TYPE getAttributeType(s32 index) const _IRR_OVERRIDE_;
+	E_ATTRIBUTE_TYPE getAttributeType(s32 index) const override;
 
 	//! Returns the type string of the attribute
 	//! \param attributeName: String for the attribute type
 	//! \param defaultNotFound Value returned when attributeName was not found
-	virtual const wchar_t* getAttributeTypeString(const c8* attributeName, const wchar_t* defaultNotFound = L"unknown") const _IRR_OVERRIDE_;
+	const wchar_t* getAttributeTypeString(const c8* attributeName, const wchar_t* defaultNotFound = L"unknown") const override;
 
 	//! Returns the type string of the attribute by index.
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual const wchar_t* getAttributeTypeString(s32 index, const wchar_t* defaultNotFound = L"unknown") const _IRR_OVERRIDE_;
+	const wchar_t* getAttributeTypeString(s32 index, const wchar_t* defaultNotFound = L"unknown") const override;
 
 	//! Returns if an attribute with a name exists
-	virtual bool existsAttribute(const c8* attributeName) const _IRR_OVERRIDE_;
+	bool existsAttribute(const c8* attributeName) const override;
 
 	//! Returns attribute index from name, -1 if not found
-	virtual s32 findAttribute(const c8* attributeName) const _IRR_OVERRIDE_;
+	s32 findAttribute(const c8* attributeName) const override;
 
 	//! Removes all attributes
-	virtual void clear() _IRR_OVERRIDE_;
+	void clear() override;
 
 
 	/*
@@ -70,23 +70,23 @@ public:
 	*/
 
 	//! Adds an attribute as integer
-	virtual void addInt(const c8* attributeName, s32 value) _IRR_OVERRIDE_;
+	void addInt(const c8* attributeName, s32 value) override;
 
 	//! Sets an attribute as integer value
-	virtual void setAttribute(const c8* attributeName, s32 value) _IRR_OVERRIDE_;
+	void setAttribute(const c8* attributeName, s32 value) override;
 
 	//! Gets an attribute as integer value
 	//! \param attributeName: Name of the attribute to get.
 	//! \param defaultNotFound Value returned when attributeName was not found
 	//! \return Returns value of the attribute previously set by setAttribute()
-	virtual s32 getAttributeAsInt(const c8* attributeName, irr::s32 defaultNotFound=0) const _IRR_OVERRIDE_;
+	s32 getAttributeAsInt(const c8* attributeName, irr::s32 defaultNotFound=0) const override;
 
 	//! Gets an attribute as integer value
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual s32 getAttributeAsInt(s32 index) const _IRR_OVERRIDE_;
+	s32 getAttributeAsInt(s32 index) const override;
 
 	//! Sets an attribute as integer value
-	virtual void setAttribute(s32 index, s32 value) _IRR_OVERRIDE_;
+	void setAttribute(s32 index, s32 value) override;
 
 	/*
 
@@ -95,23 +95,23 @@ public:
 	*/
 
 	//! Adds an attribute as float
-	virtual void addFloat(const c8* attributeName, f32 value) _IRR_OVERRIDE_;
+	void addFloat(const c8* attributeName, f32 value) override;
 
 	//! Sets a attribute as float value
-	virtual void setAttribute(const c8* attributeName, f32 value) _IRR_OVERRIDE_;
+	void setAttribute(const c8* attributeName, f32 value) override;
 
 	//! Gets an attribute as float value
 	//! \param attributeName: Name of the attribute to get.
 	//! \param defaultNotFound Value returned when attributeName was not found
 	//! \return Returns value of the attribute previously set by setAttribute()
-	virtual f32 getAttributeAsFloat(const c8* attributeName, irr::f32 defaultNotFound=0.f) const _IRR_OVERRIDE_;
+	f32 getAttributeAsFloat(const c8* attributeName, irr::f32 defaultNotFound=0.f) const override;
 
 	//! Gets an attribute as float value
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual f32 getAttributeAsFloat(s32 index) const _IRR_OVERRIDE_;
+	f32 getAttributeAsFloat(s32 index) const override;
 
 	//! Sets an attribute as float value
-	virtual void setAttribute(s32 index, f32 value) _IRR_OVERRIDE_;
+	void setAttribute(s32 index, f32 value) override;
 
 
 	/*
@@ -119,23 +119,23 @@ public:
 	*/
 
 	//! Adds an attribute as bool
-	virtual void addBool(const c8* attributeName, bool value) _IRR_OVERRIDE_;
+	void addBool(const c8* attributeName, bool value) override;
 
 	//! Sets an attribute as boolean value
-	virtual void setAttribute(const c8* attributeName, bool value) _IRR_OVERRIDE_;
+	void setAttribute(const c8* attributeName, bool value) override;
 
 	//! Gets an attribute as boolean value
 	//! \param attributeName: Name of the attribute to get.
 	//! \param defaultNotFound Value returned when attributeName was not found
 	//! \return Returns value of the attribute previously set by setAttribute()
-	virtual bool getAttributeAsBool(const c8* attributeName, bool defaultNotFound=false) const _IRR_OVERRIDE_;
+	bool getAttributeAsBool(const c8* attributeName, bool defaultNotFound=false) const override;
 
 	//! Gets an attribute as boolean value
 	//! \param index: Index value, must be between 0 and getAttributeCount()-1.
-	virtual bool getAttributeAsBool(s32 index) const _IRR_OVERRIDE_;
+	bool getAttributeAsBool(s32 index) const override;
 
 	//! Sets an attribute as boolean value
-	virtual void setAttribute(s32 index, bool value) _IRR_OVERRIDE_;
+	void setAttribute(s32 index, bool value) override;
 
 protected:
 

--- a/source/Irrlicht/CB3DMeshFileLoader.h
+++ b/source/Irrlicht/CB3DMeshFileLoader.h
@@ -33,13 +33,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".bsp")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! creates/loads an animated mesh from the file.
 	//! \return Pointer to the created mesh. Returns 0 if loading failed.
 	//! If you no longer need the mesh, you should call IAnimatedMesh::drop().
 	//! See IReferenceCounted::drop() for more information.
-	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
+	IAnimatedMesh* createMesh(io::IReadFile* file) override;
 
 private:
 

--- a/source/Irrlicht/CB3DMeshWriter.h
+++ b/source/Irrlicht/CB3DMeshWriter.h
@@ -27,10 +27,10 @@ public:
 	CB3DMeshWriter();
 
 	//! Returns the type of the mesh writer
-    virtual EMESH_WRITER_TYPE getType() const _IRR_OVERRIDE_;
+    EMESH_WRITER_TYPE getType() const override;
 
 	//! writes a mesh
-    virtual bool writeMesh(io::IWriteFile* file, scene::IMesh* mesh, s32 flags=EMWF_NONE) _IRR_OVERRIDE_;
+    bool writeMesh(io::IWriteFile* file, scene::IMesh* mesh, s32 flags=EMWF_NONE) override;
 
 private:
     void writeJointChunk(io::IWriteFile* file, ISkinnedMesh* mesh , ISkinnedMesh::SJoint* joint, f32 animationSpeedMultiplier);

--- a/source/Irrlicht/CBillboardSceneNode.h
+++ b/source/Irrlicht/CBillboardSceneNode.h
@@ -28,58 +28,58 @@ public:
 	virtual ~CBillboardSceneNode();
 
 	//! pre render event
-	virtual void OnRegisterSceneNode() _IRR_OVERRIDE_;
+	void OnRegisterSceneNode() override;
 
 	//! render
-	virtual void render() _IRR_OVERRIDE_;
+	void render() override;
 
 	//! returns the axis aligned bounding box of this node
-	virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+	const core::aabbox3d<f32>& getBoundingBox() const override;
 
 	//! sets the size of the billboard
-	virtual void setSize(const core::dimension2d<f32>& size) _IRR_OVERRIDE_;
+	void setSize(const core::dimension2d<f32>& size) override;
 
 	//! Sets the widths of the top and bottom edges of the billboard independently.
-	virtual void setSize(f32 height, f32 bottomEdgeWidth, f32 topEdgeWidth) _IRR_OVERRIDE_;
+	void setSize(f32 height, f32 bottomEdgeWidth, f32 topEdgeWidth) override;
 
 	//! gets the size of the billboard
-	virtual const core::dimension2d<f32>& getSize() const _IRR_OVERRIDE_;
+	const core::dimension2d<f32>& getSize() const override;
 
 	//! Gets the widths of the top and bottom edges of the billboard.
-	virtual void getSize(f32& height, f32& bottomEdgeWidth, f32& topEdgeWidth) const _IRR_OVERRIDE_;
+	void getSize(f32& height, f32& bottomEdgeWidth, f32& topEdgeWidth) const override;
 
-	virtual video::SMaterial& getMaterial(u32 i) _IRR_OVERRIDE_;
+	video::SMaterial& getMaterial(u32 i) override;
 
 	//! returns amount of materials used by this scene node.
-	virtual u32 getMaterialCount() const _IRR_OVERRIDE_;
+	u32 getMaterialCount() const override;
 
 	//! Set the color of all vertices of the billboard
 	//! \param overallColor: the color to set
-	virtual void setColor(const video::SColor& overallColor) _IRR_OVERRIDE_;
+	void setColor(const video::SColor& overallColor) override;
 
 	//! Set the color of the top and bottom vertices of the billboard
 	//! \param topColor: the color to set the top vertices
 	//! \param bottomColor: the color to set the bottom vertices
 	virtual void setColor(const video::SColor& topColor,
-			const video::SColor& bottomColor) _IRR_OVERRIDE_;
+			const video::SColor& bottomColor) override;
 
 	//! Gets the color of the top and bottom vertices of the billboard
 	//! \param[out] topColor: stores the color of the top vertices
 	//! \param[out] bottomColor: stores the color of the bottom vertices
 	virtual void getColor(video::SColor& topColor,
-			video::SColor& bottomColor) const _IRR_OVERRIDE_;
+			video::SColor& bottomColor) const override;
 
 	//! Get the real boundingbox used by the billboard (which depends on the active camera)
-	virtual const core::aabbox3d<f32>& getTransformedBillboardBoundingBox(const irr::scene::ICameraSceneNode* camera) _IRR_OVERRIDE_;
+	const core::aabbox3d<f32>& getTransformedBillboardBoundingBox(const irr::scene::ICameraSceneNode* camera) override;
 
 	//! Get the amount of mesh buffers.
-	virtual u32 getMeshBufferCount() const _IRR_OVERRIDE_
+	u32 getMeshBufferCount() const override
 	{
 		return Buffer ? 1 : 0;
 	}
 
 	//! Get pointer to the mesh buffer.
-	virtual IMeshBuffer* getMeshBuffer(u32 nr) const _IRR_OVERRIDE_
+	IMeshBuffer* getMeshBuffer(u32 nr) const override
 	{
 		if ( nr == 0 )
 			return Buffer;
@@ -87,10 +87,10 @@ public:
 	}
 
 	//! Returns type of the scene node
-	virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_BILLBOARD; }
+	ESCENE_NODE_TYPE getType() const override { return ESNT_BILLBOARD; }
 
 	//! Creates a clone of this scene node and its children.
-	virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+	ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 protected:
 	void updateMesh(const irr::scene::ICameraSceneNode* camera);

--- a/source/Irrlicht/CBoneSceneNode.h
+++ b/source/Irrlicht/CBoneSceneNode.h
@@ -23,33 +23,33 @@ namespace scene
 			s32 id=-1, u32 boneIndex=0, const c8* boneName=0);
 
 		//! Returns the index of the bone
-		virtual u32 getBoneIndex() const _IRR_OVERRIDE_;
+		u32 getBoneIndex() const override;
 
 		//! Sets the animation mode of the bone. Returns true if successful.
-		virtual bool setAnimationMode(E_BONE_ANIMATION_MODE mode) _IRR_OVERRIDE_;
+		bool setAnimationMode(E_BONE_ANIMATION_MODE mode) override;
 
 		//! Gets the current animation mode of the bone
-		virtual E_BONE_ANIMATION_MODE getAnimationMode() const _IRR_OVERRIDE_;
+		E_BONE_ANIMATION_MODE getAnimationMode() const override;
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		/*
 		//! Returns the relative transformation of the scene node.
-		//virtual core::matrix4 getRelativeTransformation() const _IRR_OVERRIDE_;
+		//core::matrix4 getRelativeTransformation() const override;
 		*/
 
-		virtual void OnAnimate(u32 timeMs) _IRR_OVERRIDE_;
+		void OnAnimate(u32 timeMs) override;
 
-		virtual void updateAbsolutePositionOfAllChildren() _IRR_OVERRIDE_;
+		void updateAbsolutePositionOfAllChildren() override;
 
 		//! How the relative transformation of the bone is used
-		virtual void setSkinningSpace(E_BONE_SKINNING_SPACE space) _IRR_OVERRIDE_
+		void setSkinningSpace(E_BONE_SKINNING_SPACE space) override
 		{
 			SkinningSpace=space;
 		}
 
-		virtual E_BONE_SKINNING_SPACE getSkinningSpace() const _IRR_OVERRIDE_
+		E_BONE_SKINNING_SPACE getSkinningSpace() const override
 		{
 			return SkinningSpace;
 		}

--- a/source/Irrlicht/CCameraSceneNode.h
+++ b/source/Irrlicht/CCameraSceneNode.h
@@ -30,117 +30,117 @@ namespace scene
 		\param projection The new projection matrix of the camera.
 		\param isOrthogonal Set this to true if the matrix is an orthogonal one (e.g.
 		from matrix4::buildProjectionMatrixOrthoLH(). */
-		virtual void setProjectionMatrix(const core::matrix4& projection, bool isOrthogonal = false) _IRR_OVERRIDE_;
+		void setProjectionMatrix(const core::matrix4& projection, bool isOrthogonal = false) override;
 
 		//! Gets the current projection matrix of the camera
 		//! \return Returns the current projection matrix of the camera.
-		virtual const core::matrix4& getProjectionMatrix() const _IRR_OVERRIDE_;
+		const core::matrix4& getProjectionMatrix() const override;
 
 		//! Gets the current view matrix of the camera
 		//! \return Returns the current view matrix of the camera.
-		virtual const core::matrix4& getViewMatrix() const _IRR_OVERRIDE_;
+		const core::matrix4& getViewMatrix() const override;
 
 		//! Sets a custom view matrix affector.
 		/** \param affector: The affector matrix. */
-		virtual void setViewMatrixAffector(const core::matrix4& affector) _IRR_OVERRIDE_;
+		void setViewMatrixAffector(const core::matrix4& affector) override;
 
 		//! Gets the custom view matrix affector.
-		virtual const core::matrix4& getViewMatrixAffector() const _IRR_OVERRIDE_;
+		const core::matrix4& getViewMatrixAffector() const override;
 
 		//! It is possible to send mouse and key events to the camera. Most cameras
 		//! may ignore this input, but camera scene nodes which are created for
 		//! example with scene::ISceneManager::addMayaCameraSceneNode or
 		//! scene::ISceneManager::addMeshViewerCameraSceneNode, may want to get this input
 		//! for changing their position, look at target or whatever.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! Sets the look at target of the camera
 		/** If the camera's target and rotation are bound ( @see bindTargetAndRotation() )
 		then calling this will also change the camera's scene node rotation to match the target.
 		\param pos: Look at target of the camera. */
-		virtual void setTarget(const core::vector3df& pos) _IRR_OVERRIDE_;
+		void setTarget(const core::vector3df& pos) override;
 
 		//! Sets the rotation of the node.
 		/** This only modifies the relative rotation of the node.
 		If the camera's target and rotation are bound ( @see bindTargetAndRotation() )
 		then calling this will also change the camera's target to match the rotation.
 		\param rotation New rotation of the node in degrees. */
-		virtual void setRotation(const core::vector3df& rotation) _IRR_OVERRIDE_;
+		void setRotation(const core::vector3df& rotation) override;
 
 		//! Gets the current look at target of the camera
 		/** \return The current look at target of the camera */
-		virtual const core::vector3df& getTarget() const _IRR_OVERRIDE_;
+		const core::vector3df& getTarget() const override;
 
 		//! Sets the up vector of the camera.
 		//! \param pos: New upvector of the camera.
-		virtual void setUpVector(const core::vector3df& pos) _IRR_OVERRIDE_;
+		void setUpVector(const core::vector3df& pos) override;
 
 		//! Gets the up vector of the camera.
 		//! \return Returns the up vector of the camera.
-		virtual const core::vector3df& getUpVector() const _IRR_OVERRIDE_;
+		const core::vector3df& getUpVector() const override;
 
 		//! Gets distance from the camera to the near plane.
 		//! \return Value of the near plane of the camera.
-		virtual f32 getNearValue() const _IRR_OVERRIDE_;
+		f32 getNearValue() const override;
 
 		//! Gets the distance from the camera to the far plane.
 		//! \return Value of the far plane of the camera.
-		virtual f32 getFarValue() const _IRR_OVERRIDE_;
+		f32 getFarValue() const override;
 
 		//! Get the aspect ratio of the camera.
 		//! \return The aspect ratio of the camera.
-		virtual f32 getAspectRatio() const _IRR_OVERRIDE_;
+		f32 getAspectRatio() const override;
 
 		//! Gets the field of view of the camera.
 		//! \return Field of view of the camera
-		virtual f32 getFOV() const _IRR_OVERRIDE_;
+		f32 getFOV() const override;
 
 		//! Sets the value of the near clipping plane. (default: 1.0f)
-		virtual void setNearValue(f32 zn) _IRR_OVERRIDE_;
+		void setNearValue(f32 zn) override;
 
 		//! Sets the value of the far clipping plane (default: 2000.0f)
-		virtual void setFarValue(f32 zf) _IRR_OVERRIDE_;
+		void setFarValue(f32 zf) override;
 
 		//! Sets the aspect ratio (default: 4.0f / 3.0f)
-		virtual void setAspectRatio(f32 aspect) _IRR_OVERRIDE_;
+		void setAspectRatio(f32 aspect) override;
 
 		//! Sets the field of view (Default: PI / 3.5f)
-		virtual void setFOV(f32 fovy) _IRR_OVERRIDE_;
+		void setFOV(f32 fovy) override;
 
 		//! PreRender event
-		virtual void OnRegisterSceneNode() _IRR_OVERRIDE_;
+		void OnRegisterSceneNode() override;
 
 		//! Render
-		virtual void render() _IRR_OVERRIDE_;
+		void render() override;
 
 		//! Update
-		virtual void updateMatrices() _IRR_OVERRIDE_;
+		void updateMatrices() override;
 
 		//! Returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! Returns the view area.
-		virtual const SViewFrustum* getViewFrustum() const _IRR_OVERRIDE_;
+		const SViewFrustum* getViewFrustum() const override;
 
 		//! Disables or enables the camera to get key or mouse inputs.
 		//! If this is set to true, the camera will respond to key inputs
 		//! otherwise not.
-		virtual void setInputReceiverEnabled(bool enabled) _IRR_OVERRIDE_;
+		void setInputReceiverEnabled(bool enabled) override;
 
 		//! Returns if the input receiver of the camera is currently enabled.
-		virtual bool isInputReceiverEnabled() const _IRR_OVERRIDE_;
+		bool isInputReceiverEnabled() const override;
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_CAMERA; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_CAMERA; }
 
 		//! Binds the camera scene node's rotation to its target position and vice versa, or unbinds them.
-		virtual void bindTargetAndRotation(bool bound) _IRR_OVERRIDE_;
+		void bindTargetAndRotation(bool bound) override;
 
 		//! Queries if the camera scene node's rotation and its target position are bound together.
-		virtual bool getTargetAndRotationBinding(void) const _IRR_OVERRIDE_;
+		bool getTargetAndRotationBinding(void) const override;
 
 		//! Creates a clone of this scene node and its children.
-		virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+		ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 	protected:
 

--- a/source/Irrlicht/CDummyTransformationSceneNode.h
+++ b/source/Irrlicht/CDummyTransformationSceneNode.h
@@ -20,36 +20,36 @@ namespace scene
 		CDummyTransformationSceneNode(ISceneNode* parent, ISceneManager* mgr, s32 id);
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! Returns a reference to the current relative transformation matrix.
 		//! This is the matrix, this scene node uses instead of scale, translation
 		//! and rotation.
-		virtual core::matrix4& getRelativeTransformationMatrix() _IRR_OVERRIDE_;
+		core::matrix4& getRelativeTransformationMatrix() override;
 
 		//! Returns the relative transformation of the scene node.
-		virtual core::matrix4 getRelativeTransformation() const _IRR_OVERRIDE_;
+		core::matrix4 getRelativeTransformation() const override;
 
 		//! does nothing.
-		virtual void render() _IRR_OVERRIDE_ {}
+		void render() override {}
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_DUMMY_TRANSFORMATION; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_DUMMY_TRANSFORMATION; }
 
 		//! Creates a clone of this scene node and its children.
-		virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+		ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 
 	private:
 
 		// TODO: We can add least add some warnings to find troubles faster until we have
 		// fixed bug id 2318691.
-		virtual const core::vector3df& getScale() const _IRR_OVERRIDE_;
-		virtual void setScale(const core::vector3df& scale) _IRR_OVERRIDE_;
-		virtual const core::vector3df& getRotation() const _IRR_OVERRIDE_;
-		virtual void setRotation(const core::vector3df& rotation) _IRR_OVERRIDE_;
-		virtual const core::vector3df& getPosition() const _IRR_OVERRIDE_;
-		virtual void setPosition(const core::vector3df& newpos) _IRR_OVERRIDE_;
+		const core::vector3df& getScale() const override;
+		void setScale(const core::vector3df& scale) override;
+		const core::vector3df& getRotation() const override;
+		void setRotation(const core::vector3df& rotation) override;
+		const core::vector3df& getPosition() const override;
+		void setPosition(const core::vector3df& newpos) override;
 
 		core::matrix4 RelativeTransformationMatrix;
 		core::aabbox3d<f32> Box;

--- a/source/Irrlicht/CEGLManager.h
+++ b/source/Irrlicht/CEGLManager.h
@@ -32,42 +32,42 @@ namespace video
 		// Initialize EGL.
 		/* This method initialize EGLand create EGL display, anyway surface and context
 		aren't create. */
-		virtual bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) _IRR_OVERRIDE_;
+		bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) override;
 
 		// Terminate EGL.
 		/* Terminate EGL context. This method break both existed surface and context. */
-		virtual void terminate() _IRR_OVERRIDE_;
+		void terminate() override;
 
 		// Create EGL surface.
 		/* This method create EGL surface. On some platforms eg. Android, we must
 		recreate surface on each resume, because WindowID may change, so existed
 		surface may not be valid. If EGL context already exist, this method
 		automatically activates it. */
-		virtual bool generateSurface() _IRR_OVERRIDE_;
+		bool generateSurface() override;
 
 		// Destroy EGL surface.
 		/* This method destroy EGL. On some platforms eg. Android, we should call
 		this method on each pause, because after resume this surface may not be valid.
 		Hovewer this method doesn'r break EGL context. */
-		virtual void destroySurface() _IRR_OVERRIDE_;
+		void destroySurface() override;
 
 		// Create EGL context.
 		/* This method create and activate EGL context. */
-		virtual bool generateContext() _IRR_OVERRIDE_;
+		bool generateContext() override;
 
 		// Destroy EGL context.
 		/* This method destroy EGL context. */
-		virtual void destroyContext() _IRR_OVERRIDE_;
+		void destroyContext() override;
 
-		virtual const SExposedVideoData& getContext() const _IRR_OVERRIDE_;
+		const SExposedVideoData& getContext() const override;
 
-		virtual bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) _IRR_OVERRIDE_;
+		bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) override;
 
 		// Get procedure address.
-		virtual void* getProcAddress(const std::string &procName) _IRR_OVERRIDE_;
+		void* getProcAddress(const std::string &procName) override;
 
 		// Swap buffers.
-		virtual bool swapBuffers() _IRR_OVERRIDE_;
+		bool swapBuffers() override;
 
 	protected:
 		enum EConfigStyle

--- a/source/Irrlicht/CEmptySceneNode.h
+++ b/source/Irrlicht/CEmptySceneNode.h
@@ -20,19 +20,19 @@ namespace scene
 		CEmptySceneNode(ISceneNode* parent, ISceneManager* mgr, s32 id);
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! This method is called just before the rendering process of the whole scene.
-		virtual void OnRegisterSceneNode() _IRR_OVERRIDE_;
+		void OnRegisterSceneNode() override;
 
 		//! does nothing.
-		virtual void render() _IRR_OVERRIDE_;
+		void render() override;
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_EMPTY; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_EMPTY; }
 
 		//! Creates a clone of this scene node and its children.
-		virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+		ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 	private:
 

--- a/source/Irrlicht/CFileList.h
+++ b/source/Irrlicht/CFileList.h
@@ -82,37 +82,37 @@ public:
 	\param offset The offset where the file is stored in an archive
 	\param size The size of the file in bytes.
 	\param id The ID of the file in the archive which owns it */
-	virtual u32 addItem(const io::path& fullPath, u32 offset, u32 size, bool isDirectory, u32 id=0) _IRR_OVERRIDE_;
+	u32 addItem(const io::path& fullPath, u32 offset, u32 size, bool isDirectory, u32 id=0) override;
 
 	//! Sorts the file list. You should call this after adding any items to the file list
-	virtual void sort() _IRR_OVERRIDE_;
+	void sort() override;
 
 	//! Returns the amount of files in the filelist.
-	virtual u32 getFileCount() const _IRR_OVERRIDE_;
+	u32 getFileCount() const override;
 
 	//! Gets the name of a file in the list, based on an index.
-	virtual const io::path& getFileName(u32 index) const _IRR_OVERRIDE_;
+	const io::path& getFileName(u32 index) const override;
 
 	//! Gets the full name of a file in the list, path included, based on an index.
-	virtual const io::path& getFullFileName(u32 index) const _IRR_OVERRIDE_;
+	const io::path& getFullFileName(u32 index) const override;
 
 	//! Returns the ID of a file in the file list, based on an index.
-	virtual u32 getID(u32 index) const _IRR_OVERRIDE_;
+	u32 getID(u32 index) const override;
 
 	//! Returns true if the file is a directory
-	virtual bool isDirectory(u32 index) const _IRR_OVERRIDE_;
+	bool isDirectory(u32 index) const override;
 
 	//! Returns the size of a file
-	virtual u32 getFileSize(u32 index) const _IRR_OVERRIDE_;
+	u32 getFileSize(u32 index) const override;
 
 	//! Returns the offset of a file
-	virtual u32 getFileOffset(u32 index) const _IRR_OVERRIDE_;
+	u32 getFileOffset(u32 index) const override;
 
 	//! Searches for a file or folder within the list, returns the index
-	virtual s32 findFile(const io::path& filename, bool isFolder) const _IRR_OVERRIDE_;
+	s32 findFile(const io::path& filename, bool isFolder) const override;
 
 	//! Returns the base path of the file list
-	virtual const io::path& getPath() const _IRR_OVERRIDE_;
+	const io::path& getPath() const override;
 
 protected:
 

--- a/source/Irrlicht/CFileSystem.h
+++ b/source/Irrlicht/CFileSystem.h
@@ -29,101 +29,101 @@ public:
 	virtual ~CFileSystem();
 
 	//! opens a file for read access
-	virtual IReadFile* createAndOpenFile(const io::path& filename) _IRR_OVERRIDE_;
+	IReadFile* createAndOpenFile(const io::path& filename) override;
 
 	//! Creates an IReadFile interface for accessing memory like a file.
-	virtual IReadFile* createMemoryReadFile(const void* memory, s32 len, const io::path& fileName, bool deleteMemoryWhenDropped = false) _IRR_OVERRIDE_;
+	IReadFile* createMemoryReadFile(const void* memory, s32 len, const io::path& fileName, bool deleteMemoryWhenDropped = false) override;
 
 	//! Creates an IReadFile interface for accessing files inside files
-	virtual IReadFile* createLimitReadFile(const io::path& fileName, IReadFile* alreadyOpenedFile, long pos, long areaSize) _IRR_OVERRIDE_;
+	IReadFile* createLimitReadFile(const io::path& fileName, IReadFile* alreadyOpenedFile, long pos, long areaSize) override;
 
 	//! Creates an IWriteFile interface for accessing memory like a file.
-	virtual IWriteFile* createMemoryWriteFile(void* memory, s32 len, const io::path& fileName, bool deleteMemoryWhenDropped=false) _IRR_OVERRIDE_;
+	IWriteFile* createMemoryWriteFile(void* memory, s32 len, const io::path& fileName, bool deleteMemoryWhenDropped=false) override;
 
 	//! Opens a file for write access.
-	virtual IWriteFile* createAndWriteFile(const io::path& filename, bool append=false) _IRR_OVERRIDE_;
+	IWriteFile* createAndWriteFile(const io::path& filename, bool append=false) override;
 
 	//! Adds an archive to the file system.
 	virtual bool addFileArchive(const io::path& filename,
 			bool ignoreCase = true, bool ignorePaths = true,
 			E_FILE_ARCHIVE_TYPE archiveType = EFAT_UNKNOWN,
 			const core::stringc& password="",
-			IFileArchive** retArchive = 0) _IRR_OVERRIDE_;
+			IFileArchive** retArchive = 0) override;
 
 	//! Adds an archive to the file system.
 	virtual bool addFileArchive(IReadFile* file, bool ignoreCase=true,
 			bool ignorePaths=true,
 			E_FILE_ARCHIVE_TYPE archiveType=EFAT_UNKNOWN,
 			const core::stringc& password="",
-			IFileArchive** retArchive = 0) _IRR_OVERRIDE_;
+			IFileArchive** retArchive = 0) override;
 
 	//! Adds an archive to the file system.
-	virtual bool addFileArchive(IFileArchive* archive) _IRR_OVERRIDE_;
+	bool addFileArchive(IFileArchive* archive) override;
 
 	//! move the hirarchy of the filesystem. moves sourceIndex relative up or down
-	virtual bool moveFileArchive(u32 sourceIndex, s32 relative) _IRR_OVERRIDE_;
+	bool moveFileArchive(u32 sourceIndex, s32 relative) override;
 
 	//! Adds an external archive loader to the engine.
-	virtual void addArchiveLoader(IArchiveLoader* loader) _IRR_OVERRIDE_;
+	void addArchiveLoader(IArchiveLoader* loader) override;
 
 	//! Returns the total number of archive loaders added.
-	virtual u32 getArchiveLoaderCount() const _IRR_OVERRIDE_;
+	u32 getArchiveLoaderCount() const override;
 
 	//! Gets the archive loader by index.
-	virtual IArchiveLoader* getArchiveLoader(u32 index) const _IRR_OVERRIDE_;
+	IArchiveLoader* getArchiveLoader(u32 index) const override;
 
 	//! gets the file archive count
-	virtual u32 getFileArchiveCount() const _IRR_OVERRIDE_;
+	u32 getFileArchiveCount() const override;
 
 	//! gets an archive
-	virtual IFileArchive* getFileArchive(u32 index) _IRR_OVERRIDE_;
+	IFileArchive* getFileArchive(u32 index) override;
 
 	//! removes an archive from the file system.
-	virtual bool removeFileArchive(u32 index) _IRR_OVERRIDE_;
+	bool removeFileArchive(u32 index) override;
 
 	//! removes an archive from the file system.
-	virtual bool removeFileArchive(const io::path& filename) _IRR_OVERRIDE_;
+	bool removeFileArchive(const io::path& filename) override;
 
 	//! Removes an archive from the file system.
-	virtual bool removeFileArchive(const IFileArchive* archive) _IRR_OVERRIDE_;
+	bool removeFileArchive(const IFileArchive* archive) override;
 
 	//! Returns the string of the current working directory
-	virtual const io::path& getWorkingDirectory() _IRR_OVERRIDE_;
+	const io::path& getWorkingDirectory() override;
 
 	//! Changes the current Working Directory to the string given.
 	//! The string is operating system dependent. Under Windows it will look
 	//! like this: "drive:\directory\sudirectory\"
-	virtual bool changeWorkingDirectoryTo(const io::path& newDirectory) _IRR_OVERRIDE_;
+	bool changeWorkingDirectoryTo(const io::path& newDirectory) override;
 
 	//! Converts a relative path to an absolute (unique) path, resolving symbolic links
-	virtual io::path getAbsolutePath(const io::path& filename) const _IRR_OVERRIDE_;
+	io::path getAbsolutePath(const io::path& filename) const override;
 
 	//! Returns the directory a file is located in.
 	/** \param filename: The file to get the directory from */
-	virtual io::path getFileDir(const io::path& filename) const _IRR_OVERRIDE_;
+	io::path getFileDir(const io::path& filename) const override;
 
 	//! Returns the base part of a filename, i.e. the name without the directory
 	//! part. If no directory is prefixed, the full name is returned.
 	/** \param filename: The file to get the basename from */
-	virtual io::path getFileBasename(const io::path& filename, bool keepExtension=true) const _IRR_OVERRIDE_;
+	io::path getFileBasename(const io::path& filename, bool keepExtension=true) const override;
 
 	//! flatten a path and file name for example: "/you/me/../." becomes "/you"
-	virtual io::path& flattenFilename( io::path& directory, const io::path& root = "/" ) const _IRR_OVERRIDE_;
+	io::path& flattenFilename( io::path& directory, const io::path& root = "/" ) const override;
 
 	//! Get the relative filename, relative to the given directory
-	virtual path getRelativeFilename(const path& filename, const path& directory) const _IRR_OVERRIDE_;
+	path getRelativeFilename(const path& filename, const path& directory) const override;
 
-	virtual EFileSystemType setFileListSystem(EFileSystemType listType) _IRR_OVERRIDE_;
+	EFileSystemType setFileListSystem(EFileSystemType listType) override;
 
 	//! Creates a list of files and directories in the current working directory
 	//! and returns it.
-	virtual IFileList* createFileList() _IRR_OVERRIDE_;
+	IFileList* createFileList() override;
 
 	//! Creates an empty filelist
-	virtual IFileList* createEmptyFileList(const io::path& path, bool ignoreCase, bool ignorePaths) _IRR_OVERRIDE_;
+	IFileList* createEmptyFileList(const io::path& path, bool ignoreCase, bool ignorePaths) override;
 
 	//! determines if a file exists and would be able to be opened.
-	virtual bool existFile(const io::path& filename) const _IRR_OVERRIDE_;
+	bool existFile(const io::path& filename) const override;
 
 private:
 

--- a/source/Irrlicht/CGLXManager.h
+++ b/source/Irrlicht/CGLXManager.h
@@ -34,34 +34,34 @@ namespace video
         ~CGLXManager();
 
         // Initialize
-        virtual bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) _IRR_OVERRIDE_;
+        bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) override;
 
         // Terminate
-        virtual void terminate() _IRR_OVERRIDE_;
+        void terminate() override;
 
         // Create surface.
-        virtual bool generateSurface() _IRR_OVERRIDE_;
+        bool generateSurface() override;
 
         // Destroy surface.
-        virtual void destroySurface() _IRR_OVERRIDE_;
+        void destroySurface() override;
 
         // Create context.
-        virtual bool generateContext() _IRR_OVERRIDE_;
+        bool generateContext() override;
 
         // Destroy context.
-        virtual void destroyContext() _IRR_OVERRIDE_;
+        void destroyContext() override;
 
         //! Get current context
-        virtual const SExposedVideoData& getContext() const _IRR_OVERRIDE_;
+        const SExposedVideoData& getContext() const override;
 
         //! Change render context, disable old and activate new defined by videoData
-        virtual bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) _IRR_OVERRIDE_;
+        bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) override;
 
 		// Get procedure address.
-		virtual void* getProcAddress(const std::string &procName) _IRR_OVERRIDE_;
+		void* getProcAddress(const std::string &procName) override;
 
         // Swap buffers.
-        virtual bool swapBuffers() _IRR_OVERRIDE_;
+        bool swapBuffers() override;
 
         XVisualInfo* getVisual() const {return VisualInfo;} // return XVisualInfo
 

--- a/source/Irrlicht/CGUIButton.h
+++ b/source/Irrlicht/CGUIButton.h
@@ -30,64 +30,64 @@ namespace gui
 		virtual ~CGUIButton();
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! sets another skin independent font. if this is set to zero, the button uses the font of the skin.
-		virtual void setOverrideFont(IGUIFont* font=0) _IRR_OVERRIDE_;
+		void setOverrideFont(IGUIFont* font=0) override;
 
 		//! Gets the override font (if any)
-		virtual IGUIFont* getOverrideFont() const _IRR_OVERRIDE_;
+		IGUIFont* getOverrideFont() const override;
 
 		//! Get the font which is used right now for drawing
-		virtual IGUIFont* getActiveFont() const _IRR_OVERRIDE_;
+		IGUIFont* getActiveFont() const override;
 
 		//! Sets another color for the button text.
-		virtual void setOverrideColor(video::SColor color)  _IRR_OVERRIDE_;
+		void setOverrideColor(video::SColor color)  override;
 
 		//! Gets the override color
-		virtual video::SColor getOverrideColor(void) const  _IRR_OVERRIDE_;
+		video::SColor getOverrideColor(void) const  override;
 
 		//! Gets the currently used text color
-		virtual video::SColor getActiveColor() const _IRR_OVERRIDE_;
+		video::SColor getActiveColor() const override;
 
 		//! Sets if the button text should use the override color or the color in the gui skin.
-		virtual void enableOverrideColor(bool enable)  _IRR_OVERRIDE_;
+		void enableOverrideColor(bool enable)  override;
 
 		//! Checks if an override color is enabled
-		virtual bool isOverrideColorEnabled(void) const  _IRR_OVERRIDE_;
+		bool isOverrideColorEnabled(void) const  override;
 
 		//! Sets an image which should be displayed on the button when it is in the given state.
-		virtual void setImage(EGUI_BUTTON_IMAGE_STATE state, video::ITexture* image=0, const core::rect<s32>& sourceRect=core::rect<s32>(0,0,0,0))  _IRR_OVERRIDE_;
+		void setImage(EGUI_BUTTON_IMAGE_STATE state, video::ITexture* image=0, const core::rect<s32>& sourceRect=core::rect<s32>(0,0,0,0))  override;
 
 		//! Sets an image which should be displayed on the button when it is in normal state.
-		virtual void setImage(video::ITexture* image=0) _IRR_OVERRIDE_
+		void setImage(video::ITexture* image=0) override
 		{
 			setImage(EGBIS_IMAGE_UP, image);
 		}
 
 		//! Sets an image which should be displayed on the button when it is in normal state.
-		virtual void setImage(video::ITexture* image, const core::rect<s32>& pos) _IRR_OVERRIDE_
+		void setImage(video::ITexture* image, const core::rect<s32>& pos) override
 		{
 			setImage(EGBIS_IMAGE_UP, image, pos);
 		}
 
 		//! Sets an image which should be displayed on the button when it is in pressed state.
-		virtual void setPressedImage(video::ITexture* image=0) _IRR_OVERRIDE_
+		void setPressedImage(video::ITexture* image=0) override
 		{
 			setImage(EGBIS_IMAGE_DOWN, image);
 		}
 
 		//! Sets an image which should be displayed on the button when it is in pressed state.
-		virtual void setPressedImage(video::ITexture* image, const core::rect<s32>& pos) _IRR_OVERRIDE_
+		void setPressedImage(video::ITexture* image, const core::rect<s32>& pos) override
 		{
 			setImage(EGBIS_IMAGE_DOWN, image, pos);
 		}
 
 		//! Sets the sprite bank used by the button
-		virtual void setSpriteBank(IGUISpriteBank* bank=0) _IRR_OVERRIDE_;
+		void setSpriteBank(IGUISpriteBank* bank=0) override;
 
 		//! Sets the animated sprite for a specific button state
 		/** \param index: Number of the sprite within the sprite bank, use -1 for no sprite
@@ -97,60 +97,60 @@ namespace gui
 		*/
 		virtual void setSprite(EGUI_BUTTON_STATE state, s32 index,
 				video::SColor color=video::SColor(255,255,255,255),
-				bool loop=false, bool scale=false) _IRR_OVERRIDE_;
+				bool loop=false, bool scale=false) override;
 
 		//! Get the sprite-index for the given state or -1 when no sprite is set
-		virtual s32 getSpriteIndex(EGUI_BUTTON_STATE state) const _IRR_OVERRIDE_;
+		s32 getSpriteIndex(EGUI_BUTTON_STATE state) const override;
 
 		//! Get the sprite color for the given state. Color is only used when a sprite is set.
-		virtual video::SColor getSpriteColor(EGUI_BUTTON_STATE state) const _IRR_OVERRIDE_;
+		video::SColor getSpriteColor(EGUI_BUTTON_STATE state) const override;
 
 		//! Returns if the sprite in the given state does loop
-		virtual bool getSpriteLoop(EGUI_BUTTON_STATE state) const _IRR_OVERRIDE_;
+		bool getSpriteLoop(EGUI_BUTTON_STATE state) const override;
 
 		//! Returns if the sprite in the given state is scaled
-		virtual bool getSpriteScale(EGUI_BUTTON_STATE state) const _IRR_OVERRIDE_;
+		bool getSpriteScale(EGUI_BUTTON_STATE state) const override;
 
 		//! Sets if the button should behave like a push button. Which means it
 		//! can be in two states: Normal or Pressed. With a click on the button,
 		//! the user can change the state of the button.
-		virtual void setIsPushButton(bool isPushButton=true) _IRR_OVERRIDE_;
+		void setIsPushButton(bool isPushButton=true) override;
 
 		//! Checks whether the button is a push button
-		virtual bool isPushButton() const _IRR_OVERRIDE_;
+		bool isPushButton() const override;
 
 		//! Sets the pressed state of the button if this is a pushbutton
-		virtual void setPressed(bool pressed=true) _IRR_OVERRIDE_;
+		void setPressed(bool pressed=true) override;
 
 		//! Returns if the button is currently pressed
-		virtual bool isPressed() const _IRR_OVERRIDE_;
+		bool isPressed() const override;
 
 		//! Sets if the button should use the skin to draw its border
-		virtual void setDrawBorder(bool border=true) _IRR_OVERRIDE_;
+		void setDrawBorder(bool border=true) override;
 
 		//! Checks if the button face and border are being drawn
-		virtual bool isDrawingBorder() const _IRR_OVERRIDE_;
+		bool isDrawingBorder() const override;
 
 		//! Sets if the alpha channel should be used for drawing images on the button (default is false)
-		virtual void setUseAlphaChannel(bool useAlphaChannel=true) _IRR_OVERRIDE_;
+		void setUseAlphaChannel(bool useAlphaChannel=true) override;
 
 		//! Checks if the alpha channel should be used for drawing images on the button
-		virtual bool isAlphaChannelUsed() const _IRR_OVERRIDE_;
+		bool isAlphaChannelUsed() const override;
 
 		//! Sets if the button should scale the button images to fit
-		virtual void setScaleImage(bool scaleImage=true) _IRR_OVERRIDE_;
+		void setScaleImage(bool scaleImage=true) override;
 
 		//! Checks whether the button scales the used images
-		virtual bool isScalingImage() const _IRR_OVERRIDE_;
+		bool isScalingImage() const override;
 
 		//! Get if the shift key was pressed in last EGET_BUTTON_CLICKED event
-		virtual bool getClickShiftState() const	_IRR_OVERRIDE_
+		bool getClickShiftState() const	override
 		{
 			return ClickShiftState;
 		}
 
 		//! Get if the control key was pressed in last EGET_BUTTON_CLICKED event
-		virtual bool getClickControlState() const _IRR_OVERRIDE_
+		bool getClickControlState() const override
 		{
 			return ClickControlState;
 		}

--- a/source/Irrlicht/CGUICheckBox.h
+++ b/source/Irrlicht/CGUICheckBox.h
@@ -23,30 +23,30 @@ namespace gui
 		CGUICheckBox(bool checked, IGUIEnvironment* environment, IGUIElement* parent, s32 id, core::rect<s32> rectangle);
 
 		//! set if box is checked
-		virtual void setChecked(bool checked) _IRR_OVERRIDE_;
+		void setChecked(bool checked) override;
 
 		//! returns if box is checked
-		virtual bool isChecked() const _IRR_OVERRIDE_;
+		bool isChecked() const override;
 
 		//! Sets whether to draw the background
-		virtual void setDrawBackground(bool draw) _IRR_OVERRIDE_;
+		void setDrawBackground(bool draw) override;
 
 		//! Checks if background drawing is enabled
 		/** \return true if background drawing is enabled, false otherwise */
-		virtual bool isDrawBackgroundEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBackgroundEnabled() const override;
 
 		//! Sets whether to draw the border
-		virtual void setDrawBorder(bool draw) _IRR_OVERRIDE_;
+		void setDrawBorder(bool draw) override;
 
 		//! Checks if border drawing is enabled
 		/** \return true if border drawing is enabled, false otherwise */
-		virtual bool isDrawBorderEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBorderEnabled() const override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 	private:
 

--- a/source/Irrlicht/CGUIComboBox.h
+++ b/source/Irrlicht/CGUIComboBox.h
@@ -30,49 +30,49 @@ namespace gui
 			s32 id, core::rect<s32> rectangle);
 
 		//! Returns amount of items in box
-		virtual u32 getItemCount() const _IRR_OVERRIDE_;
+		u32 getItemCount() const override;
 
 		//! returns string of an item. the idx may be a value from 0 to itemCount-1
-		virtual const wchar_t* getItem(u32 idx) const _IRR_OVERRIDE_;
+		const wchar_t* getItem(u32 idx) const override;
 
 		//! Returns item data of an item. the idx may be a value from 0 to itemCount-1
-		virtual u32 getItemData(u32 idx) const _IRR_OVERRIDE_;
+		u32 getItemData(u32 idx) const override;
 
 		//! Returns index based on item data
-		virtual s32 getIndexForItemData( u32 data ) const _IRR_OVERRIDE_;
+		s32 getIndexForItemData( u32 data ) const override;
 
 		//! adds an item and returns the index of it
-		virtual u32 addItem(const wchar_t* text, u32 data) _IRR_OVERRIDE_;
+		u32 addItem(const wchar_t* text, u32 data) override;
 
 		//! Removes an item from the combo box.
-		virtual void removeItem(u32 id) _IRR_OVERRIDE_;
+		void removeItem(u32 id) override;
 
 		//! deletes all items in the combo box
-		virtual void clear() _IRR_OVERRIDE_;
+		void clear() override;
 
 		//! returns the text of the currently selected item
-		virtual const wchar_t* getText() const _IRR_OVERRIDE_;
+		const wchar_t* getText() const override;
 
 		//! returns id of selected item. returns -1 if no item is selected.
-		virtual s32 getSelected() const _IRR_OVERRIDE_;
+		s32 getSelected() const override;
 
 		//! sets the selected item. Set this to -1 if no item should be selected
-		virtual void setSelected(s32 idx) _IRR_OVERRIDE_;
+		void setSelected(s32 idx) override;
 
 		//! sets the text alignment of the text part
-		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) _IRR_OVERRIDE_;
+		void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) override;
 
 		//! Set the maximal number of rows for the selection listbox
-		virtual void setMaxSelectionRows(u32 max) _IRR_OVERRIDE_;
+		void setMaxSelectionRows(u32 max) override;
 
 		//! Get the maximal number of rows for the selection listbox
-		virtual u32 getMaxSelectionRows() const _IRR_OVERRIDE_;
+		u32 getMaxSelectionRows() const override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 	private:
 

--- a/source/Irrlicht/CGUIEditBox.h
+++ b/source/Irrlicht/CGUIEditBox.h
@@ -28,119 +28,119 @@ namespace gui
 		virtual ~CGUIEditBox();
 
 		//! Sets another skin independent font.
-		virtual void setOverrideFont(IGUIFont* font=0) _IRR_OVERRIDE_;
+		void setOverrideFont(IGUIFont* font=0) override;
 
 		//! Gets the override font (if any)
 		/** \return The override font (may be 0) */
-		virtual IGUIFont* getOverrideFont() const _IRR_OVERRIDE_;
+		IGUIFont* getOverrideFont() const override;
 
 		//! Get the font which is used right now for drawing
 		/** Currently this is the override font when one is set and the
 		font of the active skin otherwise */
-		virtual IGUIFont* getActiveFont() const _IRR_OVERRIDE_;
+		IGUIFont* getActiveFont() const override;
 
 		//! Sets another color for the text.
-		virtual void setOverrideColor(video::SColor color) _IRR_OVERRIDE_;
+		void setOverrideColor(video::SColor color) override;
 
 		//! Gets the override color
-		virtual video::SColor getOverrideColor() const _IRR_OVERRIDE_;
+		video::SColor getOverrideColor() const override;
 
 		//! Sets if the text should use the override color or the
 		//! color in the gui skin.
-		virtual void enableOverrideColor(bool enable) _IRR_OVERRIDE_;
+		void enableOverrideColor(bool enable) override;
 
 		//! Checks if an override color is enabled
 		/** \return true if the override color is enabled, false otherwise */
-		virtual bool isOverrideColorEnabled(void) const _IRR_OVERRIDE_;
+		bool isOverrideColorEnabled(void) const override;
 
 		//! Sets whether to draw the background
-		virtual void setDrawBackground(bool draw) _IRR_OVERRIDE_;
+		void setDrawBackground(bool draw) override;
 
 		//! Checks if background drawing is enabled
-		virtual bool isDrawBackgroundEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBackgroundEnabled() const override;
 
 		//! Turns the border on or off
-		virtual void setDrawBorder(bool border) _IRR_OVERRIDE_;
+		void setDrawBorder(bool border) override;
 
 		//! Checks if border drawing is enabled
-		virtual bool isDrawBorderEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBorderEnabled() const override;
 
 		//! Enables or disables word wrap for using the edit box as multiline text editor.
-		virtual void setWordWrap(bool enable) _IRR_OVERRIDE_;
+		void setWordWrap(bool enable) override;
 
 		//! Checks if word wrap is enabled
 		//! \return true if word wrap is enabled, false otherwise
-		virtual bool isWordWrapEnabled() const _IRR_OVERRIDE_;
+		bool isWordWrapEnabled() const override;
 
 		//! Enables or disables newlines.
 		/** \param enable: If set to true, the EGET_EDITBOX_ENTER event will not be fired,
 		instead a newline character will be inserted. */
-		virtual void setMultiLine(bool enable) _IRR_OVERRIDE_;
+		void setMultiLine(bool enable) override;
 
 		//! Checks if multi line editing is enabled
 		//! \return true if mult-line is enabled, false otherwise
-		virtual bool isMultiLineEnabled() const _IRR_OVERRIDE_;
+		bool isMultiLineEnabled() const override;
 
 		//! Enables or disables automatic scrolling with cursor position
 		//! \param enable: If set to true, the text will move around with the cursor position
-		virtual void setAutoScroll(bool enable) _IRR_OVERRIDE_;
+		void setAutoScroll(bool enable) override;
 
 		//! Checks to see if automatic scrolling is enabled
 		//! \return true if automatic scrolling is enabled, false if not
-		virtual bool isAutoScrollEnabled() const _IRR_OVERRIDE_;
+		bool isAutoScrollEnabled() const override;
 
 		//! Gets the size area of the text in the edit box
 		//! \return Returns the size in pixels of the text
-		virtual core::dimension2du getTextDimension() _IRR_OVERRIDE_;
+		core::dimension2du getTextDimension() override;
 
 		//! Sets text justification
-		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) _IRR_OVERRIDE_;
+		void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! Sets the new caption of this element.
-		virtual void setText(const wchar_t* text) _IRR_OVERRIDE_;
+		void setText(const wchar_t* text) override;
 
 		//! Sets the maximum amount of characters which may be entered in the box.
 		//! \param max: Maximum amount of characters. If 0, the character amount is
 		//! infinity.
-		virtual void setMax(u32 max) _IRR_OVERRIDE_;
+		void setMax(u32 max) override;
 
 		//! Returns maximum amount of characters, previously set by setMax();
-		virtual u32 getMax() const _IRR_OVERRIDE_;
+		u32 getMax() const override;
 
 		//! Set the character used for the cursor.
 		/** By default it's "_" */
-		virtual void setCursorChar(const wchar_t cursorChar) _IRR_OVERRIDE_;
+		void setCursorChar(const wchar_t cursorChar) override;
 
 		//! Get the character used for the cursor.
-		virtual wchar_t getCursorChar() const _IRR_OVERRIDE_;
+		wchar_t getCursorChar() const override;
 
 		//! Set the blinktime for the cursor. 2x blinktime is one full cycle.
 		//** \param timeMs Blinktime in milliseconds. When set to 0 the cursor is constantly on without blinking */
-		virtual void setCursorBlinkTime(irr::u32 timeMs) _IRR_OVERRIDE_;
+		void setCursorBlinkTime(irr::u32 timeMs) override;
 
 		//! Get the cursor blinktime
-		virtual irr::u32 getCursorBlinkTime() const _IRR_OVERRIDE_;
+		irr::u32 getCursorBlinkTime() const override;
 
 		//! Sets whether the edit box is a password box. Setting this to true will
 		/** disable MultiLine, WordWrap and the ability to copy with ctrl+c or ctrl+x
 		\param passwordBox: true to enable password, false to disable
 		\param passwordChar: the character that is displayed instead of letters */
-		virtual void setPasswordBox(bool passwordBox, wchar_t passwordChar = L'*') _IRR_OVERRIDE_;
+		void setPasswordBox(bool passwordBox, wchar_t passwordChar = L'*') override;
 
 		//! Returns true if the edit box is currently a password box.
-		virtual bool isPasswordBox() const _IRR_OVERRIDE_;
+		bool isPasswordBox() const override;
 
 		//! Updates the absolute position, splits text if required
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 		//! Returns whether the element takes input from the IME
-		virtual bool acceptsIME() _IRR_OVERRIDE_;
+		bool acceptsIME() override;
 
 	protected:
 		//! Breaks the single text line.

--- a/source/Irrlicht/CGUIEnvironment.h
+++ b/source/Irrlicht/CGUIEnvironment.h
@@ -31,143 +31,143 @@ public:
 	virtual ~CGUIEnvironment();
 
 	//! draws all gui elements
-	virtual void drawAll(bool useScreenSize) _IRR_OVERRIDE_;
+	void drawAll(bool useScreenSize) override;
 
 	//! returns the current video driver
-	virtual video::IVideoDriver* getVideoDriver() const _IRR_OVERRIDE_;
+	video::IVideoDriver* getVideoDriver() const override;
 
 	//! returns pointer to the filesystem
-	virtual io::IFileSystem* getFileSystem() const _IRR_OVERRIDE_;
+	io::IFileSystem* getFileSystem() const override;
 
 	//! returns a pointer to the OS operator
-	virtual IOSOperator* getOSOperator() const _IRR_OVERRIDE_;
+	IOSOperator* getOSOperator() const override;
 
 	//! posts an input event to the environment
-	virtual bool postEventFromUser(const SEvent& event) _IRR_OVERRIDE_;
+	bool postEventFromUser(const SEvent& event) override;
 
 	//! This sets a new event receiver for gui events. Usually you do not have to
 	//! use this method, it is used by the internal engine.
-	virtual void setUserEventReceiver(IEventReceiver* evr) _IRR_OVERRIDE_;
+	void setUserEventReceiver(IEventReceiver* evr) override;
 
 	//! removes all elements from the environment
-	virtual void clear() _IRR_OVERRIDE_;
+	void clear() override;
 
 	//! called if an event happened.
-	virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+	bool OnEvent(const SEvent& event) override;
 
 	//! returns the current gui skin
-	virtual IGUISkin* getSkin() const _IRR_OVERRIDE_;
+	IGUISkin* getSkin() const override;
 
 	//! Sets a new GUI Skin
-	virtual void setSkin(IGUISkin* skin) _IRR_OVERRIDE_;
+	void setSkin(IGUISkin* skin) override;
 
 	//! Creates a new GUI Skin based on a template.
 	/** \return Returns a pointer to the created skin.
 	If you no longer need the skin, you should call IGUISkin::drop().
 	See IReferenceCounted::drop() for more information. */
-	virtual IGUISkin* createSkin(EGUI_SKIN_TYPE type) _IRR_OVERRIDE_;
+	IGUISkin* createSkin(EGUI_SKIN_TYPE type) override;
 
 	//! Creates the image list from the given texture.
 	virtual IGUIImageList* createImageList(video::ITexture* texture,
-					core::dimension2d<s32> imageSize, bool useAlphaChannel) _IRR_OVERRIDE_;
+					core::dimension2d<s32> imageSize, bool useAlphaChannel) override;
 
 	//! returns the font
-	virtual IGUIFont* getFont(const io::path& filename) _IRR_OVERRIDE_;
+	IGUIFont* getFont(const io::path& filename) override;
 
 	//! add an externally loaded font
-	virtual IGUIFont* addFont(const io::path& name, IGUIFont* font) _IRR_OVERRIDE_;
+	IGUIFont* addFont(const io::path& name, IGUIFont* font) override;
 
 	//! remove loaded font
-	virtual void removeFont(IGUIFont* font) _IRR_OVERRIDE_;
+	void removeFont(IGUIFont* font) override;
 
 	//! returns default font
-	virtual IGUIFont* getBuiltInFont() const _IRR_OVERRIDE_;
+	IGUIFont* getBuiltInFont() const override;
 
 	//! returns the sprite bank
-	virtual IGUISpriteBank* getSpriteBank(const io::path& filename) _IRR_OVERRIDE_;
+	IGUISpriteBank* getSpriteBank(const io::path& filename) override;
 
 	//! returns the sprite bank
-	virtual IGUISpriteBank* addEmptySpriteBank(const io::path& name) _IRR_OVERRIDE_;
+	IGUISpriteBank* addEmptySpriteBank(const io::path& name) override;
 
 	//! adds an button. The returned pointer must not be dropped.
-	virtual IGUIButton* addButton(const core::rect<s32>& rectangle, IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0,const wchar_t* tooltiptext = 0) _IRR_OVERRIDE_;
+	IGUIButton* addButton(const core::rect<s32>& rectangle, IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0,const wchar_t* tooltiptext = 0) override;
 
 	//! adds a scrollbar. The returned pointer must not be dropped.
 	virtual IGUIScrollBar* addScrollBar(bool horizontal, const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1) override;
 
 	//! Adds an image element.
 	virtual IGUIImage* addImage(video::ITexture* image, core::position2d<s32> pos,
-		bool useAlphaChannel=true, IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0) _IRR_OVERRIDE_;
+		bool useAlphaChannel=true, IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0) override;
 
 	//! adds an image. The returned pointer must not be dropped.
 	virtual IGUIImage* addImage(const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0, bool useAlphaChannel=true) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0, bool useAlphaChannel=true) override;
 
 	//! adds a checkbox
 	virtual IGUICheckBox* addCheckBox(bool checked, const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1, const wchar_t* text=0) override;
 
 	//! adds a list box
 	virtual IGUIListBox* addListBox(const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1, bool drawBackground=false) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1, bool drawBackground=false) override;
 
 	//! Adds a file open dialog.
 	virtual IGUIFileOpenDialog* addFileOpenDialog(const wchar_t* title = 0,
 			bool modal=true, IGUIElement* parent=0, s32 id=-1,
-			bool restoreCWD=false, io::path::char_type* startDir=0) _IRR_OVERRIDE_;
+			bool restoreCWD=false, io::path::char_type* startDir=0) override;
 
 	//! adds a static text. The returned pointer must not be dropped.
 	virtual IGUIStaticText* addStaticText(const wchar_t* text, const core::rect<s32>& rectangle,
-		bool border=false, bool wordWrap=true, IGUIElement* parent=0, s32 id=-1, bool drawBackground = false) _IRR_OVERRIDE_;
+		bool border=false, bool wordWrap=true, IGUIElement* parent=0, s32 id=-1, bool drawBackground = false) override;
 
 	//! Adds an edit box. The returned pointer must not be dropped.
 	virtual IGUIEditBox* addEditBox(const wchar_t* text, const core::rect<s32>& rectangle,
-		bool border=false, IGUIElement* parent=0, s32 id=-1) _IRR_OVERRIDE_;
+		bool border=false, IGUIElement* parent=0, s32 id=-1) override;
 
 	//! Adds a tab control to the environment.
 	virtual IGUITabControl* addTabControl(const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, bool fillbackground=false, bool border=true, s32 id=-1) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, bool fillbackground=false, bool border=true, s32 id=-1) override;
 
 	//! Adds tab to the environment.
 	virtual IGUITab* addTab(const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1) override;
 
 	//! Adds a combo box to the environment.
 	virtual IGUIComboBox* addComboBox(const core::rect<s32>& rectangle,
-		IGUIElement* parent=0, s32 id=-1) _IRR_OVERRIDE_;
+		IGUIElement* parent=0, s32 id=-1) override;
 
 	//! sets the focus to an element
-	virtual bool setFocus(IGUIElement* element) _IRR_OVERRIDE_;
+	bool setFocus(IGUIElement* element) override;
 
 	//! removes the focus from an element
-	virtual bool removeFocus(IGUIElement* element) _IRR_OVERRIDE_;
+	bool removeFocus(IGUIElement* element) override;
 
 	//! Returns if the element has focus
-	virtual bool hasFocus(const IGUIElement* element, bool checkSubElements=false) const _IRR_OVERRIDE_;
+	bool hasFocus(const IGUIElement* element, bool checkSubElements=false) const override;
 
 	//! Returns the element with the focus
-	virtual IGUIElement* getFocus() const _IRR_OVERRIDE_;
+	IGUIElement* getFocus() const override;
 
 	//! Returns the element last known to be under the mouse
-	virtual IGUIElement* getHovered() const _IRR_OVERRIDE_;
+	IGUIElement* getHovered() const override;
 
 	//! Returns the root gui element.
-	virtual IGUIElement* getRootGUIElement() _IRR_OVERRIDE_;
+	IGUIElement* getRootGUIElement() override;
 
-	virtual void OnPostRender( u32 time ) _IRR_OVERRIDE_;
+	void OnPostRender( u32 time ) override;
 
 	//! Find the next element which would be selected when pressing the tab-key
-	virtual IGUIElement* getNextElement(bool reverse=false, bool group=false) _IRR_OVERRIDE_;
+	IGUIElement* getNextElement(bool reverse=false, bool group=false) override;
 
 	//! Set the way the gui will handle focus changes
-	virtual void setFocusBehavior(u32 flags) _IRR_OVERRIDE_;
+	void setFocusBehavior(u32 flags) override;
 
 	//! Get the way the gui does handle focus changes
-	virtual u32 getFocusBehavior() const _IRR_OVERRIDE_;
+	u32 getFocusBehavior() const override;
 
 	//! Adds a IGUIElement to deletion queue.
-	virtual void addToDeletionQueue(IGUIElement* element) _IRR_OVERRIDE_;
+	void addToDeletionQueue(IGUIElement* element) override;
 
 private:
 

--- a/source/Irrlicht/CGUIFileOpenDialog.h
+++ b/source/Irrlicht/CGUIFileOpenDialog.h
@@ -32,22 +32,22 @@ namespace gui
 		virtual ~CGUIFileOpenDialog();
 
 		//! returns the filename of the selected file. Returns NULL, if no file was selected.
-		virtual const wchar_t* getFileName() const _IRR_OVERRIDE_;
+		const wchar_t* getFileName() const override;
 
 		//! Returns the filename of the selected file. Is empty if no file was selected.
-		virtual const io::path& getFileNameP() const _IRR_OVERRIDE_;
+		const io::path& getFileNameP() const override;
 
 		//! Returns the directory of the selected file. Returns NULL, if no directory was selected.
-		virtual const io::path& getDirectoryName() const _IRR_OVERRIDE_;
+		const io::path& getDirectoryName() const override;
 
 		//! Returns the directory of the selected file converted to wide characters. Returns NULL if no directory was selected.
-		virtual const wchar_t* getDirectoryNameW() const _IRR_OVERRIDE_;
+		const wchar_t* getDirectoryNameW() const override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 	protected:
 

--- a/source/Irrlicht/CGUIFont.h
+++ b/source/Irrlicht/CGUIFont.h
@@ -47,32 +47,32 @@ public:
 	//! draws an text and clips it to the specified rectangle if wanted
 	virtual void draw(const core::stringw& text, const core::rect<s32>& position,
 			video::SColor color, bool hcenter=false,
-			bool vcenter=false, const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+			bool vcenter=false, const core::rect<s32>* clip=0) override;
 
 	//! returns the dimension of a text
-	virtual core::dimension2d<u32> getDimension(const wchar_t* text) const _IRR_OVERRIDE_;
+	core::dimension2d<u32> getDimension(const wchar_t* text) const override;
 
 	//! Calculates the index of the character in the text which is on a specific position.
-	virtual s32 getCharacterFromPos(const wchar_t* text, s32 pixel_x) const _IRR_OVERRIDE_;
+	s32 getCharacterFromPos(const wchar_t* text, s32 pixel_x) const override;
 
 	//! Returns the type of this font
-	virtual EGUI_FONT_TYPE getType() const _IRR_OVERRIDE_ { return EGFT_BITMAP; }
+	EGUI_FONT_TYPE getType() const override { return EGFT_BITMAP; }
 
 	//! set an Pixel Offset on Drawing ( scale position on width )
-	virtual void setKerningWidth (s32 kerning) _IRR_OVERRIDE_;
-	virtual void setKerningHeight (s32 kerning) _IRR_OVERRIDE_;
+	void setKerningWidth (s32 kerning) override;
+	void setKerningHeight (s32 kerning) override;
 
 	//! set an Pixel Offset on Drawing ( scale position on width )
-	virtual s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const _IRR_OVERRIDE_;
-	virtual s32 getKerningHeight() const _IRR_OVERRIDE_;
+	s32 getKerningWidth(const wchar_t* thisLetter=0, const wchar_t* previousLetter=0) const override;
+	s32 getKerningHeight() const override;
 
 	//! gets the sprite bank
-	virtual IGUISpriteBank* getSpriteBank() const _IRR_OVERRIDE_;
+	IGUISpriteBank* getSpriteBank() const override;
 
 	//! returns the sprite number from a given character
-	virtual u32 getSpriteNoFromChar(const wchar_t *c) const _IRR_OVERRIDE_;
+	u32 getSpriteNoFromChar(const wchar_t *c) const override;
 
-	virtual void setInvisibleCharacters( const wchar_t *s ) _IRR_OVERRIDE_;
+	void setInvisibleCharacters( const wchar_t *s ) override;
 
 private:
 

--- a/source/Irrlicht/CGUIImage.h
+++ b/source/Irrlicht/CGUIImage.h
@@ -26,52 +26,52 @@ namespace gui
 		virtual ~CGUIImage();
 
 		//! sets an image
-		virtual void setImage(video::ITexture* image) _IRR_OVERRIDE_;
+		void setImage(video::ITexture* image) override;
 
 		//! Gets the image texture
-		virtual video::ITexture* getImage() const _IRR_OVERRIDE_;
+		video::ITexture* getImage() const override;
 
 		//! sets the color of the image
-		virtual void setColor(video::SColor color) _IRR_OVERRIDE_;
+		void setColor(video::SColor color) override;
 
 		//! sets if the image should scale to fit the element
-		virtual void setScaleImage(bool scale) _IRR_OVERRIDE_;
+		void setScaleImage(bool scale) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! sets if the image should use its alpha channel to draw itself
-		virtual void setUseAlphaChannel(bool use) _IRR_OVERRIDE_;
+		void setUseAlphaChannel(bool use) override;
 
 		//! Gets the color of the image
-		virtual video::SColor getColor() const _IRR_OVERRIDE_;
+		video::SColor getColor() const override;
 
 		//! Returns true if the image is scaled to fit, false if not
-		virtual bool isImageScaled() const _IRR_OVERRIDE_;
+		bool isImageScaled() const override;
 
 		//! Returns true if the image is using the alpha channel, false if not
-		virtual bool isAlphaChannelUsed() const _IRR_OVERRIDE_;
+		bool isAlphaChannelUsed() const override;
 
 		//! Sets the source rectangle of the image. By default the full image is used.
-		virtual void setSourceRect(const core::rect<s32>& sourceRect) _IRR_OVERRIDE_;
+		void setSourceRect(const core::rect<s32>& sourceRect) override;
 
 		//! Returns the customized source rectangle of the image to be used.
-		virtual core::rect<s32> getSourceRect() const _IRR_OVERRIDE_;
+		core::rect<s32> getSourceRect() const override;
 
 		//! Restrict drawing-area.
-		virtual void setDrawBounds(const core::rect<f32>& drawBoundUVs) _IRR_OVERRIDE_;
+		void setDrawBounds(const core::rect<f32>& drawBoundUVs) override;
 
 		//! Get drawing-area restrictions.
-		virtual core::rect<f32> getDrawBounds() const _IRR_OVERRIDE_;
+		core::rect<f32> getDrawBounds() const override;
 
 		//! Sets whether to draw a background color (EGDC_3D_DARK_SHADOW) when no texture is set
-		virtual void setDrawBackground(bool draw) _IRR_OVERRIDE_
+		void setDrawBackground(bool draw) override
 		{
 			DrawBackground = draw;
 		}
 
 		//! Checks if a background is drawn when no texture is set
-		virtual bool isDrawBackgroundEnabled() const  _IRR_OVERRIDE_
+		bool isDrawBackgroundEnabled() const  override
 		{
 			return DrawBackground;
 		}

--- a/source/Irrlicht/CGUIImageList.h
+++ b/source/Irrlicht/CGUIImageList.h
@@ -38,16 +38,16 @@ public:
 	//! \param clip: Optional pointer to a rectangle against which the text will be clipped.
 	//! If the pointer is null, no clipping will be done.
 	virtual void draw( s32 index, const core::position2d<s32>& destPos,
-		const core::rect<s32>* clip = 0 ) _IRR_OVERRIDE_;
+		const core::rect<s32>* clip = 0 ) override;
 
 	//! Returns the count of Images in the list.
 	//! \return Returns the count of Images in the list.
-	virtual s32 getImageCount() const _IRR_OVERRIDE_
+	s32 getImageCount() const override
 	{ return ImageCount; }
 
 	//! Returns the size of the images in the list.
 	//! \return Returns the size of the images in the list.
-	virtual core::dimension2d<s32> getImageSize() const _IRR_OVERRIDE_
+	core::dimension2d<s32> getImageSize() const override
 	{ return ImageSize; }
 
 private:

--- a/source/Irrlicht/CGUIListBox.h
+++ b/source/Irrlicht/CGUIListBox.h
@@ -31,102 +31,102 @@ namespace gui
 		virtual ~CGUIListBox();
 
 		//! returns amount of list items
-		virtual u32 getItemCount() const _IRR_OVERRIDE_;
+		u32 getItemCount() const override;
 
 		//! returns string of a list item. the id may be a value from 0 to itemCount-1
-		virtual const wchar_t* getListItem(u32 id) const _IRR_OVERRIDE_;
+		const wchar_t* getListItem(u32 id) const override;
 
 		//! adds an list item, returns id of item
-		virtual u32 addItem(const wchar_t* text) _IRR_OVERRIDE_;
+		u32 addItem(const wchar_t* text) override;
 
 		//! clears the list
-		virtual void clear() _IRR_OVERRIDE_;
+		void clear() override;
 
 		//! returns id of selected item. returns -1 if no item is selected.
-		virtual s32 getSelected() const _IRR_OVERRIDE_;
+		s32 getSelected() const override;
 
 		//! sets the selected item. Set this to -1 if no item should be selected
-		virtual void setSelected(s32 id) _IRR_OVERRIDE_;
+		void setSelected(s32 id) override;
 
 		//! sets the selected item. Set this to -1 if no item should be selected
-		virtual void setSelected(const wchar_t *item) _IRR_OVERRIDE_;
+		void setSelected(const wchar_t *item) override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! adds an list item with an icon
 		//! \param text Text of list entry
 		//! \param icon Sprite index of the Icon within the current sprite bank. Set it to -1 if you want no icon
 		//! \return
 		//! returns the id of the new created item
-		virtual u32 addItem(const wchar_t* text, s32 icon) _IRR_OVERRIDE_;
+		u32 addItem(const wchar_t* text, s32 icon) override;
 
 		//! Returns the icon of an item
-		virtual s32 getIcon(u32 id) const _IRR_OVERRIDE_;
+		s32 getIcon(u32 id) const override;
 
 		//! removes an item from the list
-		virtual void removeItem(u32 id) _IRR_OVERRIDE_;
+		void removeItem(u32 id) override;
 
 		//! get the the id of the item at the given absolute coordinates
-		virtual s32 getItemAt(s32 xpos, s32 ypos) const _IRR_OVERRIDE_;
+		s32 getItemAt(s32 xpos, s32 ypos) const override;
 
 		//! Sets the sprite bank which should be used to draw list icons. This font is set to the sprite bank of
 		//! the built-in-font by default. A sprite can be displayed in front of every list item.
 		//! An icon is an index within the icon sprite bank. Several default icons are available in the
 		//! skin through getIcon
-		virtual void setSpriteBank(IGUISpriteBank* bank) _IRR_OVERRIDE_;
+		void setSpriteBank(IGUISpriteBank* bank) override;
 
 		//! set whether the listbox should scroll to newly selected items
-		virtual void setAutoScrollEnabled(bool scroll) _IRR_OVERRIDE_;
+		void setAutoScrollEnabled(bool scroll) override;
 
 		//! returns true if automatic scrolling is enabled, false if not.
-		virtual bool isAutoScrollEnabled() const _IRR_OVERRIDE_;
+		bool isAutoScrollEnabled() const override;
 
 		//! Update the position and size of the listbox, and update the scrollbar
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 		//! set all item colors at given index to color
-		virtual void setItemOverrideColor(u32 index, video::SColor color) _IRR_OVERRIDE_;
+		void setItemOverrideColor(u32 index, video::SColor color) override;
 
 		//! set all item colors of specified type at given index to color
-		virtual void setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, video::SColor color) _IRR_OVERRIDE_;
+		void setItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType, video::SColor color) override;
 
 		//! clear all item colors at index
-		virtual void clearItemOverrideColor(u32 index) _IRR_OVERRIDE_;
+		void clearItemOverrideColor(u32 index) override;
 
 		//! clear item color at index for given colortype
-		virtual void clearItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) _IRR_OVERRIDE_;
+		void clearItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) override;
 
 		//! has the item at index its color overwritten?
-		virtual bool hasItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const _IRR_OVERRIDE_;
+		bool hasItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const override;
 
 		//! return the overwrite color at given item index.
-		virtual video::SColor getItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const _IRR_OVERRIDE_;
+		video::SColor getItemOverrideColor(u32 index, EGUI_LISTBOX_COLOR colorType) const override;
 
 		//! return the default color which is used for the given colorType
-		virtual video::SColor getItemDefaultColor(EGUI_LISTBOX_COLOR colorType) const _IRR_OVERRIDE_;
+		video::SColor getItemDefaultColor(EGUI_LISTBOX_COLOR colorType) const override;
 
 		//! set the item at the given index
-		virtual void setItem(u32 index, const wchar_t* text, s32 icon) _IRR_OVERRIDE_;
+		void setItem(u32 index, const wchar_t* text, s32 icon) override;
 
 		//! Insert the item at the given index
 		//! Return the index on success or -1 on failure.
-		virtual s32 insertItem(u32 index, const wchar_t* text, s32 icon) _IRR_OVERRIDE_;
+		s32 insertItem(u32 index, const wchar_t* text, s32 icon) override;
 
 		//! Swap the items at the given indices
-		virtual void swapItems(u32 index1, u32 index2) _IRR_OVERRIDE_;
+		void swapItems(u32 index1, u32 index2) override;
 
 		//! set global itemHeight
-		virtual void setItemHeight( s32 height ) _IRR_OVERRIDE_;
+		void setItemHeight( s32 height ) override;
 
 		//! Sets whether to draw the background
-		virtual void setDrawBackground(bool draw) _IRR_OVERRIDE_;
+		void setDrawBackground(bool draw) override;
 
 		//! Access the vertical scrollbar
-		virtual IGUIScrollBar* getVerticalScrollBar() const _IRR_OVERRIDE_;
+		IGUIScrollBar* getVerticalScrollBar() const override;
 
 	private:
 

--- a/source/Irrlicht/CGUIScrollBar.h
+++ b/source/Irrlicht/CGUIScrollBar.h
@@ -29,46 +29,46 @@ namespace gui
 		virtual ~CGUIScrollBar();
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
-		virtual void OnPostRender(u32 timeMs) _IRR_OVERRIDE_;
+		void OnPostRender(u32 timeMs) override;
 
 
 		//! gets the maximum value of the scrollbar.
-		virtual s32 getMax() const _IRR_OVERRIDE_;
+		s32 getMax() const override;
 
 		//! sets the maximum value of the scrollbar.
-		virtual void setMax(s32 max) _IRR_OVERRIDE_;
+		void setMax(s32 max) override;
 
 		//! gets the minimum value of the scrollbar.
-		virtual s32 getMin() const _IRR_OVERRIDE_;
+		s32 getMin() const override;
 
 		//! sets the minimum value of the scrollbar.
-		virtual void setMin(s32 min) _IRR_OVERRIDE_;
+		void setMin(s32 min) override;
 
 		//! gets the small step value
-		virtual s32 getSmallStep() const _IRR_OVERRIDE_;
+		s32 getSmallStep() const override;
 
 		//! sets the small step value
-		virtual void setSmallStep(s32 step) _IRR_OVERRIDE_;
+		void setSmallStep(s32 step) override;
 
 		//! gets the large step value
-		virtual s32 getLargeStep() const _IRR_OVERRIDE_;
+		s32 getLargeStep() const override;
 
 		//! sets the large step value
-		virtual void setLargeStep(s32 step) _IRR_OVERRIDE_;
+		void setLargeStep(s32 step) override;
 
 		//! gets the current position of the scrollbar
-		virtual s32 getPos() const _IRR_OVERRIDE_;
+		s32 getPos() const override;
 
 		//! sets the position of the scrollbar
-		virtual void setPos(s32 pos) _IRR_OVERRIDE_;
+		void setPos(s32 pos) override;
 
 		//! updates the rectangle
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 	private:
 

--- a/source/Irrlicht/CGUISkin.h
+++ b/source/Irrlicht/CGUISkin.h
@@ -30,49 +30,49 @@ namespace gui
 		virtual ~CGUISkin();
 
 		//! returns default color
-		virtual video::SColor getColor(EGUI_DEFAULT_COLOR color) const _IRR_OVERRIDE_;
+		video::SColor getColor(EGUI_DEFAULT_COLOR color) const override;
 
 		//! sets a default color
-		virtual void setColor(EGUI_DEFAULT_COLOR which, video::SColor newColor) _IRR_OVERRIDE_;
+		void setColor(EGUI_DEFAULT_COLOR which, video::SColor newColor) override;
 
 		//! returns size for the given size type
-		virtual s32 getSize(EGUI_DEFAULT_SIZE size) const _IRR_OVERRIDE_;
+		s32 getSize(EGUI_DEFAULT_SIZE size) const override;
 
 		//! sets a default size
-		virtual void setSize(EGUI_DEFAULT_SIZE which, s32 size) _IRR_OVERRIDE_;
+		void setSize(EGUI_DEFAULT_SIZE which, s32 size) override;
 
 		//! returns the default font
-		virtual IGUIFont* getFont(EGUI_DEFAULT_FONT which=EGDF_DEFAULT) const _IRR_OVERRIDE_;
+		IGUIFont* getFont(EGUI_DEFAULT_FONT which=EGDF_DEFAULT) const override;
 
 		//! sets a default font
-		virtual void setFont(IGUIFont* font, EGUI_DEFAULT_FONT which=EGDF_DEFAULT) _IRR_OVERRIDE_;
+		void setFont(IGUIFont* font, EGUI_DEFAULT_FONT which=EGDF_DEFAULT) override;
 
 		//! sets the sprite bank used for drawing icons
-		virtual void setSpriteBank(IGUISpriteBank* bank) _IRR_OVERRIDE_;
+		void setSpriteBank(IGUISpriteBank* bank) override;
 
 		//! gets the sprite bank used for drawing icons
-		virtual IGUISpriteBank* getSpriteBank() const _IRR_OVERRIDE_;
+		IGUISpriteBank* getSpriteBank() const override;
 
 		//! Returns a default icon
 		/** Returns the sprite index within the sprite bank */
-		virtual u32 getIcon(EGUI_DEFAULT_ICON icon) const _IRR_OVERRIDE_;
+		u32 getIcon(EGUI_DEFAULT_ICON icon) const override;
 
 		//! Sets a default icon
 		/** Sets the sprite index used for drawing icons like arrows,
 		close buttons and ticks in checkboxes
 		\param icon: Enum specifying which icon to change
 		\param index: The sprite index used to draw this icon */
-		virtual void setIcon(EGUI_DEFAULT_ICON icon, u32 index) _IRR_OVERRIDE_;
+		void setIcon(EGUI_DEFAULT_ICON icon, u32 index) override;
 
 		//! Returns a default text.
 		/** For example for Message box button captions:
 		"OK", "Cancel", "Yes", "No" and so on. */
-		virtual const wchar_t* getDefaultText(EGUI_DEFAULT_TEXT text) const _IRR_OVERRIDE_;
+		const wchar_t* getDefaultText(EGUI_DEFAULT_TEXT text) const override;
 
 		//! Sets a default text.
 		/** For example for Message box button captions:
 		"OK", "Cancel", "Yes", "No" and so on. */
-		virtual void setDefaultText(EGUI_DEFAULT_TEXT which, const wchar_t* newText) _IRR_OVERRIDE_;
+		void setDefaultText(EGUI_DEFAULT_TEXT which, const wchar_t* newText) override;
 
 		//! draws a standard 3d button pane
 		/** Used for drawing for example buttons in normal state.
@@ -85,7 +85,7 @@ namespace gui
 		implementations to find out how to draw the part exactly. */
 		virtual void draw3DButtonPaneStandard(IGUIElement* element,
 				const core::rect<s32>& rect,
-				const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip=0) override;
 
 		//! draws a pressed 3d button pane
 		/** Used for drawing for example buttons in pressed state.
@@ -98,7 +98,7 @@ namespace gui
 		implementations to find out how to draw the part exactly. */
 		virtual void draw3DButtonPanePressed(IGUIElement* element,
 				const core::rect<s32>& rect,
-				const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip=0) override;
 
 		//! draws a sunken 3d pane
 		/** Used for drawing the background of edit, combo or check boxes.
@@ -114,7 +114,7 @@ namespace gui
 				video::SColor bgcolor, bool flat,
 				bool fillBackGround,
 				const core::rect<s32>& rect,
-				const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip=0) override;
 
 		//! draws a window background
 		/** Used for drawing the background of dialogs and windows.
@@ -134,7 +134,7 @@ namespace gui
 				bool drawTitleBar, video::SColor titleBarColor,
 				const core::rect<s32>& rect,
 				const core::rect<s32>* clip,
-				core::rect<s32>* checkClientArea) _IRR_OVERRIDE_;
+				core::rect<s32>* checkClientArea) override;
 
 		//! draws a standard 3d menu pane
 		/** Used for drawing for menus and context menus.
@@ -147,7 +147,7 @@ namespace gui
 		\param clip: Clip area.	*/
 		virtual void draw3DMenuPane(IGUIElement* element,
 				const core::rect<s32>& rect,
-				const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip=0) override;
 
 		//! draws a standard 3d tool bar
 		/** Used for drawing for toolbars and menus.
@@ -158,7 +158,7 @@ namespace gui
 		\param clip: Clip area.	*/
 		virtual void draw3DToolBar(IGUIElement* element,
 				const core::rect<s32>& rect,
-				const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip=0) override;
 
 		//! draws a tab button
 		/** Used for drawing for tab buttons on top of tabs.
@@ -170,7 +170,7 @@ namespace gui
 		\param clip: Clip area.	*/
 		virtual void draw3DTabButton(IGUIElement* element, bool active,
 			const core::rect<s32>& rect, const core::rect<s32>* clip=0,
-			EGUI_ALIGNMENT alignment=EGUIA_UPPERLEFT) _IRR_OVERRIDE_;
+			EGUI_ALIGNMENT alignment=EGUIA_UPPERLEFT) override;
 
 		//! draws a tab control body
 		/** \param element: Pointer to the element which wishes to draw this. This parameter
@@ -182,7 +182,7 @@ namespace gui
 		\param clip: Clip area.	*/
 		virtual void draw3DTabBody(IGUIElement* element, bool border, bool background,
 			const core::rect<s32>& rect, const core::rect<s32>* clip=0, s32 tabHeight=-1,
-			EGUI_ALIGNMENT alignment=EGUIA_UPPERLEFT) _IRR_OVERRIDE_;
+			EGUI_ALIGNMENT alignment=EGUIA_UPPERLEFT) override;
 
 		//! draws an icon, usually from the skin's sprite bank
 		/** \param element: Pointer to the element which wishes to draw this icon.
@@ -197,7 +197,7 @@ namespace gui
 		virtual void drawIcon(IGUIElement* element, EGUI_DEFAULT_ICON icon,
 				const core::position2di position,
 				u32 starttime=0, u32 currenttime=0,
-				bool loop=false, const core::rect<s32>* clip=0) _IRR_OVERRIDE_;
+				bool loop=false, const core::rect<s32>* clip=0) override;
 
 
 		//! draws a 2d rectangle.
@@ -210,11 +210,11 @@ namespace gui
 		\param clip: Pointer to rectangle against which the rectangle will be clipped.
 		If the pointer is null, no clipping will be performed. */
 		virtual void draw2DRectangle(IGUIElement* element, const video::SColor &color,
-				const core::rect<s32>& pos, const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+				const core::rect<s32>& pos, const core::rect<s32>* clip = 0) override;
 
 
 		//! get the type of this skin
-		virtual EGUI_SKIN_TYPE getType() const _IRR_OVERRIDE_;
+		EGUI_SKIN_TYPE getType() const override;
 
 	private:
 

--- a/source/Irrlicht/CGUISpriteBank.h
+++ b/source/Irrlicht/CGUISpriteBank.h
@@ -32,38 +32,38 @@ public:
 	CGUISpriteBank(IGUIEnvironment* env);
 	virtual ~CGUISpriteBank();
 
-	virtual core::array< core::rect<s32> >& getPositions() _IRR_OVERRIDE_;
-	virtual core::array< SGUISprite >& getSprites() _IRR_OVERRIDE_;
+	core::array< core::rect<s32> >& getPositions() override;
+	core::array< SGUISprite >& getSprites() override;
 
-	virtual u32 getTextureCount() const _IRR_OVERRIDE_;
-	virtual video::ITexture* getTexture(u32 index) const _IRR_OVERRIDE_;
-	virtual void addTexture(video::ITexture* texture) _IRR_OVERRIDE_;
-	virtual void setTexture(u32 index, video::ITexture* texture) _IRR_OVERRIDE_;
+	u32 getTextureCount() const override;
+	video::ITexture* getTexture(u32 index) const override;
+	void addTexture(video::ITexture* texture) override;
+	void setTexture(u32 index, video::ITexture* texture) override;
 
 	//! Add the texture and use it for a single non-animated sprite.
-	virtual s32 addTextureAsSprite(video::ITexture* texture) _IRR_OVERRIDE_;
+	s32 addTextureAsSprite(video::ITexture* texture) override;
 
 	//! clears sprites, rectangles and textures
-	virtual void clear() _IRR_OVERRIDE_;
+	void clear() override;
 
 	//! Draws a sprite in 2d with position and color
 	virtual void draw2DSprite(u32 index, const core::position2di& pos, const core::rect<s32>* clip=0,
 				const video::SColor& color= video::SColor(255,255,255,255),
-				u32 starttime=0, u32 currenttime=0, bool loop=true, bool center=false) _IRR_OVERRIDE_;
+				u32 starttime=0, u32 currenttime=0, bool loop=true, bool center=false) override;
 
 	//! Draws a sprite in 2d with destination rectangle and colors
 	virtual void draw2DSprite(u32 index, const core::rect<s32>& destRect,
 			const core::rect<s32>* clip=0,
 			const video::SColor * const colors=0,
 			u32 timeTicks = 0,
-			bool loop=true) _IRR_OVERRIDE_;
+			bool loop=true) override;
 
 	//! Draws a sprite batch in 2d using an array of positions and a color
 	virtual void draw2DSpriteBatch(const core::array<u32>& indices, const core::array<core::position2di>& pos,
 			const core::rect<s32>* clip=0,
 			const video::SColor& color= video::SColor(255,255,255,255),
 			u32 starttime=0, u32 currenttime=0,
-			bool loop=true, bool center=false) _IRR_OVERRIDE_;
+			bool loop=true, bool center=false) override;
 
 protected:
 

--- a/source/Irrlicht/CGUIStaticText.h
+++ b/source/Irrlicht/CGUIStaticText.h
@@ -28,78 +28,78 @@ namespace gui
 		virtual ~CGUIStaticText();
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! Sets another skin independent font.
-		virtual void setOverrideFont(IGUIFont* font=0) _IRR_OVERRIDE_;
+		void setOverrideFont(IGUIFont* font=0) override;
 
 		//! Gets the override font (if any)
-		virtual IGUIFont* getOverrideFont() const _IRR_OVERRIDE_;
+		IGUIFont* getOverrideFont() const override;
 
 		//! Get the font which is used right now for drawing
-		virtual IGUIFont* getActiveFont() const _IRR_OVERRIDE_;
+		IGUIFont* getActiveFont() const override;
 
 		//! Sets another color for the text.
-		virtual void setOverrideColor(video::SColor color) _IRR_OVERRIDE_;
+		void setOverrideColor(video::SColor color) override;
 
 		//! Sets another color for the background.
-		virtual void setBackgroundColor(video::SColor color) _IRR_OVERRIDE_;
+		void setBackgroundColor(video::SColor color) override;
 
 		//! Sets whether to draw the background
-		virtual void setDrawBackground(bool draw) _IRR_OVERRIDE_;
+		void setDrawBackground(bool draw) override;
 
 		//! Gets the background color
-		virtual video::SColor getBackgroundColor() const _IRR_OVERRIDE_;
+		video::SColor getBackgroundColor() const override;
 
 		//! Checks if background drawing is enabled
-		virtual bool isDrawBackgroundEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBackgroundEnabled() const override;
 
 		//! Sets whether to draw the border
-		virtual void setDrawBorder(bool draw) _IRR_OVERRIDE_;
+		void setDrawBorder(bool draw) override;
 
 		//! Checks if border drawing is enabled
-		virtual bool isDrawBorderEnabled() const _IRR_OVERRIDE_;
+		bool isDrawBorderEnabled() const override;
 
 		//! Sets alignment mode for text
-		virtual void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) _IRR_OVERRIDE_;
+		void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) override;
 
 		//! Gets the override color
-		virtual video::SColor getOverrideColor() const _IRR_OVERRIDE_;
+		video::SColor getOverrideColor() const override;
 
 		//! Gets the currently used text color
-		virtual video::SColor getActiveColor() const _IRR_OVERRIDE_;
+		video::SColor getActiveColor() const override;
 
 		//! Sets if the static text should use the override color or the
 		//! color in the gui skin.
-		virtual void enableOverrideColor(bool enable) _IRR_OVERRIDE_;
+		void enableOverrideColor(bool enable) override;
 
 		//! Checks if an override color is enabled
-		virtual bool isOverrideColorEnabled() const _IRR_OVERRIDE_;
+		bool isOverrideColorEnabled() const override;
 
 		//! Set whether the text in this label should be clipped if it goes outside bounds
-		virtual void setTextRestrainedInside(bool restrainedInside) _IRR_OVERRIDE_;
+		void setTextRestrainedInside(bool restrainedInside) override;
 
 		//! Checks if the text in this label should be clipped if it goes outside bounds
-		virtual bool isTextRestrainedInside() const _IRR_OVERRIDE_;
+		bool isTextRestrainedInside() const override;
 
 		//! Enables or disables word wrap for using the static text as
 		//! multiline text control.
-		virtual void setWordWrap(bool enable) _IRR_OVERRIDE_;
+		void setWordWrap(bool enable) override;
 
 		//! Checks if word wrap is enabled
-		virtual bool isWordWrapEnabled() const _IRR_OVERRIDE_;
+		bool isWordWrapEnabled() const override;
 
 		//! Sets the new caption of this element.
-		virtual void setText(const wchar_t* text) _IRR_OVERRIDE_;
+		void setText(const wchar_t* text) override;
 
 		//! Returns the height of the text in pixels when it is drawn.
-		virtual s32 getTextHeight() const _IRR_OVERRIDE_;
+		s32 getTextHeight() const override;
 
 		//! Returns the width of the current text, in the current font
-		virtual s32 getTextWidth() const _IRR_OVERRIDE_;
+		s32 getTextWidth() const override;
 
 		//! Updates the absolute position, splits text if word wrap is enabled
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 		//! Set whether the string should be interpreted as right-to-left (RTL) text
 		/** \note This component does not implement the Unicode bidi standard, the
@@ -107,10 +107,10 @@ namespace gui
 		main difference when RTL is enabled is that the linebreaks for multiline
 		elements are performed starting from the end.
 		*/
-		virtual void setRightToLeft(bool rtl) _IRR_OVERRIDE_;
+		void setRightToLeft(bool rtl) override;
 
 		//! Checks if the text should be interpreted as right-to-left text
-		virtual bool isRightToLeft() const _IRR_OVERRIDE_;
+		bool isRightToLeft() const override;
 
 	private:
 

--- a/source/Irrlicht/CGUITabControl.h
+++ b/source/Irrlicht/CGUITabControl.h
@@ -30,24 +30,24 @@ namespace gui
 			s32 id);
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! sets if the tab should draw its background
-		virtual void setDrawBackground(bool draw=true) _IRR_OVERRIDE_;
+		void setDrawBackground(bool draw=true) override;
 
 		//! sets the color of the background, if it should be drawn.
-		virtual void setBackgroundColor(video::SColor c) _IRR_OVERRIDE_;
+		void setBackgroundColor(video::SColor c) override;
 
 		//! sets the color of the text
-		virtual void setTextColor(video::SColor c) _IRR_OVERRIDE_;
+		void setTextColor(video::SColor c) override;
 
 		//! returns true if the tab is drawing its background, false if not
-		virtual bool isDrawingBackground() const _IRR_OVERRIDE_;
+		bool isDrawingBackground() const override;
 
 		//! returns the color of the background
-		virtual video::SColor getBackgroundColor() const _IRR_OVERRIDE_;
+		video::SColor getBackgroundColor() const override;
 
-		virtual video::SColor getTextColor() const _IRR_OVERRIDE_;
+		video::SColor getTextColor() const override;
 
 	private:
 
@@ -72,82 +72,82 @@ namespace gui
 		virtual ~CGUITabControl();
 
 		//! Adds a tab
-		virtual IGUITab* addTab(const wchar_t* caption, s32 id=-1) _IRR_OVERRIDE_;
+		IGUITab* addTab(const wchar_t* caption, s32 id=-1) override;
 
 		//! Adds an existing tab
-		virtual s32 addTab(IGUITab* tab) _IRR_OVERRIDE_;
+		s32 addTab(IGUITab* tab) override;
 
 		//! Insert the tab at the given index
-		virtual IGUITab* insertTab(s32 idx, const wchar_t* caption, s32 id=-1) _IRR_OVERRIDE_;
+		IGUITab* insertTab(s32 idx, const wchar_t* caption, s32 id=-1) override;
 
 		//! Insert an existing tab
 		/** Note that it will also add the tab as a child of this TabControl.
 		\return Index of added tab (should be same as the one passed) or -1 for failure*/
-		virtual s32 insertTab(s32 idx, IGUITab* tab, bool serializationMode) _IRR_OVERRIDE_;
+		s32 insertTab(s32 idx, IGUITab* tab, bool serializationMode) override;
 
 		//! Removes a tab from the tabcontrol
-		virtual void removeTab(s32 idx) _IRR_OVERRIDE_;
+		void removeTab(s32 idx) override;
 
 		//! Clears the tabcontrol removing all tabs
-		virtual void clear() _IRR_OVERRIDE_;
+		void clear() override;
 
 		//! Returns amount of tabs in the tabcontrol
-		virtual s32 getTabCount() const _IRR_OVERRIDE_;
+		s32 getTabCount() const override;
 
 		//! Returns a tab based on zero based index
-		virtual IGUITab* getTab(s32 idx) const _IRR_OVERRIDE_;
+		IGUITab* getTab(s32 idx) const override;
 
 		//! Brings a tab to front.
-		virtual bool setActiveTab(s32 idx) _IRR_OVERRIDE_;
+		bool setActiveTab(s32 idx) override;
 
 		//! Brings a tab to front.
-		virtual bool setActiveTab(IGUITab *tab) _IRR_OVERRIDE_;
+		bool setActiveTab(IGUITab *tab) override;
 
 		//! For given given tab find it's zero-based index (or -1 for not found)
-		virtual s32 getTabIndex(const IGUIElement *tab) const _IRR_OVERRIDE_;
+		s32 getTabIndex(const IGUIElement *tab) const override;
 
 		//! Returns which tab is currently active
-		virtual s32 getActiveTab() const _IRR_OVERRIDE_;
+		s32 getActiveTab() const override;
 
 		//! get the the id of the tab at the given absolute coordinates
-		virtual s32 getTabAt(s32 xpos, s32 ypos) const _IRR_OVERRIDE_;
+		s32 getTabAt(s32 xpos, s32 ypos) const override;
 
 		//! called if an event happened.
-		virtual bool OnEvent(const SEvent& event) _IRR_OVERRIDE_;
+		bool OnEvent(const SEvent& event) override;
 
 		//! draws the element and its children
-		virtual void draw() _IRR_OVERRIDE_;
+		void draw() override;
 
 		//! Removes a child.
-		virtual void removeChild(IGUIElement* child) _IRR_OVERRIDE_;
+		void removeChild(IGUIElement* child) override;
 
 		//! Set the height of the tabs
-		virtual void setTabHeight( s32 height ) _IRR_OVERRIDE_;
+		void setTabHeight( s32 height ) override;
 
 		//! Get the height of the tabs
-		virtual s32 getTabHeight() const _IRR_OVERRIDE_;
+		s32 getTabHeight() const override;
 
 		//! set the maximal width of a tab. Per default width is 0 which means "no width restriction".
-		virtual void setTabMaxWidth(s32 width ) _IRR_OVERRIDE_;
+		void setTabMaxWidth(s32 width ) override;
 
 		//! get the maximal width of a tab
-		virtual s32 getTabMaxWidth() const _IRR_OVERRIDE_;
+		s32 getTabMaxWidth() const override;
 
 		//! Set the alignment of the tabs
 		//! note: EGUIA_CENTER is not an option
-		virtual void setTabVerticalAlignment( gui::EGUI_ALIGNMENT alignment ) _IRR_OVERRIDE_;
+		void setTabVerticalAlignment( gui::EGUI_ALIGNMENT alignment ) override;
 
 		//! Get the alignment of the tabs
-		virtual gui::EGUI_ALIGNMENT getTabVerticalAlignment() const _IRR_OVERRIDE_;
+		gui::EGUI_ALIGNMENT getTabVerticalAlignment() const override;
 
 		//! Set the extra width added to tabs on each side of the text
-		virtual void setTabExtraWidth( s32 extraWidth ) _IRR_OVERRIDE_;
+		void setTabExtraWidth( s32 extraWidth ) override;
 
 		//! Get the extra width added to tabs on each side of the text
-		virtual s32 getTabExtraWidth() const _IRR_OVERRIDE_;
+		s32 getTabExtraWidth() const override;
 
 		//! Update the position of the element, decides scroll button status
-		virtual void updateAbsolutePosition() _IRR_OVERRIDE_;
+		void updateAbsolutePosition() override;
 
 	private:
 

--- a/source/Irrlicht/CImage.h
+++ b/source/Irrlicht/CImage.h
@@ -37,33 +37,33 @@ public:
 	CImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size);
 
 	//! returns a pixel
-	virtual SColor getPixel(u32 x, u32 y) const _IRR_OVERRIDE_;
+	SColor getPixel(u32 x, u32 y) const override;
 
 	//! sets a pixel
-	virtual void setPixel(u32 x, u32 y, const SColor &color, bool blend = false ) _IRR_OVERRIDE_;
+	void setPixel(u32 x, u32 y, const SColor &color, bool blend = false ) override;
 
 	//! copies this surface into another, scaling it to fit.
-	virtual void copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch=0) _IRR_OVERRIDE_;
+	void copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch=0) override;
 
 	//! copies this surface into another, scaling it to fit.
-	virtual void copyToScaling(IImage* target) _IRR_OVERRIDE_;
+	void copyToScaling(IImage* target) override;
 
 	//! copies this surface into another
-	virtual void copyTo(IImage* target, const core::position2d<s32>& pos=core::position2d<s32>(0,0)) _IRR_OVERRIDE_;
+	void copyTo(IImage* target, const core::position2d<s32>& pos=core::position2d<s32>(0,0)) override;
 
 	//! copies this surface into another
-	virtual void copyTo(IImage* target, const core::position2d<s32>& pos, const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect=0) _IRR_OVERRIDE_;
+	void copyTo(IImage* target, const core::position2d<s32>& pos, const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect=0) override;
 
 	//! copies this surface into another, using the alpha mask, an cliprect and a color to add with
 	virtual void copyToWithAlpha(IImage* target, const core::position2d<s32>& pos,
 			const core::rect<s32>& sourceRect, const SColor &color,
-			const core::rect<s32>* clipRect = 0, bool combineAlpha=false) _IRR_OVERRIDE_;
+			const core::rect<s32>* clipRect = 0, bool combineAlpha=false) override;
 
 	//! copies this surface into another, scaling it to fit, applying a box filter
-	virtual void copyToScalingBoxFilter(IImage* target, s32 bias = 0, bool blend = false) _IRR_OVERRIDE_;
+	void copyToScalingBoxFilter(IImage* target, s32 bias = 0, bool blend = false) override;
 
 	//! fills the surface with given color
-	virtual void fill(const SColor &color) _IRR_OVERRIDE_;
+	void fill(const SColor &color) override;
 
 private:
 	inline SColor getPixelBox ( s32 x, s32 y, s32 fx, s32 fy, s32 bias ) const;

--- a/source/Irrlicht/CImageLoaderBMP.h
+++ b/source/Irrlicht/CImageLoaderBMP.h
@@ -75,13 +75,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".tga")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! returns true if the file maybe is able to be loaded by this class
-	virtual bool isALoadableFileFormat(io::IReadFile* file) const _IRR_OVERRIDE_;
+	bool isALoadableFileFormat(io::IReadFile* file) const override;
 
 	//! creates a surface from the file
-	virtual IImage* loadImage(io::IReadFile* file) const _IRR_OVERRIDE_;
+	IImage* loadImage(io::IReadFile* file) const override;
 
 private:
 

--- a/source/Irrlicht/CImageLoaderJPG.h
+++ b/source/Irrlicht/CImageLoaderJPG.h
@@ -39,13 +39,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".tga")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! returns true if the file maybe is able to be loaded by this class
-	virtual bool isALoadableFileFormat(io::IReadFile* file) const _IRR_OVERRIDE_;
+	bool isALoadableFileFormat(io::IReadFile* file) const override;
 
 	//! creates a surface from the file
-	virtual IImage* loadImage(io::IReadFile* file) const _IRR_OVERRIDE_;
+	IImage* loadImage(io::IReadFile* file) const override;
 
 private:
 

--- a/source/Irrlicht/CImageLoaderPNG.h
+++ b/source/Irrlicht/CImageLoaderPNG.h
@@ -27,13 +27,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".png")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! returns true if the file maybe is able to be loaded by this class
-	virtual bool isALoadableFileFormat(io::IReadFile* file) const _IRR_OVERRIDE_;
+	bool isALoadableFileFormat(io::IReadFile* file) const override;
 
 	//! creates a surface from the file
-	virtual IImage* loadImage(io::IReadFile* file) const _IRR_OVERRIDE_;
+	IImage* loadImage(io::IReadFile* file) const override;
 };
 
 

--- a/source/Irrlicht/CImageLoaderTGA.h
+++ b/source/Irrlicht/CImageLoaderTGA.h
@@ -59,13 +59,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".tga")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! returns true if the file maybe is able to be loaded by this class
-	virtual bool isALoadableFileFormat(io::IReadFile* file) const _IRR_OVERRIDE_;
+	bool isALoadableFileFormat(io::IReadFile* file) const override;
 
 	//! creates a surface from the file
-	virtual IImage* loadImage(io::IReadFile* file) const _IRR_OVERRIDE_;
+	IImage* loadImage(io::IReadFile* file) const override;
 
 private:
 

--- a/source/Irrlicht/CImageWriterJPG.h
+++ b/source/Irrlicht/CImageWriterJPG.h
@@ -23,10 +23,10 @@ public:
 	CImageWriterJPG();
 
 	//! return true if this writer can write a file with the given extension
-	virtual bool isAWriteableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isAWriteableFileExtension(const io::path& filename) const override;
 
 	//! write image to file
-	virtual bool writeImage(io::IWriteFile *file, IImage *image, u32 param) const _IRR_OVERRIDE_;
+	bool writeImage(io::IWriteFile *file, IImage *image, u32 param) const override;
 };
 
 }

--- a/source/Irrlicht/CImageWriterPNG.h
+++ b/source/Irrlicht/CImageWriterPNG.h
@@ -23,10 +23,10 @@ public:
 	CImageWriterPNG();
 
 	//! return true if this writer can write a file with the given extension
-	virtual bool isAWriteableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isAWriteableFileExtension(const io::path& filename) const override;
 
 	//! write image to file
-	virtual bool writeImage(io::IWriteFile *file, IImage *image, u32 param) const _IRR_OVERRIDE_;
+	bool writeImage(io::IWriteFile *file, IImage *image, u32 param) const override;
 };
 
 } // namespace video

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -44,56 +44,56 @@ namespace irr
 		virtual ~CIrrDeviceLinux();
 
 		//! runs the device. Returns false if device wants to be deleted
-		virtual bool run() _IRR_OVERRIDE_;
+		bool run() override;
 
 		//! Cause the device to temporarily pause execution and let other processes to run
 		// This should bring down processor usage without major performance loss for Irrlicht
-		virtual void yield() _IRR_OVERRIDE_;
+		void yield() override;
 
 		//! Pause execution and let other processes to run for a specified amount of time.
-		virtual void sleep(u32 timeMs, bool pauseTimer) _IRR_OVERRIDE_;
+		void sleep(u32 timeMs, bool pauseTimer) override;
 
 		//! sets the caption of the window
-		virtual void setWindowCaption(const wchar_t* text) _IRR_OVERRIDE_;
+		void setWindowCaption(const wchar_t* text) override;
 
 		//! returns if window is active. if not, nothing need to be drawn
-		virtual bool isWindowActive() const _IRR_OVERRIDE_;
+		bool isWindowActive() const override;
 
 		//! returns if window has focus.
-		virtual bool isWindowFocused() const _IRR_OVERRIDE_;
+		bool isWindowFocused() const override;
 
 		//! returns if window is minimized.
-		virtual bool isWindowMinimized() const _IRR_OVERRIDE_;
+		bool isWindowMinimized() const override;
 
 		//! returns color format of the window.
-		virtual video::ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		video::ECOLOR_FORMAT getColorFormat() const override;
 
 		//! presents a surface in the client area
-		virtual bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0 ) _IRR_OVERRIDE_;
+		bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0 ) override;
 
 		//! notifies the device that it should close itself
-		virtual void closeDevice() _IRR_OVERRIDE_;
+		void closeDevice() override;
 
 		//! Sets if the window should be resizable in windowed mode.
-		virtual void setResizable(bool resize=false) _IRR_OVERRIDE_;
+		void setResizable(bool resize=false) override;
 
 		//! Resize the render window.
-		virtual void setWindowSize(const irr::core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void setWindowSize(const irr::core::dimension2d<u32>& size) override;
 
 		//! Minimizes the window.
-		virtual void minimizeWindow() _IRR_OVERRIDE_;
+		void minimizeWindow() override;
 
 		//! Maximizes the window.
-		virtual void maximizeWindow() _IRR_OVERRIDE_;
+		void maximizeWindow() override;
 
 		//! Restores the window size.
-		virtual void restoreWindow() _IRR_OVERRIDE_;
+		void restoreWindow() override;
 
 		//! Get the position of this window on screen
-		virtual core::position2di getWindowPosition() _IRR_OVERRIDE_;
+		core::position2di getWindowPosition() override;
 
 		//! Activate any joysticks, and generate events for them.
-		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) _IRR_OVERRIDE_;
+		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
 		//! gets text from the clipboard
 		//! \return Returns 0 if no string is in there, otherwise utf-8 text.
@@ -105,10 +105,10 @@ namespace irr
 		virtual void copyToClipboard(const c8 *text) const;
 
 		//! Remove all messages pending in the system message loop
-		virtual void clearSystemMessages() _IRR_OVERRIDE_;
+		void clearSystemMessages() override;
 
 		//! Get the device type
-		virtual E_DEVICE_TYPE getType() const _IRR_OVERRIDE_
+		E_DEVICE_TYPE getType() const override
 		{
 			return EIDT_X11;
 		}
@@ -155,7 +155,7 @@ namespace irr
 			~CCursorControl();
 
 			//! Changes the visible state of the mouse cursor.
-			virtual void setVisible(bool visible) _IRR_OVERRIDE_
+			void setVisible(bool visible) override
 			{
 				if (visible==IsVisible)
 					return;
@@ -172,31 +172,31 @@ namespace irr
 			}
 
 			//! Returns if the cursor is currently visible.
-			virtual bool isVisible() const _IRR_OVERRIDE_
+			bool isVisible() const override
 			{
 				return IsVisible;
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<f32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<f32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(f32 x, f32 y) _IRR_OVERRIDE_
+			void setPosition(f32 x, f32 y) override
 			{
 				setPosition((s32)(x*Device->Width), (s32)(y*Device->Height));
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<s32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<s32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(s32 x, s32 y) _IRR_OVERRIDE_
+			void setPosition(s32 x, s32 y) override
 			{
 #ifdef _IRR_COMPILE_WITH_X11_
 
@@ -261,7 +261,7 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual const core::position2d<s32>& getPosition(bool updateCursor) _IRR_OVERRIDE_
+			const core::position2d<s32>& getPosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateCursorPos();
@@ -269,7 +269,7 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual core::position2d<f32> getRelativePosition(bool updateCursor) _IRR_OVERRIDE_
+			core::position2d<f32> getRelativePosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateCursorPos();
@@ -284,7 +284,7 @@ namespace irr
 						CursorPos.Y / (f32)ReferenceRect.getHeight());
 			}
 
-			virtual void setReferenceRect(core::rect<s32>* rect=0) _IRR_OVERRIDE_
+			void setReferenceRect(core::rect<s32>* rect=0) override
 			{
 				if (rect)
 				{
@@ -304,29 +304,29 @@ namespace irr
 			}
 
 			//! Sets the active cursor icon
-			virtual void setActiveIcon(gui::ECURSOR_ICON iconId) _IRR_OVERRIDE_;
+			void setActiveIcon(gui::ECURSOR_ICON iconId) override;
 
 			//! Gets the currently active icon
-			virtual gui::ECURSOR_ICON getActiveIcon() const _IRR_OVERRIDE_
+			gui::ECURSOR_ICON getActiveIcon() const override
 			{
 				return ActiveIcon;
 			}
 
 			//! Add a custom sprite as cursor icon.
-			virtual gui::ECURSOR_ICON addIcon(const gui::SCursorSprite& icon) _IRR_OVERRIDE_;
+			gui::ECURSOR_ICON addIcon(const gui::SCursorSprite& icon) override;
 
 			//! replace the given cursor icon.
-			virtual void changeIcon(gui::ECURSOR_ICON iconId, const gui::SCursorSprite& icon) _IRR_OVERRIDE_;
+			void changeIcon(gui::ECURSOR_ICON iconId, const gui::SCursorSprite& icon) override;
 
 			//! Return a system-specific size which is supported for cursors. Larger icons will fail, smaller icons might work.
-			virtual core::dimension2di getSupportedIconSize() const _IRR_OVERRIDE_;
+			core::dimension2di getSupportedIconSize() const override;
 
 #ifdef _IRR_COMPILE_WITH_X11_
 			//! Set platform specific behavior flags.
-			virtual void setPlatformBehavior(gui::ECURSOR_PLATFORM_BEHAVIOR behavior) _IRR_OVERRIDE_ {PlatformBehavior = behavior; }
+			void setPlatformBehavior(gui::ECURSOR_PLATFORM_BEHAVIOR behavior) override {PlatformBehavior = behavior; }
 
 			//! Return platform specific behavior.
-			virtual gui::ECURSOR_PLATFORM_BEHAVIOR getPlatformBehavior() const _IRR_OVERRIDE_ { return PlatformBehavior; }
+			gui::ECURSOR_PLATFORM_BEHAVIOR getPlatformBehavior() const override { return PlatformBehavior; }
 
 			void update();
 			void clearCursors();

--- a/source/Irrlicht/CIrrDeviceOSX.h
+++ b/source/Irrlicht/CIrrDeviceOSX.h
@@ -47,56 +47,56 @@ namespace irr
 		virtual ~CIrrDeviceMacOSX();
 
 		//! runs the device. Returns false if device wants to be deleted
-		virtual bool run() _IRR_OVERRIDE_;
+		bool run() override;
 
 		//! Cause the device to temporarily pause execution and let other processes to run
 		// This should bring down processor usage without major performance loss for Irrlicht
-		virtual void yield() _IRR_OVERRIDE_;
+		void yield() override;
 
 		//! Pause execution and let other processes to run for a specified amount of time.
-		virtual void sleep(u32 timeMs, bool pauseTimer) _IRR_OVERRIDE_;
+		void sleep(u32 timeMs, bool pauseTimer) override;
 
 		//! sets the caption of the window
-		virtual void setWindowCaption(const wchar_t* text) _IRR_OVERRIDE_;
+		void setWindowCaption(const wchar_t* text) override;
 
 		//! returns if window is active. if not, nothing need to be drawn
-		virtual bool isWindowActive() const _IRR_OVERRIDE_;
+		bool isWindowActive() const override;
 
 		//! Checks if the Irrlicht window has focus
-		virtual bool isWindowFocused() const _IRR_OVERRIDE_;
+		bool isWindowFocused() const override;
 
 		//! Checks if the Irrlicht window is minimized
-		virtual bool isWindowMinimized() const _IRR_OVERRIDE_;
+		bool isWindowMinimized() const override;
 
 		//! presents a surface in the client area
-		virtual bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0 ) _IRR_OVERRIDE_;
+		bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0 ) override;
 
 		//! notifies the device that it should close itself
-		virtual void closeDevice() _IRR_OVERRIDE_;
+		void closeDevice() override;
 
 		//! Sets if the window should be resizable in windowed mode.
-		virtual void setResizable(bool resize) _IRR_OVERRIDE_;
+		void setResizable(bool resize) override;
 
 		//! Returns true if the window is resizable, false if not
 		virtual bool isResizable() const;
 
 		//! Minimizes the window if possible
-		virtual void minimizeWindow() _IRR_OVERRIDE_;
+		void minimizeWindow() override;
 
 		//! Maximizes the window if possible.
-		virtual void maximizeWindow() _IRR_OVERRIDE_;
+		void maximizeWindow() override;
 
 		//! Restore the window to normal size if possible.
-		virtual void restoreWindow() _IRR_OVERRIDE_;
+		void restoreWindow() override;
 
         //! Get the position of this window on screen
-        virtual core::position2di getWindowPosition() _IRR_OVERRIDE_;
+        core::position2di getWindowPosition() override;
 
 		//! Activate any joysticks, and generate events for them.
-		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) _IRR_OVERRIDE_;
+		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
 		//! Get the device type
-		virtual E_DEVICE_TYPE getType() const _IRR_OVERRIDE_
+		E_DEVICE_TYPE getType() const override
 		{
 				return EIDT_OSX;
 		}
@@ -127,39 +127,39 @@ namespace irr
 			}
 
 			//! Changes the visible state of the mouse cursor.
-			virtual void setVisible(bool visible)  _IRR_OVERRIDE_
+			void setVisible(bool visible)  override
 			{
 				IsVisible = visible;
 				Device->setCursorVisible(visible);
 			}
 
 			//! Returns if the cursor is currently visible.
-			virtual bool isVisible() const  _IRR_OVERRIDE_
+			bool isVisible() const  override
 			{
 				return IsVisible;
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<f32> &pos)  _IRR_OVERRIDE_
+			void setPosition(const core::position2d<f32> &pos)  override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(f32 x, f32 y)  _IRR_OVERRIDE_
+			void setPosition(f32 x, f32 y)  override
 			{
 				setPosition((s32)(x*WindowSize.Width), (s32)(y*WindowSize.Height));
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<s32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<s32> &pos) override
 			{
 				if (CursorPos.X != pos.X || CursorPos.Y != pos.Y)
 					setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(s32 x, s32 y) _IRR_OVERRIDE_
+			void setPosition(s32 x, s32 y) override
 			{
 				if (UseReferenceRect)
 				{
@@ -172,13 +172,13 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual const core::position2d<s32>& getPosition(bool updateCursor) _IRR_OVERRIDE_
+			const core::position2d<s32>& getPosition(bool updateCursor) override
 			{
 				return CursorPos;
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual core::position2d<f32> getRelativePosition(bool updateCursor) _IRR_OVERRIDE_
+			core::position2d<f32> getRelativePosition(bool updateCursor) override
 			{
 				if (!UseReferenceRect)
 				{
@@ -191,7 +191,7 @@ namespace irr
 			}
 
 			//! Sets an absolute reference rect for calculating the cursor position.
-			virtual void setReferenceRect(core::rect<s32>* rect=0)  _IRR_OVERRIDE_
+			void setReferenceRect(core::rect<s32>* rect=0)  override
 			{
 				if (rect)
 				{

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -37,59 +37,59 @@ namespace irr
 		virtual ~CIrrDeviceSDL();
 
 		//! runs the device. Returns false if device wants to be deleted
-		virtual bool run() _IRR_OVERRIDE_;
+		bool run() override;
 
 		//! pause execution temporarily
-		virtual void yield() _IRR_OVERRIDE_;
+		void yield() override;
 
 		//! pause execution for a specified time
-		virtual void sleep(u32 timeMs, bool pauseTimer) _IRR_OVERRIDE_;
+		void sleep(u32 timeMs, bool pauseTimer) override;
 
 		//! sets the caption of the window
-		virtual void setWindowCaption(const wchar_t* text) _IRR_OVERRIDE_;
+		void setWindowCaption(const wchar_t* text) override;
 
 		//! returns if window is active. if not, nothing need to be drawn
-		virtual bool isWindowActive() const _IRR_OVERRIDE_;
+		bool isWindowActive() const override;
 
 		//! returns if window has focus.
-		bool isWindowFocused() const _IRR_OVERRIDE_;
+		bool isWindowFocused() const override;
 
 		//! returns if window is minimized.
-		bool isWindowMinimized() const _IRR_OVERRIDE_;
+		bool isWindowMinimized() const override;
 
 		//! returns color format of the window.
-		video::ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		video::ECOLOR_FORMAT getColorFormat() const override;
 
 		//! presents a surface in the client area
-		virtual bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0) _IRR_OVERRIDE_;
+		bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0) override;
 
 		//! notifies the device that it should close itself
-		virtual void closeDevice() _IRR_OVERRIDE_;
+		void closeDevice() override;
 
 		//! Sets if the window should be resizable in windowed mode.
-		virtual void setResizable(bool resize=false) _IRR_OVERRIDE_;
+		void setResizable(bool resize=false) override;
 
 		//! Minimizes the window.
-		virtual void minimizeWindow() _IRR_OVERRIDE_;
+		void minimizeWindow() override;
 
 		//! Maximizes the window.
-		virtual void maximizeWindow() _IRR_OVERRIDE_;
+		void maximizeWindow() override;
 
 		//! Restores the window size.
-		virtual void restoreWindow() _IRR_OVERRIDE_;
+		void restoreWindow() override;
 
 		//! Checks if the Irrlicht window is running in fullscreen mode
 		/** \return True if window is fullscreen. */
-		virtual bool isFullscreen() const _IRR_OVERRIDE_;
+		bool isFullscreen() const override;
 
 		//! Get the position of this window on screen
-		virtual core::position2di getWindowPosition() _IRR_OVERRIDE_;
+		core::position2di getWindowPosition() override;
 
 		//! Activate any joysticks, and generate events for them.
-		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) _IRR_OVERRIDE_;
+		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
 		//! Get the device type
-		virtual E_DEVICE_TYPE getType() const _IRR_OVERRIDE_
+		E_DEVICE_TYPE getType() const override
 		{
 			return EIDT_SDL;
 		}
@@ -107,7 +107,7 @@ namespace irr
 			}
 
 			//! Changes the visible state of the mouse cursor.
-			virtual void setVisible(bool visible) _IRR_OVERRIDE_
+			void setVisible(bool visible) override
 			{
 				IsVisible = visible;
 				if ( visible )
@@ -119,37 +119,37 @@ namespace irr
 			}
 
 			//! Returns if the cursor is currently visible.
-			virtual bool isVisible() const _IRR_OVERRIDE_
+			bool isVisible() const override
 			{
 				return IsVisible;
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<f32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<f32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(f32 x, f32 y) _IRR_OVERRIDE_
+			void setPosition(f32 x, f32 y) override
 			{
 				setPosition((s32)(x*Device->Width), (s32)(y*Device->Height));
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<s32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<s32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(s32 x, s32 y) _IRR_OVERRIDE_
+			void setPosition(s32 x, s32 y) override
 			{
 				SDL_WarpMouseInWindow(Device->Window, x, y);
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual const core::position2d<s32>& getPosition(bool updateCursor) _IRR_OVERRIDE_
+			const core::position2d<s32>& getPosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateCursorPos();
@@ -157,7 +157,7 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual core::position2d<f32> getRelativePosition(bool updateCursor) _IRR_OVERRIDE_
+			core::position2d<f32> getRelativePosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateCursorPos();
@@ -165,7 +165,7 @@ namespace irr
 					CursorPos.Y / (f32)Device->Height);
 			}
 
-			virtual void setReferenceRect(core::rect<s32>* rect=0) _IRR_OVERRIDE_
+			void setReferenceRect(core::rect<s32>* rect=0) override
 			{
 			}
 

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -58,105 +58,105 @@ namespace irr
 		virtual ~CIrrDeviceStub();
 
 		//! returns the video driver
-		virtual video::IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+		video::IVideoDriver* getVideoDriver() override;
 
 		//! return file system
-		virtual io::IFileSystem* getFileSystem() _IRR_OVERRIDE_;
+		io::IFileSystem* getFileSystem() override;
 
 		//! returns the gui environment
-		virtual gui::IGUIEnvironment* getGUIEnvironment() _IRR_OVERRIDE_;
+		gui::IGUIEnvironment* getGUIEnvironment() override;
 
 		//! returns the scene manager
-		virtual scene::ISceneManager* getSceneManager() _IRR_OVERRIDE_;
+		scene::ISceneManager* getSceneManager() override;
 
 		//! \return Returns a pointer to the mouse cursor control interface.
-		virtual gui::ICursorControl* getCursorControl() _IRR_OVERRIDE_;
+		gui::ICursorControl* getCursorControl() override;
 
 		//! return the context manager
-		virtual video::IContextManager* getContextManager() _IRR_OVERRIDE_;
+		video::IContextManager* getContextManager() override;
 
 		//! Returns a pointer to the ITimer object. With it the current Time can be received.
-		virtual ITimer* getTimer() _IRR_OVERRIDE_;
+		ITimer* getTimer() override;
 
 		//! Returns the version of the engine.
-		virtual const char* getVersion() const _IRR_OVERRIDE_;
+		const char* getVersion() const override;
 
 		//! send the event to the right receiver
-		virtual bool postEventFromUser(const SEvent& event) _IRR_OVERRIDE_;
+		bool postEventFromUser(const SEvent& event) override;
 
 		//! Sets a new event receiver to receive events
-		virtual void setEventReceiver(IEventReceiver* receiver) _IRR_OVERRIDE_;
+		void setEventReceiver(IEventReceiver* receiver) override;
 
 		//! Returns pointer to the current event receiver. Returns 0 if there is none.
-		virtual IEventReceiver* getEventReceiver() _IRR_OVERRIDE_;
+		IEventReceiver* getEventReceiver() override;
 
 		//! Sets the input receiving scene manager.
 		/** If set to null, the main scene manager (returned by GetSceneManager()) will receive the input */
-		virtual void setInputReceivingSceneManager(scene::ISceneManager* sceneManager) _IRR_OVERRIDE_;
+		void setInputReceivingSceneManager(scene::ISceneManager* sceneManager) override;
 
 		//! Returns a pointer to the logger.
-		virtual ILogger* getLogger() _IRR_OVERRIDE_;
+		ILogger* getLogger() override;
 
 		//! Returns the operation system opertator object.
-		virtual IOSOperator* getOSOperator() _IRR_OVERRIDE_;
+		IOSOperator* getOSOperator() override;
 
 		//! Checks if the window is running in fullscreen mode.
-		virtual bool isFullscreen() const _IRR_OVERRIDE_;
+		bool isFullscreen() const override;
 
 		//! get color format of the current window
-		virtual video::ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		video::ECOLOR_FORMAT getColorFormat() const override;
 
 		//! Activate any joysticks, and generate events for them.
-		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) _IRR_OVERRIDE_;
+		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
         //! Activate accelerometer.
-        virtual bool activateAccelerometer(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
+        bool activateAccelerometer(float updateInterval = 0.016666f) override;
         
         //! Deactivate accelerometer.
-        virtual bool deactivateAccelerometer() _IRR_OVERRIDE_;
+        bool deactivateAccelerometer() override;
         
         //! Is accelerometer active.
-        virtual bool isAccelerometerActive() _IRR_OVERRIDE_;
+        bool isAccelerometerActive() override;
         
         //! Is accelerometer available.
-        virtual bool isAccelerometerAvailable() _IRR_OVERRIDE_;
+        bool isAccelerometerAvailable() override;
         
         //! Activate gyroscope.
-        virtual bool activateGyroscope(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
+        bool activateGyroscope(float updateInterval = 0.016666f) override;
         
         //! Deactivate gyroscope.
-        virtual bool deactivateGyroscope() _IRR_OVERRIDE_;
+        bool deactivateGyroscope() override;
         
         //! Is gyroscope active.
-        virtual bool isGyroscopeActive() _IRR_OVERRIDE_;
+        bool isGyroscopeActive() override;
         
         //! Is gyroscope available.
-        virtual bool isGyroscopeAvailable() _IRR_OVERRIDE_;
+        bool isGyroscopeAvailable() override;
         
         //! Activate device motion.
-        virtual bool activateDeviceMotion(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
+        bool activateDeviceMotion(float updateInterval = 0.016666f) override;
         
         //! Deactivate device motion.
-        virtual bool deactivateDeviceMotion() _IRR_OVERRIDE_;
+        bool deactivateDeviceMotion() override;
         
         //! Is device motion active.
-        virtual bool isDeviceMotionActive() _IRR_OVERRIDE_;
+        bool isDeviceMotionActive() override;
         
         //! Is device motion available.
-        virtual bool isDeviceMotionAvailable() _IRR_OVERRIDE_;
+        bool isDeviceMotionAvailable() override;
 
 		//! Set the maximal elapsed time between 2 clicks to generate doubleclicks for the mouse. It also affects tripleclick behavior.
 		//! When set to 0 no double- and tripleclicks will be generated.
-		virtual void setDoubleClickTime( u32 timeMs ) _IRR_OVERRIDE_;
+		void setDoubleClickTime( u32 timeMs ) override;
 
 		//! Get the maximal elapsed time between 2 clicks to generate double- and tripleclicks for the mouse.
-		virtual u32 getDoubleClickTime() const _IRR_OVERRIDE_;
+		u32 getDoubleClickTime() const override;
 
 		//! Remove all messages pending in the system message loop
-		virtual void clearSystemMessages() _IRR_OVERRIDE_;
+		void clearSystemMessages() override;
 
 		//! Resize the render window.
-		virtual void setWindowSize(const irr::core::dimension2d<u32>& size) _IRR_OVERRIDE_ {}
+		void setWindowSize(const irr::core::dimension2d<u32>& size) override {}
 
 	protected:
 

--- a/source/Irrlicht/CIrrDeviceWin32.h
+++ b/source/Irrlicht/CIrrDeviceWin32.h
@@ -37,70 +37,70 @@ namespace irr
 		virtual ~CIrrDeviceWin32();
 
 		//! runs the device. Returns false if device wants to be deleted
-		virtual bool run() _IRR_OVERRIDE_;
+		bool run() override;
 
 		//! Cause the device to temporarily pause execution and let other processes to run
 		// This should bring down processor usage without major performance loss for Irrlicht
-		virtual void yield() _IRR_OVERRIDE_;
+		void yield() override;
 
 		//! Pause execution and let other processes to run for a specified amount of time.
-		virtual void sleep(u32 timeMs, bool pauseTimer) _IRR_OVERRIDE_;
+		void sleep(u32 timeMs, bool pauseTimer) override;
 
 		//! sets the caption of the window
-		virtual void setWindowCaption(const wchar_t* text) _IRR_OVERRIDE_;
+		void setWindowCaption(const wchar_t* text) override;
 
 		//! returns if window is active. if not, nothing need to be drawn
-		virtual bool isWindowActive() const _IRR_OVERRIDE_;
+		bool isWindowActive() const override;
 
 		//! returns if window has focus
-		virtual bool isWindowFocused() const _IRR_OVERRIDE_;
+		bool isWindowFocused() const override;
 
 		//! returns if window is minimized
-		virtual bool isWindowMinimized() const _IRR_OVERRIDE_;
+		bool isWindowMinimized() const override;
 
 		//! presents a surface in the client area
-		virtual bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0) _IRR_OVERRIDE_;
+		bool present(video::IImage* surface, void* windowId=0, core::rect<s32>* src=0) override;
 
 		//! notifies the device that it should close itself
-		virtual void closeDevice() _IRR_OVERRIDE_;
+		void closeDevice() override;
 
 		//! Notifies the device, that it has been resized
 		/** Must be publis as it is called from free function (event handler) */
 		void OnResized();
 
 		//! Sets if the window should be resizable in windowed mode.
-		virtual void setResizable(bool resize=false) _IRR_OVERRIDE_;
+		void setResizable(bool resize=false) override;
 
 		//! Resize the render window.
-		virtual void setWindowSize(const irr::core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void setWindowSize(const irr::core::dimension2d<u32>& size) override;
 
 		//! Minimizes the window.
-		virtual void minimizeWindow() _IRR_OVERRIDE_;
+		void minimizeWindow() override;
 
 		//! Maximizes the window.
-		virtual void maximizeWindow() _IRR_OVERRIDE_;
+		void maximizeWindow() override;
 
 		//! Restores the window size.
-		virtual void restoreWindow() _IRR_OVERRIDE_;
+		void restoreWindow() override;
 
 		//! Get the position of the window on screen
-		virtual core::position2di getWindowPosition() _IRR_OVERRIDE_;
+		core::position2di getWindowPosition() override;
 
 		//! Activate any joysticks, and generate events for them.
-		virtual bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) _IRR_OVERRIDE_;
+		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
 		//! Remove all messages pending in the system message loop
-		virtual void clearSystemMessages() _IRR_OVERRIDE_;
+		void clearSystemMessages() override;
 
 		//! Get the device type
-		virtual E_DEVICE_TYPE getType() const _IRR_OVERRIDE_
+		E_DEVICE_TYPE getType() const override
 		{
 			return EIDT_WIN32;
 		}
 
 		//! Compares to the last call of this function to return double and triple clicks.
 		//! \return Returns only 1,2 or 3. A 4th click will start with 1 again.
-		virtual u32 checkSuccessiveClicks(s32 mouseX, s32 mouseY, EMOUSE_INPUT_EVENT inputEvent ) _IRR_OVERRIDE_
+		u32 checkSuccessiveClicks(s32 mouseX, s32 mouseY, EMOUSE_INPUT_EVENT inputEvent ) override
 		{
 			// we just have to make it public
 			return CIrrDeviceStub::checkSuccessiveClicks(mouseX, mouseY, inputEvent );
@@ -121,7 +121,7 @@ namespace irr
 			~CCursorControl();
 
 			//! Changes the visible state of the mouse cursor.
-			virtual void setVisible(bool visible) _IRR_OVERRIDE_
+			void setVisible(bool visible) override
 			{
 				CURSORINFO info;
 				info.cbSize = sizeof(CURSORINFO);
@@ -167,19 +167,19 @@ namespace irr
 			}
 
 			//! Returns if the cursor is currently visible.
-			virtual bool isVisible() const _IRR_OVERRIDE_
+			bool isVisible() const override
 			{
 				return IsVisible;
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<f32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<f32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(f32 x, f32 y) _IRR_OVERRIDE_
+			void setPosition(f32 x, f32 y) override
 			{
 				if (!UseReferenceRect)
 					setPosition(core::round32(x*WindowSize.Width), core::round32(y*WindowSize.Height));
@@ -188,13 +188,13 @@ namespace irr
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(const core::position2d<s32> &pos) _IRR_OVERRIDE_
+			void setPosition(const core::position2d<s32> &pos) override
 			{
 				setPosition(pos.X, pos.Y);
 			}
 
 			//! Sets the new position of the cursor.
-			virtual void setPosition(s32 x, s32 y) _IRR_OVERRIDE_
+			void setPosition(s32 x, s32 y) override
 			{
 				if (UseReferenceRect)
 				{
@@ -213,7 +213,7 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual const core::position2d<s32>& getPosition(bool updateCursor) _IRR_OVERRIDE_
+			const core::position2d<s32>& getPosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateInternalCursorPosition();
@@ -221,7 +221,7 @@ namespace irr
 			}
 
 			//! Returns the current position of the mouse cursor.
-			virtual core::position2d<f32> getRelativePosition(bool updateCursor) _IRR_OVERRIDE_
+			core::position2d<f32> getRelativePosition(bool updateCursor) override
 			{
 				if ( updateCursor )
 					updateInternalCursorPosition();
@@ -237,7 +237,7 @@ namespace irr
 			}
 
 			//! Sets an absolute reference rect for calculating the cursor position.
-			virtual void setReferenceRect(core::rect<s32>* rect=0) _IRR_OVERRIDE_
+			void setReferenceRect(core::rect<s32>* rect=0) override
 			{
 				if (rect)
 				{
@@ -300,22 +300,22 @@ namespace irr
 
 
 			//! Sets the active cursor icon
-			virtual void setActiveIcon(gui::ECURSOR_ICON iconId) _IRR_OVERRIDE_;
+			void setActiveIcon(gui::ECURSOR_ICON iconId) override;
 
 			//! Gets the currently active icon
-			virtual gui::ECURSOR_ICON getActiveIcon() const _IRR_OVERRIDE_
+			gui::ECURSOR_ICON getActiveIcon() const override
 			{
 				return ActiveIcon;
 			}
 
 			//! Add a custom sprite as cursor icon.
-			virtual gui::ECURSOR_ICON addIcon(const gui::SCursorSprite& icon) _IRR_OVERRIDE_;
+			gui::ECURSOR_ICON addIcon(const gui::SCursorSprite& icon) override;
 
 			//! replace the given cursor icon.
-			virtual void changeIcon(gui::ECURSOR_ICON iconId, const gui::SCursorSprite& icon) _IRR_OVERRIDE_;
+			void changeIcon(gui::ECURSOR_ICON iconId, const gui::SCursorSprite& icon) override;
 
 			//! Return a system-specific size which is supported for cursors. Larger icons will fail, smaller icons might work.
-			virtual core::dimension2di getSupportedIconSize() const _IRR_OVERRIDE_;
+			core::dimension2di getSupportedIconSize() const override;
 
 			void update();
 

--- a/source/Irrlicht/CIrrDeviceiOS.h
+++ b/source/Irrlicht/CIrrDeviceiOS.h
@@ -24,42 +24,42 @@ namespace irr
 		CIrrDeviceiOS(const SIrrlichtCreationParameters& params);
 		virtual ~CIrrDeviceiOS();
 
-		virtual bool run() _IRR_OVERRIDE_;
-		virtual void yield() _IRR_OVERRIDE_;
-		virtual void sleep(u32 timeMs, bool pauseTimer) _IRR_OVERRIDE_;
+		bool run() override;
+		void yield() override;
+		void sleep(u32 timeMs, bool pauseTimer) override;
 
-		virtual void setWindowCaption(const wchar_t* text) _IRR_OVERRIDE_;
+		void setWindowCaption(const wchar_t* text) override;
 
-		virtual bool isWindowActive() const _IRR_OVERRIDE_;
-		virtual bool isWindowFocused() const _IRR_OVERRIDE_;
-		virtual bool isWindowMinimized() const _IRR_OVERRIDE_;
+		bool isWindowActive() const override;
+		bool isWindowFocused() const override;
+		bool isWindowMinimized() const override;
 
-		virtual bool present(video::IImage* surface, void * windowId = 0, core::rect<s32>* src = 0) _IRR_OVERRIDE_;
+		bool present(video::IImage* surface, void * windowId = 0, core::rect<s32>* src = 0) override;
 
-		virtual void closeDevice() _IRR_OVERRIDE_;
+		void closeDevice() override;
 
-		virtual void setResizable(bool resize = false) _IRR_OVERRIDE_;
+		void setResizable(bool resize = false) override;
 
-		virtual void minimizeWindow() _IRR_OVERRIDE_;
-		virtual void maximizeWindow() _IRR_OVERRIDE_;
-		virtual void restoreWindow() _IRR_OVERRIDE_;
+		void minimizeWindow() override;
+		void maximizeWindow() override;
+		void restoreWindow() override;
 
-		virtual core::position2di getWindowPosition() _IRR_OVERRIDE_;
+		core::position2di getWindowPosition() override;
 
-        virtual bool activateAccelerometer(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
-        virtual bool deactivateAccelerometer() _IRR_OVERRIDE_;
-        virtual bool isAccelerometerActive() _IRR_OVERRIDE_;
-        virtual bool isAccelerometerAvailable() _IRR_OVERRIDE_;
-        virtual bool activateGyroscope(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
-        virtual bool deactivateGyroscope() _IRR_OVERRIDE_;
-        virtual bool isGyroscopeActive() _IRR_OVERRIDE_;
-        virtual bool isGyroscopeAvailable() _IRR_OVERRIDE_;
-        virtual bool activateDeviceMotion(float updateInterval = 0.016666f) _IRR_OVERRIDE_;
-        virtual bool deactivateDeviceMotion() _IRR_OVERRIDE_;
-        virtual bool isDeviceMotionActive() _IRR_OVERRIDE_;
-        virtual bool isDeviceMotionAvailable() _IRR_OVERRIDE_;
+        bool activateAccelerometer(float updateInterval = 0.016666f) override;
+        bool deactivateAccelerometer() override;
+        bool isAccelerometerActive() override;
+        bool isAccelerometerAvailable() override;
+        bool activateGyroscope(float updateInterval = 0.016666f) override;
+        bool deactivateGyroscope() override;
+        bool isGyroscopeActive() override;
+        bool isGyroscopeAvailable() override;
+        bool activateDeviceMotion(float updateInterval = 0.016666f) override;
+        bool deactivateDeviceMotion() override;
+        bool isDeviceMotionActive() override;
+        bool isDeviceMotionAvailable() override;
 
-        virtual E_DEVICE_TYPE getType() const _IRR_OVERRIDE_;
+        E_DEVICE_TYPE getType() const override;
 
 	private:
         void createWindow();

--- a/source/Irrlicht/CLimitReadFile.h
+++ b/source/Irrlicht/CLimitReadFile.h
@@ -30,24 +30,24 @@ namespace io
 		virtual ~CLimitReadFile();
 
 		//! returns how much was read
-		virtual size_t read(void* buffer, size_t sizeToRead) _IRR_OVERRIDE_;
+		size_t read(void* buffer, size_t sizeToRead) override;
 
 		//! changes position in file, returns true if successful
 		//! if relativeMovement==true, the pos is changed relative to current pos,
 		//! otherwise from begin of file
-		virtual bool seek(long finalPos, bool relativeMovement = false) _IRR_OVERRIDE_;
+		bool seek(long finalPos, bool relativeMovement = false) override;
 
 		//! returns size of file
-		virtual long getSize() const _IRR_OVERRIDE_;
+		long getSize() const override;
 
 		//! returns where in the file we are.
-		virtual long getPos() const _IRR_OVERRIDE_;
+		long getPos() const override;
 
 		//! returns name of file
-		virtual const io::path& getFileName() const _IRR_OVERRIDE_;
+		const io::path& getFileName() const override;
 
 		//! Get the type of the class implementing this interface
-		virtual EREAD_FILE_TYPE getType() const _IRR_OVERRIDE_
+		EREAD_FILE_TYPE getType() const override
 		{
 			return ERFT_LIMIT_READ_FILE;
 		}

--- a/source/Irrlicht/CLogger.h
+++ b/source/Irrlicht/CLogger.h
@@ -21,25 +21,25 @@ public:
 	CLogger(IEventReceiver* r);
 
 	//! Returns the current set log level.
-	virtual ELOG_LEVEL getLogLevel() const _IRR_OVERRIDE_;
+	ELOG_LEVEL getLogLevel() const override;
 
-	//! Sets a new log level.	virtual void setLogLevel(ELOG_LEVEL ll) _IRR_OVERRIDE_;
-	virtual void setLogLevel(ELOG_LEVEL ll) _IRR_OVERRIDE_;
-
-	//! Prints out a text into the log
-	virtual void log(const c8* text, ELOG_LEVEL ll=ELL_INFORMATION) _IRR_OVERRIDE_;
+	//! Sets a new log level.	void setLogLevel(ELOG_LEVEL ll) override;
+	void setLogLevel(ELOG_LEVEL ll) override;
 
 	//! Prints out a text into the log
-	virtual void log(const wchar_t* text, ELOG_LEVEL ll=ELL_INFORMATION) _IRR_OVERRIDE_;
+	void log(const c8* text, ELOG_LEVEL ll=ELL_INFORMATION) override;
 
 	//! Prints out a text into the log
-	virtual void log(const c8* text, const c8* hint, ELOG_LEVEL ll=ELL_INFORMATION) _IRR_OVERRIDE_;
+	void log(const wchar_t* text, ELOG_LEVEL ll=ELL_INFORMATION) override;
 
 	//! Prints out a text into the log
-	virtual void log(const c8* text, const wchar_t* hint, ELOG_LEVEL ll=ELL_INFORMATION) _IRR_OVERRIDE_;
+	void log(const c8* text, const c8* hint, ELOG_LEVEL ll=ELL_INFORMATION) override;
 
 	//! Prints out a text into the log
-	virtual void log(const wchar_t* text, const wchar_t* hint, ELOG_LEVEL ll=ELL_INFORMATION) _IRR_OVERRIDE_;
+	void log(const c8* text, const wchar_t* hint, ELOG_LEVEL ll=ELL_INFORMATION) override;
+
+	//! Prints out a text into the log
+	void log(const wchar_t* text, const wchar_t* hint, ELOG_LEVEL ll=ELL_INFORMATION) override;
 
 	//! Sets a new event receiver
 	void setReceiver(IEventReceiver* r);

--- a/source/Irrlicht/CMemoryFile.h
+++ b/source/Irrlicht/CMemoryFile.h
@@ -29,28 +29,28 @@ namespace io
 		virtual ~CMemoryReadFile();
 
 		//! returns how much was read
-		virtual size_t read(void* buffer, size_t sizeToRead) _IRR_OVERRIDE_;
+		size_t read(void* buffer, size_t sizeToRead) override;
 
 		//! changes position in file, returns true if successful
-		virtual bool seek(long finalPos, bool relativeMovement = false) _IRR_OVERRIDE_;
+		bool seek(long finalPos, bool relativeMovement = false) override;
 
 		//! returns size of file
-		virtual long getSize() const _IRR_OVERRIDE_;
+		long getSize() const override;
 
 		//! returns where in the file we are.
-		virtual long getPos() const _IRR_OVERRIDE_;
+		long getPos() const override;
 
 		//! returns name of file
-		virtual const io::path& getFileName() const _IRR_OVERRIDE_;
+		const io::path& getFileName() const override;
 
 		//! Get the type of the class implementing this interface
-		virtual EREAD_FILE_TYPE getType() const _IRR_OVERRIDE_
+		EREAD_FILE_TYPE getType() const override
 		{
 			return ERFT_MEMORY_READ_FILE;
 		}
 
 		//! Get direct access to internal buffer
-		virtual const void *getBuffer() const _IRR_OVERRIDE_
+		const void *getBuffer() const override
 		{
 			return Buffer;
 		}
@@ -78,18 +78,18 @@ namespace io
 		virtual ~CMemoryWriteFile();
 
 		//! returns how much was written
-		virtual size_t write(const void* buffer, size_t sizeToWrite) _IRR_OVERRIDE_;
+		size_t write(const void* buffer, size_t sizeToWrite) override;
 
 		//! changes position in file, returns true if successful
-		virtual bool seek(long finalPos, bool relativeMovement = false) _IRR_OVERRIDE_;
+		bool seek(long finalPos, bool relativeMovement = false) override;
 
 		//! returns where in the file we are.
-		virtual long getPos() const _IRR_OVERRIDE_;
+		long getPos() const override;
 
 		//! returns name of file
-		virtual const io::path& getFileName() const _IRR_OVERRIDE_;
+		const io::path& getFileName() const override;
 
-		virtual bool flush() _IRR_OVERRIDE_;
+		bool flush() override;
 
 	private:
 

--- a/source/Irrlicht/CMeshCache.h
+++ b/source/Irrlicht/CMeshCache.h
@@ -30,42 +30,42 @@ namespace scene
 		\param filename: Filename of the mesh. When called ISceneManager::getMesh() with this
 		parameter, the method will return the mesh parameter given with this method.
 		\param mesh: Pointer to a mesh which will now be referenced by this name. */
-		virtual void addMesh(const io::path& filename, IAnimatedMesh* mesh) _IRR_OVERRIDE_;
+		void addMesh(const io::path& filename, IAnimatedMesh* mesh) override;
 
 		//! Removes a mesh from the cache.
 		/** After loading a mesh with getMesh(), the mesh can be removed from the cache
 		using this method, freeing a lot of memory. */
-		virtual void removeMesh(const IMesh* const mesh) _IRR_OVERRIDE_;
+		void removeMesh(const IMesh* const mesh) override;
 
 		//! Returns amount of loaded meshes in the cache.
 		/** You can load new meshes into the cache using getMesh() and addMesh().
 		If you ever need to access the internal mesh cache, you can do this using
 		removeMesh(), getMeshNumber(), getMeshByIndex() and getMeshFilename() */
-		virtual u32 getMeshCount() const _IRR_OVERRIDE_;
+		u32 getMeshCount() const override;
 
 		//! Returns current index number of the mesh, and -1 if it is not in the cache.
-		virtual s32 getMeshIndex(const IMesh* const mesh) const _IRR_OVERRIDE_;
+		s32 getMeshIndex(const IMesh* const mesh) const override;
 
 		//! Returns a mesh based on its index number.
 		/** \param index: Index of the mesh, number between 0 and getMeshCount()-1.
 		Note that this number is only valid until a new mesh is loaded or removed *
 		\return Returns pointer to the mesh or 0 if there is none with this number. */
-		virtual IAnimatedMesh* getMeshByIndex(u32 index) _IRR_OVERRIDE_;
+		IAnimatedMesh* getMeshByIndex(u32 index) override;
 
 		//! Returns a mesh based on its name.
 		/** \param name Name of the mesh. Usually a filename.
 		\return Pointer to the mesh or 0 if there is none with this number. */
-		virtual IAnimatedMesh* getMeshByName(const io::path& name) _IRR_OVERRIDE_;
+		IAnimatedMesh* getMeshByName(const io::path& name) override;
 
 		//! Get the name of a loaded mesh, based on its index.
 		/** \param index: Index of the mesh, number between 0 and getMeshCount()-1.
 		\return The name if mesh was found and has a name, else	the path is empty. */
-		virtual const io::SNamedPath& getMeshName(u32 index) const _IRR_OVERRIDE_;
+		const io::SNamedPath& getMeshName(u32 index) const override;
 
 		//! Get the name of a loaded mesh, if there is any.
 		/** \param mesh Pointer to mesh to query.
 		\return The name if mesh was found and has a name, else	the path is empty. */
-		virtual const io::SNamedPath& getMeshName(const IMesh* const mesh) const _IRR_OVERRIDE_;
+		const io::SNamedPath& getMeshName(const IMesh* const mesh) const override;
 
 		//! Renames a loaded mesh.
 		/** Note that renaming meshes might change the ordering of the
@@ -74,7 +74,7 @@ namespace scene
 		\param index The index of the mesh in the cache.
 		\param name New name for the mesh.
 		\return True if mesh was renamed. */
-		virtual bool renameMesh(u32 index, const io::path& name) _IRR_OVERRIDE_;
+		bool renameMesh(u32 index, const io::path& name) override;
 
 		//! Renames a loaded mesh.
 		/** Note that renaming meshes might change the ordering of the
@@ -83,16 +83,16 @@ namespace scene
 		\param mesh Mesh to be renamed.
 		\param name New name for the mesh.
 		\return True if mesh was renamed. */
-		virtual bool renameMesh(const IMesh* const mesh, const io::path& name) _IRR_OVERRIDE_;
+		bool renameMesh(const IMesh* const mesh, const io::path& name) override;
 
 		//! returns if a mesh already was loaded
-		virtual bool isMeshLoaded(const io::path& name) _IRR_OVERRIDE_;
+		bool isMeshLoaded(const io::path& name) override;
 
 		//! Clears the whole mesh cache, removing all meshes.
-		virtual void clear() _IRR_OVERRIDE_;
+		void clear() override;
 
 		//! Clears all meshes that are held in the mesh cache but not used anywhere else.
-		virtual void clearUnusedMeshes() _IRR_OVERRIDE_;
+		void clearUnusedMeshes() override;
 
 	protected:
 

--- a/source/Irrlicht/CMeshManipulator.h
+++ b/source/Irrlicht/CMeshManipulator.h
@@ -23,24 +23,24 @@ public:
 	//! Recalculates all normals of the mesh.
 	/** \param mesh: Mesh on which the operation is performed.
 	\param smooth: Whether to use smoothed normals. */
-	virtual void recalculateNormals(scene::IMesh* mesh, bool smooth = false, bool angleWeighted = false) const _IRR_OVERRIDE_;
+	void recalculateNormals(scene::IMesh* mesh, bool smooth = false, bool angleWeighted = false) const override;
 
 	//! Recalculates all normals of the mesh buffer.
 	/** \param buffer: Mesh buffer on which the operation is performed.
 	\param smooth: Whether to use smoothed normals. */
-	virtual void recalculateNormals(IMeshBuffer* buffer, bool smooth = false, bool angleWeighted = false) const _IRR_OVERRIDE_;
+	void recalculateNormals(IMeshBuffer* buffer, bool smooth = false, bool angleWeighted = false) const override;
 
 	//! Clones a static IMesh into a modifiable SMesh.
-	virtual SMesh* createMeshCopy(scene::IMesh* mesh) const _IRR_OVERRIDE_;
+	SMesh* createMeshCopy(scene::IMesh* mesh) const override;
 
 	//! Returns amount of polygons in mesh.
-	virtual s32 getPolyCount(scene::IMesh* mesh) const _IRR_OVERRIDE_;
+	s32 getPolyCount(scene::IMesh* mesh) const override;
 
 	//! Returns amount of polygons in mesh.
-	virtual s32 getPolyCount(scene::IAnimatedMesh* mesh) const _IRR_OVERRIDE_;
+	s32 getPolyCount(scene::IAnimatedMesh* mesh) const override;
 
 	//! create a new AnimatedMesh and adds the mesh to it
-	virtual IAnimatedMesh * createAnimatedMesh(scene::IMesh* mesh,scene::E_ANIMATED_MESH_TYPE type) const _IRR_OVERRIDE_;
+	IAnimatedMesh * createAnimatedMesh(scene::IMesh* mesh,scene::E_ANIMATED_MESH_TYPE type) const override;
 };
 
 } // end namespace scene

--- a/source/Irrlicht/CMeshSceneNode.h
+++ b/source/Irrlicht/CMeshSceneNode.h
@@ -27,48 +27,48 @@ namespace scene
 		virtual ~CMeshSceneNode();
 
 		//! frame
-		virtual void OnRegisterSceneNode() _IRR_OVERRIDE_;
+		void OnRegisterSceneNode() override;
 
 		//! renders the node.
-		virtual void render() _IRR_OVERRIDE_;
+		void render() override;
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! returns the material based on the zero based index i. To get the amount
 		//! of materials used by this scene node, use getMaterialCount().
 		//! This function is needed for inserting the node into the scene hierarchy on a
 		//! optimal position for minimizing renderstate changes, but can also be used
 		//! to directly modify the material of a scene node.
-		virtual video::SMaterial& getMaterial(u32 i) _IRR_OVERRIDE_;
+		video::SMaterial& getMaterial(u32 i) override;
 
 		//! returns amount of materials used by this scene node.
-		virtual u32 getMaterialCount() const _IRR_OVERRIDE_;
+		u32 getMaterialCount() const override;
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_MESH; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_MESH; }
 
 		//! Sets a new mesh
-		virtual void setMesh(IMesh* mesh) _IRR_OVERRIDE_;
+		void setMesh(IMesh* mesh) override;
 
 		//! Returns the current mesh
-		virtual IMesh* getMesh(void) _IRR_OVERRIDE_ { return Mesh; }
+		IMesh* getMesh(void) override { return Mesh; }
 
 		//! Sets if the scene node should not copy the materials of the mesh but use them in a read only style.
 		/* In this way it is possible to change the materials a mesh causing all mesh scene nodes
 		referencing this mesh to change too. */
-		virtual void setReadOnlyMaterials(bool readonly) _IRR_OVERRIDE_;
+		void setReadOnlyMaterials(bool readonly) override;
 
 		//! Returns if the scene node should not copy the materials of the mesh but use them in a read only style
-		virtual bool isReadOnlyMaterials() const _IRR_OVERRIDE_;
+		bool isReadOnlyMaterials() const override;
 
 		//! Creates a clone of this scene node and its children.
-		virtual ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) _IRR_OVERRIDE_;
+		ISceneNode* clone(ISceneNode* newParent=0, ISceneManager* newManager=0) override;
 
 		//! Removes a child from this scene node.
 		//! Implemented here, to be able to remove the shadow properly, if there is one,
 		//! or to remove attached child.
-		virtual bool removeChild(ISceneNode* child) _IRR_OVERRIDE_;
+		bool removeChild(ISceneNode* child) override;
 
 	protected:
 

--- a/source/Irrlicht/CNSOGLManager.h
+++ b/source/Irrlicht/CNSOGLManager.h
@@ -31,34 +31,34 @@ namespace video
 		~CNSOGLManager();
 
         // Initialize
-        bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) _IRR_OVERRIDE_;
+        bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) override;
 
         // Terminate
-        void terminate() _IRR_OVERRIDE_;
+        void terminate() override;
 
         // Create surface.
-        bool generateSurface() _IRR_OVERRIDE_;
+        bool generateSurface() override;
 
         // Destroy surface.
-        void destroySurface() _IRR_OVERRIDE_;
+        void destroySurface() override;
 
         // Create context.
-        bool generateContext() _IRR_OVERRIDE_;
+        bool generateContext() override;
 
         // Destroy EGL context.
-        void destroyContext() _IRR_OVERRIDE_;
+        void destroyContext() override;
 
 		//! Get current context
 		const SExposedVideoData& getContext() const;
 
 		//! Change render context, disable old and activate new defined by videoData
-		bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) _IRR_OVERRIDE_;
+		bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) override;
 
 		// Get procedure address.
-		virtual void* getProcAddress(const std::string &procName) _IRR_OVERRIDE_;
+		void* getProcAddress(const std::string &procName) override;
 
         // Swap buffers.
-        bool swapBuffers() _IRR_OVERRIDE_;
+        bool swapBuffers() override;
 
     private:
         SIrrlichtCreationParameters Params;

--- a/source/Irrlicht/CNullDriver.h
+++ b/source/Irrlicht/CNullDriver.h
@@ -44,99 +44,99 @@ namespace video
 		virtual ~CNullDriver();
 
 		virtual bool beginScene(u16 clearFlag, SColor clearColor = SColor(255,0,0,0), f32 clearDepth = 1.f, u8 clearStencil = 0,
-			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) _IRR_OVERRIDE_;
+			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) override;
 
-		virtual bool endScene() _IRR_OVERRIDE_;
+		bool endScene() override;
 
 		//! Disable a feature of the driver.
-		virtual void disableFeature(E_VIDEO_DRIVER_FEATURE feature, bool flag=true) _IRR_OVERRIDE_;
+		void disableFeature(E_VIDEO_DRIVER_FEATURE feature, bool flag=true) override;
 
 		//! queries the features of the driver, returns true if feature is available
-		virtual bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const _IRR_OVERRIDE_;
+		bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override;
 
 		//! Get attributes of the actual video driver
-		virtual const io::IAttributes& getDriverAttributes() const _IRR_OVERRIDE_;
+		const io::IAttributes& getDriverAttributes() const override;
 
 		//! sets transformation
-		virtual void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) _IRR_OVERRIDE_;
+		void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) override;
 
 		//! Retrieve the number of image loaders
-		virtual u32 getImageLoaderCount() const _IRR_OVERRIDE_;
+		u32 getImageLoaderCount() const override;
 
 		//! Retrieve the given image loader
-		virtual IImageLoader* getImageLoader(u32 n) _IRR_OVERRIDE_;
+		IImageLoader* getImageLoader(u32 n) override;
 
 		//! Retrieve the number of image writers
-		virtual u32 getImageWriterCount() const _IRR_OVERRIDE_;
+		u32 getImageWriterCount() const override;
 
 		//! Retrieve the given image writer
-		virtual IImageWriter* getImageWriter(u32 n) _IRR_OVERRIDE_;
+		IImageWriter* getImageWriter(u32 n) override;
 
 		//! sets a material
-		virtual void setMaterial(const SMaterial& material) _IRR_OVERRIDE_;
+		void setMaterial(const SMaterial& material) override;
 
 		//! loads a Texture
-		virtual ITexture* getTexture(const io::path& filename) _IRR_OVERRIDE_;
+		ITexture* getTexture(const io::path& filename) override;
 
 		//! loads a Texture
-		virtual ITexture* getTexture(io::IReadFile* file) _IRR_OVERRIDE_;
+		ITexture* getTexture(io::IReadFile* file) override;
 
 		//! Returns a texture by index
-		virtual ITexture* getTextureByIndex(u32 index) _IRR_OVERRIDE_;
+		ITexture* getTextureByIndex(u32 index) override;
 
 		//! Returns amount of textures currently loaded
-		virtual u32 getTextureCount() const _IRR_OVERRIDE_;
+		u32 getTextureCount() const override;
 
 		//! Renames a texture
-		virtual void renameTexture(ITexture* texture, const io::path& newName) _IRR_OVERRIDE_;
+		void renameTexture(ITexture* texture, const io::path& newName) override;
 
-		virtual ITexture* addTexture(const core::dimension2d<u32>& size, const io::path& name, ECOLOR_FORMAT format = ECF_A8R8G8B8) _IRR_OVERRIDE_;
+		ITexture* addTexture(const core::dimension2d<u32>& size, const io::path& name, ECOLOR_FORMAT format = ECF_A8R8G8B8) override;
 
-		virtual ITexture* addTexture(const io::path& name, IImage* image) _IRR_OVERRIDE_;
+		ITexture* addTexture(const io::path& name, IImage* image) override;
 
 		virtual ITexture* addTextureCubemap(const io::path& name, IImage* imagePosX, IImage* imageNegX, IImage* imagePosY,
-			IImage* imageNegY, IImage* imagePosZ, IImage* imageNegZ) _IRR_OVERRIDE_;
+			IImage* imageNegY, IImage* imagePosZ, IImage* imageNegZ) override;
 
-		virtual ITexture* addTextureCubemap(const irr::u32 sideLen, const io::path& name, ECOLOR_FORMAT format = ECF_A8R8G8B8) _IRR_OVERRIDE_;
+		ITexture* addTextureCubemap(const irr::u32 sideLen, const io::path& name, ECOLOR_FORMAT format = ECF_A8R8G8B8) override;
 
 		virtual bool setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SColor clearColor = SColor(255,0,0,0),
-			f32 clearDepth = 1.f, u8 clearStencil = 0) _IRR_OVERRIDE_;
+			f32 clearDepth = 1.f, u8 clearStencil = 0) override;
 
 		virtual bool setRenderTarget(ITexture* texture, u16 clearFlag, SColor clearColor = SColor(255,0,0,0),
-			f32 clearDepth = 1.f, u8 clearStencil = 0) _IRR_OVERRIDE_;
+			f32 clearDepth = 1.f, u8 clearStencil = 0) override;
 
 		//! sets a viewport
-		virtual void setViewPort(const core::rect<s32>& area) _IRR_OVERRIDE_;
+		void setViewPort(const core::rect<s32>& area) override;
 
 		//! gets the area of the current viewport
-		virtual const core::rect<s32>& getViewPort() const _IRR_OVERRIDE_;
+		const core::rect<s32>& getViewPort() const override;
 
 		//! draws a vertex primitive list
 		virtual void drawVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
 				E_VERTEX_TYPE vType=EVT_STANDARD, scene::E_PRIMITIVE_TYPE pType=scene::EPT_TRIANGLES,
-				E_INDEX_TYPE iType=EIT_16BIT) _IRR_OVERRIDE_;
+				E_INDEX_TYPE iType=EIT_16BIT) override;
 
 		//! draws a vertex primitive list in 2d
 		virtual void draw2DVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
 				E_VERTEX_TYPE vType=EVT_STANDARD, scene::E_PRIMITIVE_TYPE pType=scene::EPT_TRIANGLES,
-				E_INDEX_TYPE iType=EIT_16BIT) _IRR_OVERRIDE_;
+				E_INDEX_TYPE iType=EIT_16BIT) override;
 
 		//! Draws a 3d line.
 		virtual void draw3DLine(const core::vector3df& start,
-			const core::vector3df& end, SColor color = SColor(255,255,255,255)) _IRR_OVERRIDE_;
+			const core::vector3df& end, SColor color = SColor(255,255,255,255)) override;
 
 		//! Draws a 3d triangle.
 		virtual void draw3DTriangle(const core::triangle3df& triangle,
-			SColor color = SColor(255,255,255,255)) _IRR_OVERRIDE_;
+			SColor color = SColor(255,255,255,255)) override;
 
 		//! Draws a 3d axis aligned box.
 		virtual void draw3DBox(const core::aabbox3d<f32>& box,
-			SColor color = SColor(255,255,255,255)) _IRR_OVERRIDE_;
+			SColor color = SColor(255,255,255,255)) override;
 
 		//! draws an 2d image
-		virtual void draw2DImage(const video::ITexture* texture, const core::position2d<s32>& destPos, bool useAlphaChannelOfTexture) _IRR_OVERRIDE_;
+		void draw2DImage(const video::ITexture* texture, const core::position2d<s32>& destPos, bool useAlphaChannelOfTexture) override;
 
 		//! draws a set of 2d images, using a color and the alpha
 		/** channel of the texture if desired. The images are drawn
@@ -162,7 +162,7 @@ namespace video
 				s32 kerningWidth = 0,
 				const core::rect<s32>* clipRect = 0,
 				SColor color=SColor(255,255,255,255),
-				bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture=false) override;
 
 		//! Draws a set of 2d images, using a color and the alpha channel of the texture.
 		/** All drawings are clipped against clipRect (if != 0).
@@ -185,92 +185,92 @@ namespace video
 				const core::array<core::rect<s32> >& sourceRects,
 				const core::rect<s32>* clipRect=0,
 				SColor color=SColor(255,255,255,255),
-				bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture=false) override;
 
 		//! Draws a 2d image, using a color (if color is other then Color(255,255,255,255)) and the alpha channel of the texture if wanted.
 		virtual void draw2DImage(const video::ITexture* texture, const core::position2d<s32>& destPos,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			SColor color=SColor(255,255,255,255), bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+			SColor color=SColor(255,255,255,255), bool useAlphaChannelOfTexture=false) override;
 
 		//! Draws a part of the texture into the rectangle.
 		virtual void draw2DImage(const video::ITexture* texture, const core::rect<s32>& destRect,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			const video::SColor* const colors=0, bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+			const video::SColor* const colors=0, bool useAlphaChannelOfTexture=false) override;
 
 		//! Draws a 2d rectangle
-		virtual void draw2DRectangle(SColor color, const core::rect<s32>& pos, const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+		void draw2DRectangle(SColor color, const core::rect<s32>& pos, const core::rect<s32>* clip = 0) override;
 
 		//! Draws a 2d rectangle with a gradient.
 		virtual void draw2DRectangle(const core::rect<s32>& pos,
 			SColor colorLeftUp, SColor colorRightUp, SColor colorLeftDown, SColor colorRightDown,
-			const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+			const core::rect<s32>* clip = 0) override;
 
 		//! Draws the outline of a 2d rectangle
-		virtual void draw2DRectangleOutline(const core::recti& pos, SColor color=SColor(255,255,255,255)) _IRR_OVERRIDE_;
+		void draw2DRectangleOutline(const core::recti& pos, SColor color=SColor(255,255,255,255)) override;
 
 		//! Draws a 2d line.
 		virtual void draw2DLine(const core::position2d<s32>& start,
 					const core::position2d<s32>& end,
-					SColor color=SColor(255,255,255,255)) _IRR_OVERRIDE_;
+					SColor color=SColor(255,255,255,255)) override;
 
 		//! Draws a pixel
-		virtual void drawPixel(u32 x, u32 y, const SColor & color) _IRR_OVERRIDE_;
+		void drawPixel(u32 x, u32 y, const SColor & color) override;
 
 		//! Draws a non filled concyclic reqular 2d polygon.
 		virtual void draw2DPolygon(core::position2d<s32> center,
-			f32 radius, video::SColor Color, s32 vertexCount) _IRR_OVERRIDE_;
+			f32 radius, video::SColor Color, s32 vertexCount) override;
 
 		virtual void setFog(SColor color=SColor(0,255,255,255),
 				E_FOG_TYPE fogType=EFT_FOG_LINEAR,
 				f32 start=50.0f, f32 end=100.0f, f32 density=0.01f,
-				bool pixelFog=false, bool rangeFog=false) _IRR_OVERRIDE_;
+				bool pixelFog=false, bool rangeFog=false) override;
 
 		virtual void getFog(SColor& color, E_FOG_TYPE& fogType,
 				f32& start, f32& end, f32& density,
-				bool& pixelFog, bool& rangeFog) _IRR_OVERRIDE_;
+				bool& pixelFog, bool& rangeFog) override;
 
 		//! get color format of the current color buffer
-		virtual ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		ECOLOR_FORMAT getColorFormat() const override;
 
 		//! get screen size
-		virtual const core::dimension2d<u32>& getScreenSize() const _IRR_OVERRIDE_;
+		const core::dimension2d<u32>& getScreenSize() const override;
 
 		//! get current render target
 		IRenderTarget* getCurrentRenderTarget() const;
 
 		//! get render target size
-		virtual const core::dimension2d<u32>& getCurrentRenderTargetSize() const _IRR_OVERRIDE_;
+		const core::dimension2d<u32>& getCurrentRenderTargetSize() const override;
 
 		// get current frames per second value
-		virtual s32 getFPS() const _IRR_OVERRIDE_;
+		s32 getFPS() const override;
 
 		//! returns amount of primitives (mostly triangles) were drawn in the last frame.
 		//! very useful method for statistics.
-		virtual u32 getPrimitiveCountDrawn( u32 param = 0 ) const _IRR_OVERRIDE_;
+		u32 getPrimitiveCountDrawn( u32 param = 0 ) const override;
 
 		//! \return Returns the name of the video driver. Example: In case of the DIRECT3D8
 		//! driver, it would return "Direct3D8.1".
-		virtual const wchar_t* getName() const _IRR_OVERRIDE_;
+		const wchar_t* getName() const override;
 
 		//! Sets the dynamic ambient light color. The default color is
 		//! (0,0,0,0) which means it is dark.
 		//! \param color: New color of the ambient light.
-		virtual void setAmbientLight(const SColorf& color) _IRR_OVERRIDE_;
+		void setAmbientLight(const SColorf& color) override;
 
 		//! Get the global ambient light currently used by the driver
-		virtual const SColorf& getAmbientLight() const _IRR_OVERRIDE_;
+		const SColorf& getAmbientLight() const override;
 
 		//! Adds an external image loader to the engine.
-		virtual void addExternalImageLoader(IImageLoader* loader) _IRR_OVERRIDE_;
+		void addExternalImageLoader(IImageLoader* loader) override;
 
 		//! Adds an external image writer to the engine.
-		virtual void addExternalImageWriter(IImageWriter* writer) _IRR_OVERRIDE_;
+		void addExternalImageWriter(IImageWriter* writer) override;
 
 		//! Draws a shadow volume into the stencil buffer. To draw a stencil shadow, do
 		//! this: First, draw all geometry. Then use this method, to draw the shadow
 		//! volume. Then, use IVideoDriver::drawStencilShadow() to visualize the shadow.
 		virtual void drawStencilShadowVolume(const core::array<core::vector3df>& triangles,
-			bool zfail=true, u32 debugDataVisible=0) _IRR_OVERRIDE_;
+			bool zfail=true, u32 debugDataVisible=0) override;
 
 		//! Fills the stencil shadow with color. After the shadow volume has been drawn
 		//! into the stencil buffer using IVideoDriver::drawStencilShadowVolume(), use this
@@ -279,46 +279,46 @@ namespace video
 			video::SColor leftUpEdge = video::SColor(0,0,0,0),
 			video::SColor rightUpEdge = video::SColor(0,0,0,0),
 			video::SColor leftDownEdge = video::SColor(0,0,0,0),
-			video::SColor rightDownEdge = video::SColor(0,0,0,0)) _IRR_OVERRIDE_;
+			video::SColor rightDownEdge = video::SColor(0,0,0,0)) override;
 
 
 		//! Removes a texture from the texture cache and deletes it, freeing lot of
 		//! memory.
-		virtual void removeTexture(ITexture* texture) _IRR_OVERRIDE_;
+		void removeTexture(ITexture* texture) override;
 
 		//! Removes all texture from the texture cache and deletes them, freeing lot of
 		//! memory.
-		virtual void removeAllTextures() _IRR_OVERRIDE_;
+		void removeAllTextures() override;
 
 		//! Creates a render target texture.
 		virtual ITexture* addRenderTargetTexture(const core::dimension2d<u32>& size,
-			const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) _IRR_OVERRIDE_;
+			const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) override;
 
 		//! Creates a render target texture for a cubemap
 		ITexture* addRenderTargetTextureCubemap(const irr::u32 sideLen,
-				const io::path& name, const ECOLOR_FORMAT format) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format) override;
 
 		//! Creates an 1bit alpha channel of the texture based of an color key.
-		virtual void makeColorKeyTexture(video::ITexture* texture, video::SColor color, bool zeroTexels) const _IRR_OVERRIDE_;
+		void makeColorKeyTexture(video::ITexture* texture, video::SColor color, bool zeroTexels) const override;
 
 		//! Creates an 1bit alpha channel of the texture based of an color key position.
 		virtual void makeColorKeyTexture(video::ITexture* texture, core::position2d<s32> colorKeyPixelPos,
-			bool zeroTexels) const _IRR_OVERRIDE_;
+			bool zeroTexels) const override;
 
 		//! Returns the maximum amount of primitives (mostly vertices) which
 		//! the device is able to render with one drawIndexedTriangleList
 		//! call.
-		virtual u32 getMaximalPrimitiveCount() const _IRR_OVERRIDE_;
+		u32 getMaximalPrimitiveCount() const override;
 
 		//! Enables or disables a texture creation flag.
-		virtual void setTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag, bool enabled) _IRR_OVERRIDE_;
+		void setTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag, bool enabled) override;
 
 		//! Returns if a texture creation flag is enabled or disabled.
-		virtual bool getTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag) const _IRR_OVERRIDE_;
+		bool getTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag) const override;
 
-		virtual core::array<IImage*> createImagesFromFile(const io::path& filename, E_TEXTURE_TYPE* type = 0) _IRR_OVERRIDE_;
+		core::array<IImage*> createImagesFromFile(const io::path& filename, E_TEXTURE_TYPE* type = 0) override;
 
-		virtual core::array<IImage*> createImagesFromFile(io::IReadFile* file, E_TEXTURE_TYPE* type = 0) _IRR_OVERRIDE_;
+		core::array<IImage*> createImagesFromFile(io::IReadFile* file, E_TEXTURE_TYPE* type = 0) override;
 
 		//! Creates a software image from a byte array.
 		/** \param useForeignMemory: If true, the image will use the data pointer
@@ -326,33 +326,33 @@ namespace video
 		data when the image will be destructed. If false, the memory will by copied. */
 		virtual IImage* createImageFromData(ECOLOR_FORMAT format,
 			const core::dimension2d<u32>& size, void *data, bool ownForeignMemory = false,
-			bool deleteMemory = true) _IRR_OVERRIDE_;
+			bool deleteMemory = true) override;
 
 		//! Creates an empty software image.
-		virtual IImage* createImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		IImage* createImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size) override;
 
 		//! Creates a software image from another image.
-		virtual IImage* createImage(ECOLOR_FORMAT format, IImage *imageToCopy) _IRR_OVERRIDE_;
+		IImage* createImage(ECOLOR_FORMAT format, IImage *imageToCopy) override;
 
 		//! Creates a software image from part of another image.
 		virtual IImage* createImage(IImage* imageToCopy,
 				const core::position2d<s32>& pos,
-				const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+				const core::dimension2d<u32>& size) override;
 
 		//! Creates a software image from part of a texture.
 		virtual IImage* createImage(ITexture* texture,
 				const core::position2d<s32>& pos,
-				const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+				const core::dimension2d<u32>& size) override;
 
 		//! Draws a mesh buffer
-		virtual void drawMeshBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		void drawMeshBuffer(const scene::IMeshBuffer* mb) override;
 
 		//! Draws the normals of a mesh buffer
 		virtual void drawMeshBufferNormals(const scene::IMeshBuffer* mb, f32 length=10.f,
-			SColor color=0xffffffff) _IRR_OVERRIDE_;
+			SColor color=0xffffffff) override;
 
 		//! Check if the driver supports creating textures with the given color format
-		virtual bool queryTextureFormat(ECOLOR_FORMAT format) const _IRR_OVERRIDE_
+		bool queryTextureFormat(ECOLOR_FORMAT format) const override
 		{
 			return false;
 		}
@@ -404,10 +404,10 @@ namespace video
 
 	public:
 		//! Remove hardware buffer
-		virtual void removeHardwareBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		void removeHardwareBuffer(const scene::IMeshBuffer* mb) override;
 
 		//! Remove all hardware buffers
-		virtual void removeAllHardwareBuffers() _IRR_OVERRIDE_;
+		void removeAllHardwareBuffers() override;
 
 		//! Update all hardware buffers, remove unused ones
 		virtual void updateAllHardwareBuffers();
@@ -418,68 +418,68 @@ namespace video
 		//! Create occlusion query.
 		/** Use node for identification and mesh for occlusion test. */
 		virtual void addOcclusionQuery(scene::ISceneNode* node,
-				const scene::IMesh* mesh=0) _IRR_OVERRIDE_;
+				const scene::IMesh* mesh=0) override;
 
 		//! Remove occlusion query.
-		virtual void removeOcclusionQuery(scene::ISceneNode* node) _IRR_OVERRIDE_;
+		void removeOcclusionQuery(scene::ISceneNode* node) override;
 
 		//! Remove all occlusion queries.
-		virtual void removeAllOcclusionQueries() _IRR_OVERRIDE_;
+		void removeAllOcclusionQueries() override;
 
 		//! Run occlusion query. Draws mesh stored in query.
 		/** If the mesh shall not be rendered visible, use
 		overrideMaterial to disable the color and depth buffer. */
-		virtual void runOcclusionQuery(scene::ISceneNode* node, bool visible=false) _IRR_OVERRIDE_;
+		void runOcclusionQuery(scene::ISceneNode* node, bool visible=false) override;
 
 		//! Run all occlusion queries. Draws all meshes stored in queries.
 		/** If the meshes shall not be rendered visible, use
 		overrideMaterial to disable the color and depth buffer. */
-		virtual void runAllOcclusionQueries(bool visible=false) _IRR_OVERRIDE_;
+		void runAllOcclusionQueries(bool visible=false) override;
 
 		//! Update occlusion query. Retrieves results from GPU.
 		/** If the query shall not block, set the flag to false.
 		Update might not occur in this case, though */
-		virtual void updateOcclusionQuery(scene::ISceneNode* node, bool block=true) _IRR_OVERRIDE_;
+		void updateOcclusionQuery(scene::ISceneNode* node, bool block=true) override;
 
 		//! Update all occlusion queries. Retrieves results from GPU.
 		/** If the query shall not block, set the flag to false.
 		Update might not occur in this case, though */
-		virtual void updateAllOcclusionQueries(bool block=true) _IRR_OVERRIDE_;
+		void updateAllOcclusionQueries(bool block=true) override;
 
 		//! Return query result.
 		/** Return value is the number of visible pixels/fragments.
 		The value is a safe approximation, i.e. can be larger than the
 		actual value of pixels. */
-		virtual u32 getOcclusionQueryResult(scene::ISceneNode* node) const _IRR_OVERRIDE_;
+		u32 getOcclusionQueryResult(scene::ISceneNode* node) const override;
 
 		//! Create render target.
-		virtual IRenderTarget* addRenderTarget() _IRR_OVERRIDE_;
+		IRenderTarget* addRenderTarget() override;
 
 		//! Remove render target.
-		virtual void removeRenderTarget(IRenderTarget* renderTarget) _IRR_OVERRIDE_;
+		void removeRenderTarget(IRenderTarget* renderTarget) override;
 
 		//! Remove all render targets.
-		virtual void removeAllRenderTargets() _IRR_OVERRIDE_;
+		void removeAllRenderTargets() override;
 
 		//! Only used by the engine internally.
 		/** Used to notify the driver that the window was resized. */
-		virtual void OnResize(const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void OnResize(const core::dimension2d<u32>& size) override;
 
 		//! Adds a new material renderer to the video device.
 		virtual s32 addMaterialRenderer(IMaterialRenderer* renderer,
-				const char* name = 0) _IRR_OVERRIDE_;
+				const char* name = 0) override;
 
 		//! Returns driver and operating system specific data about the IVideoDriver.
-		virtual const SExposedVideoData& getExposedVideoData() _IRR_OVERRIDE_;
+		const SExposedVideoData& getExposedVideoData() override;
 
 		//! Returns type of video driver
-		virtual E_DRIVER_TYPE getDriverType() const _IRR_OVERRIDE_;
+		E_DRIVER_TYPE getDriverType() const override;
 
 		//! Returns the transformation set by setTransform
-		virtual const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const _IRR_OVERRIDE_;
+		const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const override;
 
 		//! Returns pointer to the IGPUProgrammingServices interface.
-		virtual IGPUProgrammingServices* getGPUProgrammingServices() _IRR_OVERRIDE_;
+		IGPUProgrammingServices* getGPUProgrammingServices() override;
 
 		//! Adds a new material renderer to the VideoDriver, using pixel and/or
 		//! vertex shaders to render geometry.
@@ -487,7 +487,7 @@ namespace video
 			const c8* pixelShaderProgram = 0,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData=0) _IRR_OVERRIDE_;
+			s32 userData=0) override;
 
 		//! Like IGPUProgrammingServices::addShaderMaterial(), but tries to load the
 		//! programs from files.
@@ -495,7 +495,7 @@ namespace video
 			io::IReadFile* pixelShaderProgram = 0,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData=0) _IRR_OVERRIDE_;
+			s32 userData=0) override;
 
 		//! Like IGPUProgrammingServices::addShaderMaterial(), but tries to load the
 		//! programs from files.
@@ -503,16 +503,16 @@ namespace video
 			const io::path& pixelShaderProgramFileName,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData=0) _IRR_OVERRIDE_;
+			s32 userData=0) override;
 
 		//! Returns pointer to material renderer or null
-		virtual IMaterialRenderer* getMaterialRenderer(u32 idx) const _IRR_OVERRIDE_;
+		IMaterialRenderer* getMaterialRenderer(u32 idx) const override;
 
 		//! Returns amount of currently available material renderers.
-		virtual u32 getMaterialRendererCount() const _IRR_OVERRIDE_;
+		u32 getMaterialRendererCount() const override;
 
 		//! Returns name of the material renderer
-		virtual const char* getMaterialRendererName(u32 idx) const _IRR_OVERRIDE_;
+		const char* getMaterialRendererName(u32 idx) const override;
 
 		//! Adds a new material renderer to the VideoDriver, based on a high level shading
 		//! language. Currently only HLSL in D3D9 is supported.
@@ -531,7 +531,7 @@ namespace video
 			u32 verticesOut = 0,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData = 0) _IRR_OVERRIDE_;
+			s32 userData = 0) override;
 
 		//! Like IGPUProgrammingServices::addShaderMaterial() (look there for a detailed description),
 		//! but tries to load the programs from files.
@@ -550,7 +550,7 @@ namespace video
 			u32 verticesOut = 0,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData = 0) _IRR_OVERRIDE_;
+			s32 userData = 0) override;
 
 		//! Like IGPUProgrammingServices::addShaderMaterial() (look there for a detailed description),
 		//! but tries to load the programs from files.
@@ -569,72 +569,72 @@ namespace video
 			u32 verticesOut = 0,
 			IShaderConstantSetCallBack* callback = 0,
 			E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-			s32 userData = 0) _IRR_OVERRIDE_;
+			s32 userData = 0) override;
 
 		//! Returns a pointer to the mesh manipulator.
-		virtual scene::IMeshManipulator* getMeshManipulator() _IRR_OVERRIDE_;
+		scene::IMeshManipulator* getMeshManipulator() override;
 
-		virtual void clearBuffers(u16 flag, SColor color = SColor(255,0,0,0), f32 depth = 1.f, u8 stencil = 0) _IRR_OVERRIDE_;
+		void clearBuffers(u16 flag, SColor color = SColor(255,0,0,0), f32 depth = 1.f, u8 stencil = 0) override;
 
 		//! Returns an image created from the last rendered frame.
-		virtual IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) _IRR_OVERRIDE_;
+		IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) override;
 
 		//! Writes the provided image to disk file
-		virtual bool writeImageToFile(IImage* image, const io::path& filename, u32 param = 0) _IRR_OVERRIDE_;
+		bool writeImageToFile(IImage* image, const io::path& filename, u32 param = 0) override;
 
 		//! Writes the provided image to a file.
-		virtual bool writeImageToFile(IImage* image, io::IWriteFile * file, u32 param = 0) _IRR_OVERRIDE_;
+		bool writeImageToFile(IImage* image, io::IWriteFile * file, u32 param = 0) override;
 
 		//! Sets the name of a material renderer.
-		virtual void setMaterialRendererName(s32 idx, const char* name) _IRR_OVERRIDE_;
+		void setMaterialRendererName(s32 idx, const char* name) override;
 
 		//! Swap the material renderers used for certain id's
-		virtual void swapMaterialRenderers(u32 idx1, u32 idx2, bool swapNames) _IRR_OVERRIDE_;
+		void swapMaterialRenderers(u32 idx1, u32 idx2, bool swapNames) override;
 
 		//! looks if the image is already loaded
-		virtual video::ITexture* findTexture(const io::path& filename) _IRR_OVERRIDE_;
+		video::ITexture* findTexture(const io::path& filename) override;
 
 		//! Set/unset a clipping plane.
 		//! There are at least 6 clipping planes available for the user to set at will.
 		//! \param index: The plane index. Must be between 0 and MaxUserClipPlanes.
 		//! \param plane: The plane itself.
 		//! \param enable: If true, enable the clipping plane else disable it.
-		virtual bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) _IRR_OVERRIDE_;
+		bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) override;
 
 		//! Enable/disable a clipping plane.
 		//! There are at least 6 clipping planes available for the user to set at will.
 		//! \param index: The plane index. Must be between 0 and MaxUserClipPlanes.
 		//! \param enable: If true, enable the clipping plane else disable it.
-		virtual void enableClipPlane(u32 index, bool enable) _IRR_OVERRIDE_;
+		void enableClipPlane(u32 index, bool enable) override;
 
 		//! Returns the graphics card vendor name.
-		virtual core::stringc getVendorInfo() _IRR_OVERRIDE_ {return "Not available on this driver.";}
+		core::stringc getVendorInfo() override {return "Not available on this driver.";}
 
 		//! Set the minimum number of vertices for which a hw buffer will be created
 		/** \param count Number of vertices to set as minimum. */
-		virtual void setMinHardwareBufferVertexCount(u32 count) _IRR_OVERRIDE_;
+		void setMinHardwareBufferVertexCount(u32 count) override;
 
 		//! Get the global Material, which might override local materials.
 		/** Depending on the enable flags, values from this Material
 		are used to override those of local materials of some
 		meshbuffer being rendered. */
-		virtual SOverrideMaterial& getOverrideMaterial() _IRR_OVERRIDE_;
+		SOverrideMaterial& getOverrideMaterial() override;
 
 		//! Get the 2d override material for altering its values
-		virtual SMaterial& getMaterial2D() _IRR_OVERRIDE_;
+		SMaterial& getMaterial2D() override;
 
 		//! Enable the 2d override material
-		virtual void enableMaterial2D(bool enable=true) _IRR_OVERRIDE_;
+		void enableMaterial2D(bool enable=true) override;
 
 		//! Only used by the engine internally.
-		virtual void setAllowZWriteOnTransparent(bool flag) _IRR_OVERRIDE_
+		void setAllowZWriteOnTransparent(bool flag) override
 		{ AllowZWriteOnTransparent=flag; }
 
 		//! Returns the maximum texture size supported.
-		virtual core::dimension2du getMaxTextureSize() const _IRR_OVERRIDE_;
+		core::dimension2du getMaxTextureSize() const override;
 
 		//! Used by some SceneNodes to check if a material should be rendered in the transparent render pass
-		virtual bool needsTransparentRenderPass(const irr::video::SMaterial& material) const _IRR_OVERRIDE_;
+		bool needsTransparentRenderPass(const irr::video::SMaterial& material) const override;
 
 		//! Color conversion convenience function
 		/** Convert an image (as array of pixels) from source to destination
@@ -647,13 +647,13 @@ namespace video
 		\param dF Color format of destination
 		*/
 		virtual void convertColor(const void* sP, ECOLOR_FORMAT sF, s32 sN,
-				void* dP, ECOLOR_FORMAT dF) const _IRR_OVERRIDE_;
+				void* dP, ECOLOR_FORMAT dF) const override;
 
 		//! deprecated method
 		virtual ITexture* createRenderTargetTexture(const core::dimension2d<u32>& size,
 				const c8* name=0);
 
-		virtual bool checkDriverReset() _IRR_OVERRIDE_ {return false;}
+		bool checkDriverReset() override {return false;}
 	protected:
 
 		//! deletes all textures
@@ -719,9 +719,9 @@ namespace video
 
 			void setSize(const core::dimension2d<u32>& size) { Size = OriginalSize = size; }
 
-			virtual void* lock(E_TEXTURE_LOCK_MODE mode = ETLM_READ_WRITE, u32 mipmapLevel=0, u32 layer = 0, E_TEXTURE_LOCK_FLAGS lockFlags = ETLF_FLIP_Y_UP_RTT) _IRR_OVERRIDE_ { return 0; }
-			virtual void unlock()_IRR_OVERRIDE_ {}
-			virtual void regenerateMipMapLevels(void* data = 0, u32 layer = 0) _IRR_OVERRIDE_ {}
+			void* lock(E_TEXTURE_LOCK_MODE mode = ETLM_READ_WRITE, u32 mipmapLevel=0, u32 layer = 0, E_TEXTURE_LOCK_FLAGS lockFlags = ETLF_FLIP_Y_UP_RTT) override { return 0; }
+			void unlock()override {}
+			void regenerateMipMapLevels(void* data = 0, u32 layer = 0) override {}
 		};
 		core::array<SSurface> Textures;
 

--- a/source/Irrlicht/COBJMeshFileLoader.h
+++ b/source/Irrlicht/COBJMeshFileLoader.h
@@ -30,13 +30,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".obj")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! creates/loads an animated mesh from the file.
 	//! \return Pointer to the created mesh. Returns 0 if loading failed.
 	//! If you no longer need the mesh, you should call IAnimatedMesh::drop().
 	//! See IReferenceCounted::drop() for more information.
-	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
+	IAnimatedMesh* createMesh(io::IReadFile* file) override;
 
 private:
 

--- a/source/Irrlicht/COGLES2Driver.h
+++ b/source/Irrlicht/COGLES2Driver.h
@@ -42,12 +42,12 @@ namespace video
 		virtual ~COGLES2Driver();
 
 		virtual bool beginScene(u16 clearFlag, SColor clearColor = SColor(255, 0, 0, 0), f32 clearDepth = 1.f, u8 clearStencil = 0,
-			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) _IRR_OVERRIDE_;
+			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) override;
 
-		virtual bool endScene() _IRR_OVERRIDE_;
+		bool endScene() override;
 
 		//! sets transformation
-		virtual void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) _IRR_OVERRIDE_;
+		void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) override;
 
 		struct SHWBufferLink_opengl : public SHWBufferLink
 		{
@@ -67,41 +67,41 @@ namespace video
 		bool updateIndexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
 
 		//! updates hardware buffer if needed
-		virtual bool updateHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		bool updateHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Create hardware buffer from mesh
-		virtual SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) override;
 
 		//! Delete hardware buffer (only some drivers can)
-		virtual void deleteHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void deleteHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Draw hardware buffer
-		virtual void drawHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void drawHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-		virtual IRenderTarget* addRenderTarget() _IRR_OVERRIDE_;
+		IRenderTarget* addRenderTarget() override;
 
 		//! draws a vertex primitive list
 		virtual void drawVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
-				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) _IRR_OVERRIDE_;
+				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
 
 		//! queries the features of the driver, returns true if feature is available
-		virtual bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const _IRR_OVERRIDE_
+		bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override
 		{
 			return FeatureEnabled[feature] && COGLES2ExtensionHandler::queryFeature(feature);
 		}
 
 		//! Sets a material.
-		virtual void setMaterial(const SMaterial& material) _IRR_OVERRIDE_;
+		void setMaterial(const SMaterial& material) override;
 
 		virtual void draw2DImage(const video::ITexture* texture,
 				const core::position2d<s32>& destPos,
 				const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-				SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::rect<s32>& destRect,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) override;
 
 		// internally used
 		virtual void draw2DImage(const video::ITexture* texture, u32 layer, bool flip);
@@ -113,110 +113,110 @@ namespace video
 				const core::array<s32>& indices, s32 kerningWidth = 0,
 				const core::rect<s32>* clipRect = 0,
 				SColor color = SColor(255, 255, 255, 255),
-				bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture = false) override;
 
 		void draw2DImageBatch(const video::ITexture* texture,
 				const core::array<core::position2d<s32> >& positions,
 				const core::array<core::rect<s32> >& sourceRects,
 				const core::rect<s32>* clipRect,
 				SColor color,
-				bool useAlphaChannelOfTexture) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture) override;
 
 		//! draw an 2d rectangle
 		virtual void draw2DRectangle(SColor color, const core::rect<s32>& pos,
-				const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip = 0) override;
 
 		//!Draws an 2d rectangle with a gradient.
 		virtual void draw2DRectangle(const core::rect<s32>& pos,
 				SColor colorLeftUp, SColor colorRightUp, SColor colorLeftDown, SColor colorRightDown,
-				const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip = 0) override;
 
 		//! Draws a 2d line.
 		virtual void draw2DLine(const core::position2d<s32>& start,
 				const core::position2d<s32>& end,
-				SColor color = SColor(255, 255, 255, 255)) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255)) override;
 
 		//! Draws a single pixel
-		virtual void drawPixel(u32 x, u32 y, const SColor & color) _IRR_OVERRIDE_;
+		void drawPixel(u32 x, u32 y, const SColor & color) override;
 
 		//! Draws a 3d line.
 		virtual void draw3DLine(const core::vector3df& start,
 				const core::vector3df& end,
-				SColor color = SColor(255, 255, 255, 255)) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255)) override;
 
 		//! Draws a pixel
 //			virtual void drawPixel(u32 x, u32 y, const SColor & color);
 
 		//! Returns the name of the video driver.
-		virtual const wchar_t* getName() const _IRR_OVERRIDE_;
+		const wchar_t* getName() const override;
 
 		//! Returns the maximum texture size supported.
-		virtual core::dimension2du getMaxTextureSize() const _IRR_OVERRIDE_;
+		core::dimension2du getMaxTextureSize() const override;
 
 		//! Draws a shadow volume into the stencil buffer.
-		virtual void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) _IRR_OVERRIDE_;
+		void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) override;
 
 		//! Fills the stencil shadow with color.
 		virtual void drawStencilShadow(bool clearStencilBuffer=false,
 			video::SColor leftUpEdge = video::SColor(0,0,0,0),
 			video::SColor rightUpEdge = video::SColor(0,0,0,0),
 			video::SColor leftDownEdge = video::SColor(0,0,0,0),
-			video::SColor rightDownEdge = video::SColor(0,0,0,0)) _IRR_OVERRIDE_;
+			video::SColor rightDownEdge = video::SColor(0,0,0,0)) override;
 
 		//! sets a viewport
-		virtual void setViewPort(const core::rect<s32>& area) _IRR_OVERRIDE_;
+		void setViewPort(const core::rect<s32>& area) override;
 
 		//! Only used internally by the engine
-		virtual void OnResize(const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void OnResize(const core::dimension2d<u32>& size) override;
 
 		//! Returns type of video driver
-		virtual E_DRIVER_TYPE getDriverType() const _IRR_OVERRIDE_;
+		E_DRIVER_TYPE getDriverType() const override;
 
 		//! get color format of the current color buffer
-		virtual ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		ECOLOR_FORMAT getColorFormat() const override;
 
 		//! Returns the transformation set by setTransform
-		virtual const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const _IRR_OVERRIDE_;
+		const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const override;
 
 		//! Can be called by an IMaterialRenderer to make its work easier.
-		virtual void setBasicRenderStates(const SMaterial& material, const SMaterial& lastmaterial, bool resetAllRenderstates) _IRR_OVERRIDE_;
+		void setBasicRenderStates(const SMaterial& material, const SMaterial& lastmaterial, bool resetAllRenderstates) override;
 
 		//! Compare in SMaterial doesn't check texture parameters, so we should call this on each OnRender call.
 		void setTextureRenderStates(const SMaterial& material, bool resetAllRenderstates);
 
 		//! Get a vertex shader constant index.
-		virtual s32 getVertexShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getVertexShaderConstantID(const c8* name) override;
 
 		//! Get a pixel shader constant index.
-		virtual s32 getPixelShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getPixelShaderConstantID(const c8* name) override;
 
 		//! Sets a vertex shader constant.
-		virtual void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount = 1) _IRR_OVERRIDE_;
+		void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount = 1) override;
 
 		//! Sets a pixel shader constant.
-		virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount = 1) _IRR_OVERRIDE_;
+		void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount = 1) override;
 
 		//! Sets a constant for the vertex shader based on an index.
-		virtual bool setVertexShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! Sets a constant for the pixel shader based on an index.
-		virtual bool setPixelShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! Adds a new material renderer to the VideoDriver
 		virtual s32 addShaderMaterial(const c8* vertexShaderProgram, const c8* pixelShaderProgram,
-				IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) _IRR_OVERRIDE_;
+				IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) override;
 
 		//! Adds a new material renderer to the VideoDriver
 		virtual s32 addHighLevelShaderMaterial(
@@ -234,31 +234,31 @@ namespace video
 				u32 verticesOut = 0,
 				IShaderConstantSetCallBack* callback = 0,
 				E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-				s32 userData=0) _IRR_OVERRIDE_;
+				s32 userData=0) override;
 
 		//! Returns pointer to the IGPUProgrammingServices interface.
-		virtual IGPUProgrammingServices* getGPUProgrammingServices() _IRR_OVERRIDE_;
+		IGPUProgrammingServices* getGPUProgrammingServices() override;
 
 		//! Returns a pointer to the IVideoDriver interface.
-		virtual IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+		IVideoDriver* getVideoDriver() override;
 
 		//! Returns the maximum amount of primitives
-		virtual u32 getMaximalPrimitiveCount() const _IRR_OVERRIDE_;
+		u32 getMaximalPrimitiveCount() const override;
 
 		virtual ITexture* addRenderTargetTexture(const core::dimension2d<u32>& size,
-				const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) override;
 
 		//! Creates a render target texture for a cubemap
 		ITexture* addRenderTargetTextureCubemap(const irr::u32 sideLen,
-				const io::path& name, const ECOLOR_FORMAT format) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format) override;
 
 		virtual bool setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SColor clearColor = SColor(255, 0, 0, 0),
-			f32 clearDepth = 1.f, u8 clearStencil = 0) _IRR_OVERRIDE_;
+			f32 clearDepth = 1.f, u8 clearStencil = 0) override;
 
-		virtual void clearBuffers(u16 flag, SColor color = SColor(255, 0, 0, 0), f32 depth = 1.f, u8 stencil = 0) _IRR_OVERRIDE_;
+		void clearBuffers(u16 flag, SColor color = SColor(255, 0, 0, 0), f32 depth = 1.f, u8 stencil = 0) override;
 
 		//! Returns an image created from the last rendered frame.
-		virtual IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) _IRR_OVERRIDE_;
+		IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) override;
 
 		//! checks if an OpenGL error has happened and prints it (+ some internal code which is usually the line number)
 		bool testGLError(int code=0);
@@ -267,7 +267,7 @@ namespace video
 		bool testEGLError();
 
 		//! Set/unset a clipping plane.
-		virtual bool setClipPlane(u32 index, const core::plane3df& plane, bool enable = false) _IRR_OVERRIDE_;
+		bool setClipPlane(u32 index, const core::plane3df& plane, bool enable = false) override;
 
 		//! returns the current amount of user clip planes set.
 		u32 getClipPlaneCount() const;
@@ -276,21 +276,21 @@ namespace video
 		const core::plane3df& getClipPlane(u32 index) const;
 
 		//! Enable/disable a clipping plane.
-		virtual void enableClipPlane(u32 index, bool enable) _IRR_OVERRIDE_;
+		void enableClipPlane(u32 index, bool enable) override;
 
 		//! Returns the graphics card vendor name.
-		virtual core::stringc getVendorInfo() _IRR_OVERRIDE_
+		core::stringc getVendorInfo() override
 		{
 			return VendorName;
 		};
 
-		virtual void removeTexture(ITexture* texture) _IRR_OVERRIDE_;
+		void removeTexture(ITexture* texture) override;
 
 		//! Check if the driver supports creating textures with the given color format
-		virtual bool queryTextureFormat(ECOLOR_FORMAT format) const _IRR_OVERRIDE_;
+		bool queryTextureFormat(ECOLOR_FORMAT format) const override;
 
 		//! Used by some SceneNodes to check if a material should be rendered in the transparent render pass
-		virtual bool needsTransparentRenderPass(const irr::video::SMaterial& material) const _IRR_OVERRIDE_;
+		bool needsTransparentRenderPass(const irr::video::SMaterial& material) const override;
 
 		//! Convert E_BLEND_FACTOR to OpenGL equivalent
 		GLenum getGLBlend(E_BLEND_FACTOR factor) const;
@@ -312,9 +312,9 @@ namespace video
 
 		void chooseMaterial2D();
 
-		virtual ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) override;
 
-		virtual ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) override;
 
 		//! Map Irrlicht wrap mode to OpenGL enum
 		GLint getTextureWrapMode(u8 clamp) const;

--- a/source/Irrlicht/COGLES2MaterialRenderer.h
+++ b/source/Irrlicht/COGLES2MaterialRenderer.h
@@ -53,20 +53,20 @@ public:
 
 	virtual s32 getRenderCapability() const;
 
-	virtual void setBasicRenderStates(const SMaterial& material, const SMaterial& lastMaterial, bool resetAllRenderstates) _IRR_OVERRIDE_;
+	void setBasicRenderStates(const SMaterial& material, const SMaterial& lastMaterial, bool resetAllRenderstates) override;
 
-	virtual s32 getVertexShaderConstantID(const c8* name) _IRR_OVERRIDE_;
-	virtual s32 getPixelShaderConstantID(const c8* name) _IRR_OVERRIDE_;
-	virtual void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
-	virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+	s32 getVertexShaderConstantID(const c8* name) override;
+	s32 getPixelShaderConstantID(const c8* name) override;
+	void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
+	void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
+	bool setVertexShaderConstant(s32 index, const f32* floats, int count) override;
+	bool setVertexShaderConstant(s32 index, const s32* ints, int count) override;
+	bool setVertexShaderConstant(s32 index, const u32* ints, int count) override;
+	bool setPixelShaderConstant(s32 index, const f32* floats, int count) override;
+	bool setPixelShaderConstant(s32 index, const s32* ints, int count) override;
+	bool setPixelShaderConstant(s32 index, const u32* ints, int count) override;
 
-	virtual IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+	IVideoDriver* getVideoDriver() override;
 
 protected:
 

--- a/source/Irrlicht/COGLESDriver.h
+++ b/source/Irrlicht/COGLESDriver.h
@@ -35,12 +35,12 @@ namespace video
 		virtual ~COGLES1Driver();
 
 		virtual bool beginScene(u16 clearFlag, SColor clearColor = SColor(255, 0, 0, 0), f32 clearDepth = 1.f, u8 clearStencil = 0,
-			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) _IRR_OVERRIDE_;
+			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) override;
 
-		virtual bool endScene() _IRR_OVERRIDE_;
+		bool endScene() override;
 
 		//! sets transformation
-		virtual void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) _IRR_OVERRIDE_;
+		void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) override;
 
 
 		struct SHWBufferLink_opengl : public SHWBufferLink
@@ -59,43 +59,43 @@ namespace video
 		bool updateIndexHardwareBuffer(SHWBufferLink_opengl *HWBuffer);
 
 		//! updates hardware buffer if needed
-		virtual bool updateHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		bool updateHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Create hardware buffer from mesh
-		virtual SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) override;
 
 		//! Delete hardware buffer (only some drivers can)
-		virtual void deleteHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void deleteHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Draw hardware buffer
-		virtual void drawHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void drawHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
-		virtual IRenderTarget* addRenderTarget() _IRR_OVERRIDE_;
+		IRenderTarget* addRenderTarget() override;
 
 		//! draws a vertex primitive list
 		virtual void drawVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
-				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) _IRR_OVERRIDE_;
+				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
 
 		void drawVertexPrimitiveList2d3d(const void* vertices, u32 vertexCount, const void* indexList, u32 primitiveCount, E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType=EIT_16BIT, bool threed=true);
 
 		//! queries the features of the driver, returns true if feature is available
-		virtual bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const _IRR_OVERRIDE_
+		bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override
 		{
 //			return FeatureEnabled[feature] && COGLES1ExtensionHandler::queryFeature(feature);
 			return COGLES1ExtensionHandler::queryFeature(feature);
 		}
 
 		//! Sets a material.
-		virtual void setMaterial(const SMaterial& material) _IRR_OVERRIDE_;
+		void setMaterial(const SMaterial& material) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::position2d<s32>& destPos,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::rect<s32>& destRect,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, u32 layer, bool flip);
 
@@ -106,7 +106,7 @@ namespace video
 				const core::array<s32>& indices, s32 kerningWidth = 0,
 				const core::rect<s32>* clipRect=0,
 				SColor color=SColor(255,255,255,255),
-				bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture=false) override;
 
 		//! draws a set of 2d images, using a color and the alpha channel of the texture if desired.
 		virtual void draw2DImageBatch(const video::ITexture* texture,
@@ -114,105 +114,105 @@ namespace video
 				const core::array<core::rect<s32> >& sourceRects,
 				const core::rect<s32>* clipRect=0,
 				SColor color=SColor(255,255,255,255),
-				bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture=false) override;
 
 		//! draw an 2d rectangle
 		virtual void draw2DRectangle(SColor color, const core::rect<s32>& pos,
-			const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+			const core::rect<s32>* clip = 0) override;
 
 		//!Draws an 2d rectangle with a gradient.
 		virtual void draw2DRectangle(const core::rect<s32>& pos,
 			SColor colorLeftUp, SColor colorRightUp, SColor colorLeftDown, SColor colorRightDown,
-			const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+			const core::rect<s32>* clip = 0) override;
 
 		//! Draws a 2d line.
 		virtual void draw2DLine(const core::position2d<s32>& start,
 					const core::position2d<s32>& end,
-					SColor color=SColor(255,255,255,255)) _IRR_OVERRIDE_;
+					SColor color=SColor(255,255,255,255)) override;
 
 		//! Draws a single pixel
-		virtual void drawPixel(u32 x, u32 y, const SColor & color) _IRR_OVERRIDE_;
+		void drawPixel(u32 x, u32 y, const SColor & color) override;
 
 		//! Draws a 3d line.
 		virtual void draw3DLine(const core::vector3df& start,
 					const core::vector3df& end,
-					SColor color = SColor(255,255,255,255)) _IRR_OVERRIDE_;
+					SColor color = SColor(255,255,255,255)) override;
 
 		//! Returns the name of the video driver.
-		virtual const wchar_t* getName() const _IRR_OVERRIDE_;
+		const wchar_t* getName() const override;
 
 		//! Sets the dynamic ambient light color.
-		virtual void setAmbientLight(const SColorf& color) _IRR_OVERRIDE_;
+		void setAmbientLight(const SColorf& color) override;
 
 		//! Draws a shadow volume into the stencil buffer.
-		virtual void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) _IRR_OVERRIDE_;
+		void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) override;
 
 		//! Fills the stencil shadow with color.
 		virtual void drawStencilShadow(bool clearStencilBuffer=false,
 			video::SColor leftUpEdge = video::SColor(0,0,0,0),
 			video::SColor rightUpEdge = video::SColor(0,0,0,0),
 			video::SColor leftDownEdge = video::SColor(0,0,0,0),
-			video::SColor rightDownEdge = video::SColor(0,0,0,0)) _IRR_OVERRIDE_;
+			video::SColor rightDownEdge = video::SColor(0,0,0,0)) override;
 
 		//! sets a viewport
-		virtual void setViewPort(const core::rect<s32>& area) _IRR_OVERRIDE_;
+		void setViewPort(const core::rect<s32>& area) override;
 
 		//! Sets the fog mode.
 		virtual void setFog(SColor color, E_FOG_TYPE fogType, f32 start,
-			f32 end, f32 density, bool pixelFog, bool rangeFog) _IRR_OVERRIDE_;
+			f32 end, f32 density, bool pixelFog, bool rangeFog) override;
 
 		//! Only used internally by the engine
-		virtual void OnResize(const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void OnResize(const core::dimension2d<u32>& size) override;
 
 		//! Returns type of video driver
-		virtual E_DRIVER_TYPE getDriverType() const _IRR_OVERRIDE_;
+		E_DRIVER_TYPE getDriverType() const override;
 
 		//! get color format of the current color buffer
-		virtual ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		ECOLOR_FORMAT getColorFormat() const override;
 
 		//! Returns the transformation set by setTransform
-		virtual const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const _IRR_OVERRIDE_;
+		const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const override;
 
 		//! Can be called by an IMaterialRenderer to make its work easier.
 		virtual void setBasicRenderStates(const SMaterial& material, const SMaterial& lastmaterial,
-			bool resetAllRenderstates) _IRR_OVERRIDE_;
+			bool resetAllRenderstates) override;
 
 		//! Compare in SMaterial doesn't check texture parameters, so we should call this on each OnRender call.
 		virtual void setTextureRenderStates(const SMaterial& material, bool resetAllRenderstates);
 
 		//! Get a vertex shader constant index.
-		virtual s32 getVertexShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getVertexShaderConstantID(const c8* name) override;
 
 		//! Get a pixel shader constant index.
-		virtual s32 getPixelShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getPixelShaderConstantID(const c8* name) override;
 
 		//! Sets a constant for the vertex shader based on an index.
-		virtual bool setVertexShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! Sets a constant for the pixel shader based on an index.
-		virtual bool setPixelShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! Sets a vertex shader constant.
-		virtual void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
+		void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
 
 		//! Sets a pixel shader constant.
-		virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
+		void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
 
 		//! Adds a new material renderer to the VideoDriver
 		virtual s32 addShaderMaterial(const c8* vertexShaderProgram, const c8* pixelShaderProgram,
-			IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) _IRR_OVERRIDE_;
+			IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) override;
 
 		//! Adds a new material renderer to the VideoDriver
 		virtual s32 addHighLevelShaderMaterial(const c8* vertexShaderProgram, const c8* vertexShaderEntryPointName,
@@ -220,57 +220,57 @@ namespace video
 			E_PIXEL_SHADER_TYPE psCompileTarget, const c8* geometryShaderProgram, const c8* geometryShaderEntryPointName,
 			E_GEOMETRY_SHADER_TYPE gsCompileTarget, scene::E_PRIMITIVE_TYPE inType, scene::E_PRIMITIVE_TYPE outType,
 			u32 verticesOut, IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial,
-			s32 userData) _IRR_OVERRIDE_;
+			s32 userData) override;
 
 		//! Returns pointer to the IGPUProgrammingServices interface.
-		virtual IGPUProgrammingServices* getGPUProgrammingServices() _IRR_OVERRIDE_;
+		IGPUProgrammingServices* getGPUProgrammingServices() override;
 
 		//! Returns a pointer to the IVideoDriver interface.
-		virtual IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+		IVideoDriver* getVideoDriver() override;
 
 		//! Returns the maximum amount of primitives
-		virtual u32 getMaximalPrimitiveCount() const _IRR_OVERRIDE_;
+		u32 getMaximalPrimitiveCount() const override;
 
 		virtual ITexture* addRenderTargetTexture(const core::dimension2d<u32>& size,
-			const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) _IRR_OVERRIDE_;
+			const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) override;
 
 		//! Creates a render target texture for a cubemap
 		ITexture* addRenderTargetTextureCubemap(const irr::u32 sideLen,
-				const io::path& name, const ECOLOR_FORMAT format) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format) override;
 
 		virtual bool setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SColor clearColor = SColor(255, 0, 0, 0),
-			f32 clearDepth = 1.f, u8 clearStencil = 0) _IRR_OVERRIDE_;
+			f32 clearDepth = 1.f, u8 clearStencil = 0) override;
 
-		virtual void clearBuffers(u16 flag, SColor color = SColor(255, 0, 0, 0), f32 depth = 1.f, u8 stencil = 0) _IRR_OVERRIDE_;
+		void clearBuffers(u16 flag, SColor color = SColor(255, 0, 0, 0), f32 depth = 1.f, u8 stencil = 0) override;
 
 		//! Returns an image created from the last rendered frame.
-		virtual IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) _IRR_OVERRIDE_;
+		IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) override;
 
 		//! checks if an OpenGL error has happened and prints it (+ some internal code which is usually the line number)
 		bool testGLError(int code=0);
 
 		//! Set/unset a clipping plane.
-		virtual bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) _IRR_OVERRIDE_;
+		bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) override;
 
 		//! Enable/disable a clipping plane.
-		virtual void enableClipPlane(u32 index, bool enable) _IRR_OVERRIDE_;
+		void enableClipPlane(u32 index, bool enable) override;
 
 		//! Returns the graphics card vendor name.
-		virtual core::stringc getVendorInfo() _IRR_OVERRIDE_
+		core::stringc getVendorInfo() override
 		{
 			return VendorName;
 		}
 
 		//! Get the maximal texture size for this driver
-		virtual core::dimension2du getMaxTextureSize() const _IRR_OVERRIDE_;
+		core::dimension2du getMaxTextureSize() const override;
 
-		virtual void removeTexture(ITexture* texture) _IRR_OVERRIDE_;
+		void removeTexture(ITexture* texture) override;
 
 		//! Check if the driver supports creating textures with the given color format
-		virtual bool queryTextureFormat(ECOLOR_FORMAT format) const _IRR_OVERRIDE_;
+		bool queryTextureFormat(ECOLOR_FORMAT format) const override;
 
 		//! Used by some SceneNodes to check if a material should be rendered in the transparent render pass
-		virtual bool needsTransparentRenderPass(const irr::video::SMaterial& material) const _IRR_OVERRIDE_;
+		bool needsTransparentRenderPass(const irr::video::SMaterial& material) const override;
 
 		//! Convert E_BLEND_FACTOR to OpenGL equivalent
 		GLenum getGLBlend(E_BLEND_FACTOR factor) const;
@@ -289,9 +289,9 @@ namespace video
 		//! inits the opengl-es driver
 		bool genericDriverInit(const core::dimension2d<u32>& screenSize, bool stencilBuffer);
 
-		virtual ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) override;
 
-		virtual ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) override;
 
 		//! creates a transposed matrix in supplied GLfloat array to pass to OGLES1
 		inline void getGLMatrix(GLfloat gl_matrix[16], const core::matrix4& m);

--- a/source/Irrlicht/COGLESMaterialRenderer.h
+++ b/source/Irrlicht/COGLESMaterialRenderer.h
@@ -450,7 +450,7 @@ public:
 	}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		Driver->setBasicRenderStates(material, lastMaterial, resetAllRenderstates);
 
@@ -464,7 +464,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setActiveTexture(GL_TEXTURE1);
 		glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -24,21 +24,21 @@ public:
 	COSOperator(const core::stringc& osversion);
 
 	//! returns the current operation system version as string.
-	virtual const core::stringc& getOperatingSystemVersion() const _IRR_OVERRIDE_;
+	const core::stringc& getOperatingSystemVersion() const override;
 
 	//! copies text to the clipboard
 	//! \param text: text in utf-8
-	virtual void copyToClipboard(const c8 *text) const _IRR_OVERRIDE_;
+	void copyToClipboard(const c8 *text) const override;
 
 	//! gets text from the clipboard
 	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
-	virtual const c8* getTextFromClipboard() const _IRR_OVERRIDE_;
+	const c8* getTextFromClipboard() const override;
 
 	//! gets the total and available system RAM in kB
 	//! \param Total: will contain the total system memory
 	//! \param Avail: will contain the available memory
 	//! \return Returns true if successful, false if not
-	virtual bool getSystemMemory(u32* Total, u32* Avail) const _IRR_OVERRIDE_;
+	bool getSystemMemory(u32* Total, u32* Avail) const override;
 
 private:
 

--- a/source/Irrlicht/COpenGLCoreRenderTarget.h
+++ b/source/Irrlicht/COpenGLCoreRenderTarget.h
@@ -58,7 +58,7 @@ public:
 			DepthStencil->drop();
 	}
 
-	virtual void setTextures(ITexture* const * textures, u32 numTextures, ITexture* depthStencil, const E_CUBE_SURFACE* cubeSurfaces, u32 numCubeSurfaces) _IRR_OVERRIDE_
+	void setTextures(ITexture* const * textures, u32 numTextures, ITexture* depthStencil, const E_CUBE_SURFACE* cubeSurfaces, u32 numCubeSurfaces) override
 	{
 		bool needSizeUpdate = false;
 

--- a/source/Irrlicht/COpenGLCoreTexture.h
+++ b/source/Irrlicht/COpenGLCoreTexture.h
@@ -234,7 +234,7 @@ public:
 			Images[i]->drop();
 	}
 
-	virtual void* lock(E_TEXTURE_LOCK_MODE mode = ETLM_READ_WRITE, u32 mipmapLevel=0, u32 layer = 0, E_TEXTURE_LOCK_FLAGS lockFlags = ETLF_FLIP_Y_UP_RTT) _IRR_OVERRIDE_
+	void* lock(E_TEXTURE_LOCK_MODE mode = ETLM_READ_WRITE, u32 mipmapLevel=0, u32 layer = 0, E_TEXTURE_LOCK_FLAGS lockFlags = ETLF_FLIP_Y_UP_RTT) override
 	{
 		if (LockImage)
 			return getLockImageData(MipLevelStored);
@@ -376,7 +376,7 @@ public:
 		return (LockImage) ? getLockImageData(MipLevelStored) : 0;
 	}
 
-	virtual void unlock() _IRR_OVERRIDE_
+	void unlock() override
 	{
 		if (!LockImage)
 			return;
@@ -398,7 +398,7 @@ public:
 		LockLayer = 0;
 	}
 
-	virtual void regenerateMipMapLevels(void* data = 0, u32 layer = 0) _IRR_OVERRIDE_
+	void regenerateMipMapLevels(void* data = 0, u32 layer = 0) override
 	{
 		if (!HasMipMaps || LegacyAutoGenerateMipMaps || (Size.Width <= 1 && Size.Height <= 1))
 			return;

--- a/source/Irrlicht/COpenGLDriver.h
+++ b/source/Irrlicht/COpenGLDriver.h
@@ -52,12 +52,12 @@ namespace video
 		virtual ~COpenGLDriver();
 
 		virtual bool beginScene(u16 clearFlag, SColor clearColor = SColor(255,0,0,0), f32 clearDepth = 1.f, u8 clearStencil = 0,
-			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) _IRR_OVERRIDE_;
+			const SExposedVideoData& videoData = SExposedVideoData(), core::rect<s32>* sourceRect = 0) override;
 
-		virtual bool endScene() _IRR_OVERRIDE_;
+		bool endScene() override;
 
 		//! sets transformation
-		virtual void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) _IRR_OVERRIDE_;
+		void setTransform(E_TRANSFORMATION_STATE state, const core::matrix4& mat) override;
 
 
 		struct SHWBufferLink_opengl : public SHWBufferLink
@@ -72,75 +72,75 @@ namespace video
 		};
 
 		//! updates hardware buffer if needed
-		virtual bool updateHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		bool updateHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Create hardware buffer from mesh
-		virtual SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		SHWBufferLink *createHardwareBuffer(const scene::IMeshBuffer* mb) override;
 
 		//! Delete hardware buffer (only some drivers can)
-		virtual void deleteHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void deleteHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Draw hardware buffer
-		virtual void drawHardwareBuffer(SHWBufferLink *HWBuffer) _IRR_OVERRIDE_;
+		void drawHardwareBuffer(SHWBufferLink *HWBuffer) override;
 
 		//! Create occlusion query.
 		/** Use node for identification and mesh for occlusion test. */
 		virtual void addOcclusionQuery(scene::ISceneNode* node,
-				const scene::IMesh* mesh=0) _IRR_OVERRIDE_;
+				const scene::IMesh* mesh=0) override;
 
 		//! Remove occlusion query.
-		virtual void removeOcclusionQuery(scene::ISceneNode* node) _IRR_OVERRIDE_;
+		void removeOcclusionQuery(scene::ISceneNode* node) override;
 
 		//! Run occlusion query. Draws mesh stored in query.
 		/** If the mesh shall not be rendered visible, use
 		overrideMaterial to disable the color and depth buffer. */
-		virtual void runOcclusionQuery(scene::ISceneNode* node, bool visible=false) _IRR_OVERRIDE_;
+		void runOcclusionQuery(scene::ISceneNode* node, bool visible=false) override;
 
 		//! Update occlusion query. Retrieves results from GPU.
 		/** If the query shall not block, set the flag to false.
 		Update might not occur in this case, though */
-		virtual void updateOcclusionQuery(scene::ISceneNode* node, bool block=true) _IRR_OVERRIDE_;
+		void updateOcclusionQuery(scene::ISceneNode* node, bool block=true) override;
 
 		//! Return query result.
 		/** Return value is the number of visible pixels/fragments.
 		The value is a safe approximation, i.e. can be larger then the
 		actual value of pixels. */
-		virtual u32 getOcclusionQueryResult(scene::ISceneNode* node) const _IRR_OVERRIDE_;
+		u32 getOcclusionQueryResult(scene::ISceneNode* node) const override;
 
 		//! Create render target.
-		virtual IRenderTarget* addRenderTarget() _IRR_OVERRIDE_;
+		IRenderTarget* addRenderTarget() override;
 
 		//! draws a vertex primitive list
 		virtual void drawVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
-				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) _IRR_OVERRIDE_;
+				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
 
 		//! draws a vertex primitive list in 2d
 		virtual void draw2DVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
-				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) _IRR_OVERRIDE_;
+				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
 
 		//! queries the features of the driver, returns true if feature is available
-		virtual bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const _IRR_OVERRIDE_
+		bool queryFeature(E_VIDEO_DRIVER_FEATURE feature) const override
 		{
 			return FeatureEnabled[feature] && COpenGLExtensionHandler::queryFeature(feature);
 		}
 
 		//! Disable a feature of the driver.
-		virtual void disableFeature(E_VIDEO_DRIVER_FEATURE feature, bool flag=true) _IRR_OVERRIDE_;
+		void disableFeature(E_VIDEO_DRIVER_FEATURE feature, bool flag=true) override;
 
 		//! Sets a material. All 3d drawing functions draw geometry now
 		//! using this material.
 		//! \param material: Material to be used from now on.
-		virtual void setMaterial(const SMaterial& material) _IRR_OVERRIDE_;
+		void setMaterial(const SMaterial& material) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::position2d<s32>& destPos,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::rect<s32>& destRect,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) override;
 
 		// Explicitly bring in base class methods, otherwise
 		// this overload would hide them.
@@ -154,7 +154,7 @@ namespace video
 				const core::array<core::rect<s32> >& sourceRects,
 				const core::rect<s32>* clipRect,
 				SColor color,
-				bool useAlphaChannelOfTexture) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture) override;
 
 		//! draws a set of 2d images, using a color and the alpha
 		/** channel of the texture if desired. The images are drawn
@@ -179,46 +179,46 @@ namespace video
 				s32 kerningWidth=0,
 				const core::rect<s32>* clipRect=0,
 				SColor color=SColor(255,255,255,255),
-				bool useAlphaChannelOfTexture=false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture=false) override;
 
 		//! draw an 2d rectangle
 		virtual void draw2DRectangle(SColor color, const core::rect<s32>& pos,
-			const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+			const core::rect<s32>* clip = 0) override;
 
 		//!Draws an 2d rectangle with a gradient.
 		virtual void draw2DRectangle(const core::rect<s32>& pos,
 			SColor colorLeftUp, SColor colorRightUp, SColor colorLeftDown, SColor colorRightDown,
-			const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+			const core::rect<s32>* clip = 0) override;
 
 		//! Draws a 2d line.
 		virtual void draw2DLine(const core::position2d<s32>& start,
 					const core::position2d<s32>& end,
-					SColor color=SColor(255,255,255,255)) _IRR_OVERRIDE_;
+					SColor color=SColor(255,255,255,255)) override;
 
 		//! Draws a single pixel
-		virtual void drawPixel(u32 x, u32 y, const SColor & color) _IRR_OVERRIDE_;
+		void drawPixel(u32 x, u32 y, const SColor & color) override;
 
 		//! Draws a 3d box
-		virtual void draw3DBox( const core::aabbox3d<f32>& box, SColor color = SColor(255,255,255,255 ) ) _IRR_OVERRIDE_;
+		void draw3DBox( const core::aabbox3d<f32>& box, SColor color = SColor(255,255,255,255 ) ) override;
 
 		//! Draws a 3d line.
 		virtual void draw3DLine(const core::vector3df& start,
 					const core::vector3df& end,
-					SColor color = SColor(255,255,255,255)) _IRR_OVERRIDE_;
+					SColor color = SColor(255,255,255,255)) override;
 
 		//! \return Returns the name of the video driver. Example: In case of the Direct3D8
 		//! driver, it would return "Direct3D8.1".
-		virtual const wchar_t* getName() const _IRR_OVERRIDE_;
+		const wchar_t* getName() const override;
 
 		//! Sets the dynamic ambient light color. The default color is
 		//! (0,0,0,0) which means it is dark.
 		//! \param color: New color of the ambient light.
-		virtual void setAmbientLight(const SColorf& color) _IRR_OVERRIDE_;
+		void setAmbientLight(const SColorf& color) override;
 
 		//! Draws a shadow volume into the stencil buffer. To draw a stencil shadow, do
 		//! this: First, draw all geometry. Then use this method, to draw the shadow
 		//! volume. Then, use IVideoDriver::drawStencilShadow() to visualize the shadow.
-		virtual void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) _IRR_OVERRIDE_;
+		void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) override;
 
 		//! Fills the stencil shadow with color. After the shadow volume has been drawn
 		//! into the stencil buffer using IVideoDriver::drawStencilShadowVolume(), use this
@@ -227,64 +227,64 @@ namespace video
 			video::SColor leftUpEdge = video::SColor(0,0,0,0),
 			video::SColor rightUpEdge = video::SColor(0,0,0,0),
 			video::SColor leftDownEdge = video::SColor(0,0,0,0),
-			video::SColor rightDownEdge = video::SColor(0,0,0,0)) _IRR_OVERRIDE_;
+			video::SColor rightDownEdge = video::SColor(0,0,0,0)) override;
 
 		//! sets a viewport
-		virtual void setViewPort(const core::rect<s32>& area) _IRR_OVERRIDE_;
+		void setViewPort(const core::rect<s32>& area) override;
 
 		//! Sets the fog mode.
 		virtual void setFog(SColor color, E_FOG_TYPE fogType, f32 start,
-			f32 end, f32 density, bool pixelFog, bool rangeFog) _IRR_OVERRIDE_;
+			f32 end, f32 density, bool pixelFog, bool rangeFog) override;
 
 		//! Only used by the internal engine. Used to notify the driver that
 		//! the window was resized.
-		virtual void OnResize(const core::dimension2d<u32>& size) _IRR_OVERRIDE_;
+		void OnResize(const core::dimension2d<u32>& size) override;
 
 		//! Returns type of video driver
-		virtual E_DRIVER_TYPE getDriverType() const _IRR_OVERRIDE_;
+		E_DRIVER_TYPE getDriverType() const override;
 
 		//! get color format of the current color buffer
-		virtual ECOLOR_FORMAT getColorFormat() const _IRR_OVERRIDE_;
+		ECOLOR_FORMAT getColorFormat() const override;
 
 		//! Returns the transformation set by setTransform
-		virtual const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const _IRR_OVERRIDE_;
+		const core::matrix4& getTransform(E_TRANSFORMATION_STATE state) const override;
 
 		//! Can be called by an IMaterialRenderer to make its work easier.
 		virtual void setBasicRenderStates(const SMaterial& material, const SMaterial& lastmaterial,
-			bool resetAllRenderstates) _IRR_OVERRIDE_;
+			bool resetAllRenderstates) override;
 
 		//! Compare in SMaterial doesn't check texture parameters, so we should call this on each OnRender call.
 		virtual void setTextureRenderStates(const SMaterial& material, bool resetAllRenderstates);
 
 		//! Get a vertex shader constant index.
-		virtual s32 getVertexShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getVertexShaderConstantID(const c8* name) override;
 
 		//! Get a pixel shader constant index.
-		virtual s32 getPixelShaderConstantID(const c8* name) _IRR_OVERRIDE_;
+		s32 getPixelShaderConstantID(const c8* name) override;
 
 		//! Sets a vertex shader constant.
-		virtual void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
+		void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
 
 		//! Sets a pixel shader constant.
-		virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
+		void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
 
 		//! Sets a constant for the vertex shader based on an index.
-		virtual bool setVertexShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setVertexShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setVertexShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! Sets a constant for the pixel shader based on an index.
-		virtual bool setPixelShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const f32* floats, int count) override;
 
 		//! Int interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const s32* ints, int count) override;
 
 		//! Uint interface for the above.
-		virtual bool setPixelShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
+		bool setPixelShaderConstant(s32 index, const u32* ints, int count) override;
 
 		//! disables all textures beginning with the optional fromStage parameter. Otherwise all texture stages are disabled.
 		//! Returns whether disabling was successful or not.
@@ -294,7 +294,7 @@ namespace video
 		//! extGLGetObjectParameteriv(shaderHandle, GL_OBJECT_COMPILE_STATUS_ARB, &status)
 		//! pixel and/or vertex shaders to render geometry.
 		virtual s32 addShaderMaterial(const c8* vertexShaderProgram, const c8* pixelShaderProgram,
-			IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) _IRR_OVERRIDE_;
+			IShaderConstantSetCallBack* callback, E_MATERIAL_TYPE baseMaterial, s32 userData) override;
 
 		//! Adds a new material renderer to the VideoDriver, using GLSL to render geometry.
 		virtual s32 addHighLevelShaderMaterial(
@@ -312,31 +312,31 @@ namespace video
 				u32 verticesOut = 0,
 				IShaderConstantSetCallBack* callback = 0,
 				E_MATERIAL_TYPE baseMaterial = video::EMT_SOLID,
-				s32 userData = 0) _IRR_OVERRIDE_;
+				s32 userData = 0) override;
 
 		//! Returns a pointer to the IVideoDriver interface. (Implementation for
 		//! IMaterialRendererServices)
-		virtual IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+		IVideoDriver* getVideoDriver() override;
 
 		//! Returns the maximum amount of primitives (mostly vertices) which
 		//! the device is able to render with one drawIndexedTriangleList
 		//! call.
-		virtual u32 getMaximalPrimitiveCount() const _IRR_OVERRIDE_;
+		u32 getMaximalPrimitiveCount() const override;
 
 		virtual ITexture* addRenderTargetTexture(const core::dimension2d<u32>& size,
-				const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format = ECF_UNKNOWN) override;
 
 		//! Creates a render target texture for a cubemap
 		ITexture* addRenderTargetTextureCubemap(const irr::u32 sideLen,
-				const io::path& name, const ECOLOR_FORMAT format) _IRR_OVERRIDE_;
+				const io::path& name, const ECOLOR_FORMAT format) override;
 
 		virtual bool setRenderTargetEx(IRenderTarget* target, u16 clearFlag, SColor clearColor = SColor(255,0,0,0),
-			f32 clearDepth = 1.f, u8 clearStencil = 0) _IRR_OVERRIDE_;
+			f32 clearDepth = 1.f, u8 clearStencil = 0) override;
 
-		virtual void clearBuffers(u16 flag, SColor color = SColor(255,0,0,0), f32 depth = 1.f, u8 stencil = 0) _IRR_OVERRIDE_;
+		void clearBuffers(u16 flag, SColor color = SColor(255,0,0,0), f32 depth = 1.f, u8 stencil = 0) override;
 
 		//! Returns an image created from the last rendered frame.
-		virtual IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) _IRR_OVERRIDE_;
+		IImage* createScreenShot(video::ECOLOR_FORMAT format=video::ECF_UNKNOWN, video::E_RENDER_TARGET target=video::ERT_FRAME_BUFFER) override;
 
 		//! checks if an OpenGL error has happened and prints it (+ some internal code which is usually the line number)
 		//! for performance reasons only available in debug mode
@@ -347,31 +347,31 @@ namespace video
 		//! \param index: The plane index. Must be between 0 and MaxUserClipPlanes.
 		//! \param plane: The plane itself.
 		//! \param enable: If true, enable the clipping plane else disable it.
-		virtual bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) _IRR_OVERRIDE_;
+		bool setClipPlane(u32 index, const core::plane3df& plane, bool enable=false) override;
 
 		//! Enable/disable a clipping plane.
 		//! There are at least 6 clipping planes available for the user to set at will.
 		//! \param index: The plane index. Must be between 0 and MaxUserClipPlanes.
 		//! \param enable: If true, enable the clipping plane else disable it.
-		virtual void enableClipPlane(u32 index, bool enable) _IRR_OVERRIDE_;
+		void enableClipPlane(u32 index, bool enable) override;
 
 		//! Enable the 2d override material
-		virtual void enableMaterial2D(bool enable=true) _IRR_OVERRIDE_;
+		void enableMaterial2D(bool enable=true) override;
 
 		//! Returns the graphics card vendor name.
-		virtual core::stringc getVendorInfo() _IRR_OVERRIDE_ {return VendorName;}
+		core::stringc getVendorInfo() override {return VendorName;}
 
 		//! Returns the maximum texture size supported.
-		virtual core::dimension2du getMaxTextureSize() const _IRR_OVERRIDE_;
+		core::dimension2du getMaxTextureSize() const override;
 
 		//! Removes a texture from the texture cache and deletes it, freeing lot of memory.
-		virtual void removeTexture(ITexture* texture) _IRR_OVERRIDE_;
+		void removeTexture(ITexture* texture) override;
 
 		//! Check if the driver supports creating textures with the given color format
-		virtual bool queryTextureFormat(ECOLOR_FORMAT format) const _IRR_OVERRIDE_;
+		bool queryTextureFormat(ECOLOR_FORMAT format) const override;
 
 		//! Used by some SceneNodes to check if a material should be rendered in the transparent render pass
-		virtual bool needsTransparentRenderPass(const irr::video::SMaterial& material) const _IRR_OVERRIDE_;
+		bool needsTransparentRenderPass(const irr::video::SMaterial& material) const override;
 
 		//! Convert E_PRIMITIVE_TYPE to OpenGL equivalent
 		GLenum primitiveTypeToGL(scene::E_PRIMITIVE_TYPE type) const;
@@ -406,9 +406,9 @@ namespace video
 		//! inits the parts of the open gl driver used on all platforms
 		bool genericDriverInit();
 
-		virtual ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTexture(const io::path& name, IImage* image) override;
 
-		virtual ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) _IRR_OVERRIDE_;
+		ITexture* createDeviceDependentTextureCubemap(const io::path& name, const core::array<IImage*>& image) override;
 
 		//! creates a transposed matrix in supplied GLfloat array to pass to OpenGL
 		inline void getGLMatrix(GLfloat gl_matrix[16], const core::matrix4& m);

--- a/source/Irrlicht/COpenGLMaterialRenderer.h
+++ b/source/Irrlicht/COpenGLMaterialRenderer.h
@@ -26,7 +26,7 @@ public:
 	COpenGLMaterialRenderer_SOLID(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -51,7 +51,7 @@ public:
 	COpenGLMaterialRenderer_ONETEXTURE_BLEND(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -137,7 +137,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setActiveTexture(GL_TEXTURE0_ARB);
 
@@ -158,7 +158,7 @@ public:
 
 	//! Returns if the material is transparent.
 	/** Is not always transparent, but mostly. */
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return true;
 	}
@@ -177,7 +177,7 @@ public:
 	COpenGLMaterialRenderer_SOLID_2_LAYER(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -215,7 +215,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		if (Driver->queryFeature(EVDF_MULTITEXTURE))
 		{
@@ -245,7 +245,7 @@ public:
 	COpenGLMaterialRenderer_TRANSPARENT_ADD_COLOR(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -259,13 +259,13 @@ public:
 		Driver->getCacheHandler()->setBlend(true);
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setBlend(false);
 	}
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return true;
 	}
@@ -284,7 +284,7 @@ public:
 	COpenGLMaterialRenderer_TRANSPARENT_VERTEX_ALPHA(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -319,7 +319,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setActiveTexture(GL_TEXTURE0_ARB);
 
@@ -336,7 +336,7 @@ public:
 	}
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return true;
 	}
@@ -355,7 +355,7 @@ public:
 	COpenGLMaterialRenderer_TRANSPARENT_ALPHA_CHANNEL(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -392,7 +392,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setActiveTexture(GL_TEXTURE0_ARB);
 
@@ -407,7 +407,7 @@ public:
 	}
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return true;
 	}
@@ -426,7 +426,7 @@ public:
 	COpenGLMaterialRenderer_TRANSPARENT_ALPHA_CHANNEL_REF(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -443,13 +443,13 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setAlphaTest(false);
 	}
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return false;  // this material is not really transparent because it does no blending.
 	}
@@ -468,7 +468,7 @@ public:
 	COpenGLMaterialRenderer_LIGHTMAP(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -562,7 +562,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		if (Driver->queryFeature(EVDF_MULTITEXTURE))
 		{
@@ -595,7 +595,7 @@ public:
 	COpenGLMaterialRenderer_DETAIL_MAP(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -627,7 +627,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		if (Driver->queryFeature(EVDF_MULTITEXTURE))
 		{
@@ -651,7 +651,7 @@ public:
 	COpenGLMaterialRenderer_SPHERE_MAP(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -677,7 +677,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		Driver->getCacheHandler()->setActiveTexture(GL_TEXTURE0_ARB);
 
@@ -699,7 +699,7 @@ public:
 	COpenGLMaterialRenderer_REFLECTION_2_LAYER(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -735,7 +735,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		if (Driver->queryFeature(EVDF_MULTITEXTURE))
 		{
@@ -761,7 +761,7 @@ public:
 	COpenGLMaterialRenderer_TRANSPARENT_REFLECTION_2_LAYER(video::COpenGLDriver* d) : Driver(d) {}
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_
+		bool resetAllRenderstates, IMaterialRendererServices* services) override
 	{
 		if (Driver->getFixedPipelineState() == COpenGLDriver::EOFPS_DISABLE)
 			Driver->setFixedPipelineState(COpenGLDriver::EOFPS_DISABLE_TO_ENABLE);
@@ -820,7 +820,7 @@ public:
 		}
 	}
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_
+	void OnUnsetMaterial() override
 	{
 		if (Driver->queryFeature(EVDF_MULTITEXTURE))
 		{
@@ -840,7 +840,7 @@ public:
 	}
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_
+	bool isTransparent() const override
 	{
 		return true;
 	}

--- a/source/Irrlicht/COpenGLSLMaterialRenderer.h
+++ b/source/Irrlicht/COpenGLSLMaterialRenderer.h
@@ -56,34 +56,34 @@ public:
 	virtual ~COpenGLSLMaterialRenderer();
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_;
+		bool resetAllRenderstates, IMaterialRendererServices* services) override;
 
-	virtual bool OnRender(IMaterialRendererServices* service, E_VERTEX_TYPE vtxtype) _IRR_OVERRIDE_;
+	bool OnRender(IMaterialRendererServices* service, E_VERTEX_TYPE vtxtype) override;
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_;
+	void OnUnsetMaterial() override;
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_;
+	bool isTransparent() const override;
 
 	//! Access the callback provided by the users when creating shader materials
-	virtual IShaderConstantSetCallBack* getShaderConstantSetCallBack() const _IRR_OVERRIDE_
+	IShaderConstantSetCallBack* getShaderConstantSetCallBack() const override
 	{ 
 		return CallBack;
 	}
 
 	// implementations for the render services
-	virtual void setBasicRenderStates(const SMaterial& material, const SMaterial& lastMaterial, bool resetAllRenderstates) _IRR_OVERRIDE_;
-	virtual s32 getVertexShaderConstantID(const c8* name) _IRR_OVERRIDE_;
-	virtual s32 getPixelShaderConstantID(const c8* name) _IRR_OVERRIDE_;
-	virtual void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
-	virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setVertexShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const f32* floats, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const s32* ints, int count) _IRR_OVERRIDE_;
-	virtual bool setPixelShaderConstant(s32 index, const u32* ints, int count) _IRR_OVERRIDE_;
-	virtual IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+	void setBasicRenderStates(const SMaterial& material, const SMaterial& lastMaterial, bool resetAllRenderstates) override;
+	s32 getVertexShaderConstantID(const c8* name) override;
+	s32 getPixelShaderConstantID(const c8* name) override;
+	void setVertexShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
+	void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) override;
+	bool setVertexShaderConstant(s32 index, const f32* floats, int count) override;
+	bool setVertexShaderConstant(s32 index, const s32* ints, int count) override;
+	bool setVertexShaderConstant(s32 index, const u32* ints, int count) override;
+	bool setPixelShaderConstant(s32 index, const f32* floats, int count) override;
+	bool setPixelShaderConstant(s32 index, const s32* ints, int count) override;
+	bool setPixelShaderConstant(s32 index, const u32* ints, int count) override;
+	IVideoDriver* getVideoDriver() override;
 
 protected:
 

--- a/source/Irrlicht/COpenGLShaderMaterialRenderer.h
+++ b/source/Irrlicht/COpenGLShaderMaterialRenderer.h
@@ -35,17 +35,17 @@ public:
 	virtual ~COpenGLShaderMaterialRenderer();
 
 	virtual void OnSetMaterial(const SMaterial& material, const SMaterial& lastMaterial,
-		bool resetAllRenderstates, IMaterialRendererServices* services) _IRR_OVERRIDE_;
+		bool resetAllRenderstates, IMaterialRendererServices* services) override;
 
-	virtual bool OnRender(IMaterialRendererServices* service, E_VERTEX_TYPE vtxtype) _IRR_OVERRIDE_;
+	bool OnRender(IMaterialRendererServices* service, E_VERTEX_TYPE vtxtype) override;
 
-	virtual void OnUnsetMaterial() _IRR_OVERRIDE_;
+	void OnUnsetMaterial() override;
 
 	//! Returns if the material is transparent.
-	virtual bool isTransparent() const _IRR_OVERRIDE_;
+	bool isTransparent() const override;
 
 	//! Access the callback provided by the users when creating shader materials
-	virtual IShaderConstantSetCallBack* getShaderConstantSetCallBack() const _IRR_OVERRIDE_
+	IShaderConstantSetCallBack* getShaderConstantSetCallBack() const override
 	{ 
 		return CallBack;
 	}

--- a/source/Irrlicht/CProfiler.h
+++ b/source/Irrlicht/CProfiler.h
@@ -18,10 +18,10 @@ public:
 	virtual ~CProfiler();
 
 	//! Write all profile-data into a string
-    virtual void printAll(core::stringw &result, bool includeOverview,bool suppressUncalled) const  _IRR_OVERRIDE_;
+    void printAll(core::stringw &result, bool includeOverview,bool suppressUncalled) const  override;
 
 	//! Write the profile data of one group into a string
-    virtual void printGroup(core::stringw &result, u32 groupIndex, bool suppressUncalled) const  _IRR_OVERRIDE_;
+    void printGroup(core::stringw &result, u32 groupIndex, bool suppressUncalled) const  override;
 
 protected:
 	core::stringw makeTitleString() const;

--- a/source/Irrlicht/CReadFile.h
+++ b/source/Irrlicht/CReadFile.h
@@ -27,13 +27,13 @@ namespace io
 		virtual ~CReadFile();
 
 		//! returns how much was read
-		virtual size_t read(void* buffer, size_t sizeToRead) _IRR_OVERRIDE_;
+		size_t read(void* buffer, size_t sizeToRead) override;
 
 		//! changes position in file, returns true if successful
-		virtual bool seek(long finalPos, bool relativeMovement = false) _IRR_OVERRIDE_;
+		bool seek(long finalPos, bool relativeMovement = false) override;
 
 		//! returns size of file
-		virtual long getSize() const _IRR_OVERRIDE_;
+		long getSize() const override;
 
 		//! returns if file is open
 		bool isOpen() const
@@ -42,13 +42,13 @@ namespace io
 		}
 
 		//! returns where in the file we are.
-		virtual long getPos() const _IRR_OVERRIDE_;
+		long getPos() const override;
 
 		//! returns name of file
-		virtual const io::path& getFileName() const _IRR_OVERRIDE_;
+		const io::path& getFileName() const override;
 
 		//! Get the type of the class implementing this interface
-		virtual EREAD_FILE_TYPE getType() const _IRR_OVERRIDE_
+		EREAD_FILE_TYPE getType() const override
 		{
 			return ERFT_READ_FILE;
 		}

--- a/source/Irrlicht/CSDLManager.h
+++ b/source/Irrlicht/CSDLManager.h
@@ -26,21 +26,21 @@ namespace video
 
 		virtual ~CSDLManager() {}
 
-		virtual bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) _IRR_OVERRIDE_;
+		bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) override;
 
-		virtual void terminate() _IRR_OVERRIDE_ {};
-		virtual bool generateSurface() _IRR_OVERRIDE_ { return true; };
-		virtual void destroySurface() _IRR_OVERRIDE_ {};
-		virtual bool generateContext() _IRR_OVERRIDE_ { return true; };
-		virtual void destroyContext() _IRR_OVERRIDE_ {};
+		void terminate() override {};
+		bool generateSurface() override { return true; };
+		void destroySurface() override {};
+		bool generateContext() override { return true; };
+		void destroyContext() override {};
 
-		virtual const SExposedVideoData& getContext() const _IRR_OVERRIDE_;
+		const SExposedVideoData& getContext() const override;
 
-		virtual bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero=false) _IRR_OVERRIDE_;
+		bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero=false) override;
 
-		virtual void* getProcAddress(const std::string &procName) _IRR_OVERRIDE_;
+		void* getProcAddress(const std::string &procName) override;
 
-		virtual bool swapBuffers() _IRR_OVERRIDE_;
+		bool swapBuffers() override;
 
 	private:
 		SExposedVideoData Data;

--- a/source/Irrlicht/CSceneCollisionManager.h
+++ b/source/Irrlicht/CSceneCollisionManager.h
@@ -26,7 +26,7 @@ namespace scene
 
 		//! Returns a 3d ray which would go through the 2d screen coordinates.
 		virtual core::line3d<f32> getRayFromScreenCoordinates(
-			const core::position2d<s32> & pos, const ICameraSceneNode* camera = 0) _IRR_OVERRIDE_;
+			const core::position2d<s32> & pos, const ICameraSceneNode* camera = 0) override;
 
 	private:
 

--- a/source/Irrlicht/CSceneManager.h
+++ b/source/Irrlicht/CSceneManager.h
@@ -39,29 +39,29 @@ namespace scene
 		virtual ~CSceneManager();
 
 		//! gets an animateable mesh. loads it if needed. returned pointer must not be dropped.
-		virtual IAnimatedMesh* getMesh(const io::path& filename, const io::path& alternativeCacheName) _IRR_OVERRIDE_;
+		IAnimatedMesh* getMesh(const io::path& filename, const io::path& alternativeCacheName) override;
 
 		//! gets an animateable mesh. loads it if needed. returned pointer must not be dropped.
-		virtual IAnimatedMesh* getMesh(io::IReadFile* file) _IRR_OVERRIDE_;
+		IAnimatedMesh* getMesh(io::IReadFile* file) override;
 
 		//! Returns an interface to the mesh cache which is shared between all existing scene managers.
-		virtual IMeshCache* getMeshCache() _IRR_OVERRIDE_;
+		IMeshCache* getMeshCache() override;
 
 		//! returns the video driver
-		virtual video::IVideoDriver* getVideoDriver() _IRR_OVERRIDE_;
+		video::IVideoDriver* getVideoDriver() override;
 
 		//! return the gui environment
-		virtual gui::IGUIEnvironment* getGUIEnvironment() _IRR_OVERRIDE_;
+		gui::IGUIEnvironment* getGUIEnvironment() override;
 
 		//! return the filesystem
-		virtual io::IFileSystem* getFileSystem() _IRR_OVERRIDE_;
+		io::IFileSystem* getFileSystem() override;
 
 		//! adds a scene node for rendering an animated mesh model
 		virtual IAnimatedMeshSceneNode* addAnimatedMeshSceneNode(IAnimatedMesh* mesh, ISceneNode* parent=0, s32 id=-1,
 			const core::vector3df& position = core::vector3df(0,0,0),
 			const core::vector3df& rotation = core::vector3df(0,0,0),
 			const core::vector3df& scale = core::vector3df(1.0f, 1.0f, 1.0f),
-			bool alsoAddIfMeshPointerZero=false) _IRR_OVERRIDE_;
+			bool alsoAddIfMeshPointerZero=false) override;
 
 		//! adds a scene node for rendering a static mesh
 		//! the returned pointer must not be dropped.
@@ -69,22 +69,22 @@ namespace scene
 			const core::vector3df& position = core::vector3df(0,0,0),
 			const core::vector3df& rotation = core::vector3df(0,0,0),
 			const core::vector3df& scale = core::vector3df(1.0f, 1.0f, 1.0f),
-			bool alsoAddIfMeshPointerZero=false) _IRR_OVERRIDE_;
+			bool alsoAddIfMeshPointerZero=false) override;
 
 		//! renders the node.
-		virtual void render() _IRR_OVERRIDE_;
+		void render() override;
 
 		//! returns the axis aligned bounding box of this node
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! registers a node for rendering it at a specific time.
-		virtual u32 registerNodeForRendering(ISceneNode* node, E_SCENE_NODE_RENDER_PASS pass = ESNRP_AUTOMATIC) _IRR_OVERRIDE_;
+		u32 registerNodeForRendering(ISceneNode* node, E_SCENE_NODE_RENDER_PASS pass = ESNRP_AUTOMATIC) override;
 
 		//! Clear all nodes which are currently registered for rendering
-		virtual void clearAllRegisteredNodesForRendering() _IRR_OVERRIDE_;
+		void clearAllRegisteredNodesForRendering() override;
 
 		//! draws all scene nodes
-		virtual void drawAll() _IRR_OVERRIDE_;
+		void drawAll() override;
 
 		//! Adds a camera scene node to the tree and sets it as active camera.
 		//! \param position: Position of the space relative to its parent where the camera will be placed.
@@ -95,7 +95,7 @@ namespace scene
 		virtual ICameraSceneNode* addCameraSceneNode(ISceneNode* parent = 0,
 			const core::vector3df& position = core::vector3df(0,0,0),
 			const core::vector3df& lookat = core::vector3df(0,0,100),
-			s32 id=-1, bool makeActive=true) _IRR_OVERRIDE_;
+			s32 id=-1, bool makeActive=true) override;
 
 		//! Adds a billboard scene node to the scene. A billboard is like a 3d sprite: A 2d element,
 		//! which always looks to the camera. It is usually used for things like explosions, fire,
@@ -103,103 +103,103 @@ namespace scene
 		virtual IBillboardSceneNode* addBillboardSceneNode(ISceneNode* parent = 0,
 			const core::dimension2d<f32>& size = core::dimension2d<f32>(10.0f, 10.0f),
 			const core::vector3df& position = core::vector3df(0,0,0), s32 id=-1,
-			video::SColor shadeTop = 0xFFFFFFFF, video::SColor shadeBottom = 0xFFFFFFFF) _IRR_OVERRIDE_;
+			video::SColor shadeTop = 0xFFFFFFFF, video::SColor shadeBottom = 0xFFFFFFFF) override;
 
 		//! Adds a dummy transformation scene node to the scene graph.
 		virtual IDummyTransformationSceneNode* addDummyTransformationSceneNode(
-			ISceneNode* parent=0, s32 id=-1) _IRR_OVERRIDE_;
+			ISceneNode* parent=0, s32 id=-1) override;
 
 		//! Adds an empty scene node.
-		virtual ISceneNode* addEmptySceneNode(ISceneNode* parent, s32 id=-1) _IRR_OVERRIDE_;
+		ISceneNode* addEmptySceneNode(ISceneNode* parent, s32 id=-1) override;
 
 		//! Returns the root scene node. This is the scene node which is parent
 		//! of all scene nodes. The root scene node is a special scene node which
 		//! only exists to manage all scene nodes. It is not rendered and cannot
 		//! be removed from the scene.
 		//! \return Pointer to the root scene node.
-		virtual ISceneNode* getRootSceneNode() _IRR_OVERRIDE_;
+		ISceneNode* getRootSceneNode() override;
 
 		//! Returns the current active camera.
 		//! \return The active camera is returned. Note that this can be NULL, if there
 		//! was no camera created yet.
-		virtual ICameraSceneNode* getActiveCamera() const _IRR_OVERRIDE_;
+		ICameraSceneNode* getActiveCamera() const override;
 
 		//! Sets the active camera. The previous active camera will be deactivated.
 		//! \param camera: The new camera which should be active.
-		virtual void setActiveCamera(ICameraSceneNode* camera) _IRR_OVERRIDE_;
+		void setActiveCamera(ICameraSceneNode* camera) override;
 
 		//! Adds an external mesh loader.
-		virtual void addExternalMeshLoader(IMeshLoader* externalLoader) _IRR_OVERRIDE_;
+		void addExternalMeshLoader(IMeshLoader* externalLoader) override;
 
 		//! Returns the number of mesh loaders supported by Irrlicht at this time
-		virtual u32 getMeshLoaderCount() const _IRR_OVERRIDE_;
+		u32 getMeshLoaderCount() const override;
 
 		//! Retrieve the given mesh loader
-		virtual IMeshLoader* getMeshLoader(u32 index) const _IRR_OVERRIDE_;
+		IMeshLoader* getMeshLoader(u32 index) const override;
 
 		//! Returns a pointer to the scene collision manager.
-		virtual ISceneCollisionManager* getSceneCollisionManager() _IRR_OVERRIDE_;
+		ISceneCollisionManager* getSceneCollisionManager() override;
 
 		//! Returns a pointer to the mesh manipulator.
-		virtual IMeshManipulator* getMeshManipulator() _IRR_OVERRIDE_;
+		IMeshManipulator* getMeshManipulator() override;
 
 		//! Adds a scene node to the deletion queue.
-		virtual void addToDeletionQueue(ISceneNode* node) _IRR_OVERRIDE_;
+		void addToDeletionQueue(ISceneNode* node) override;
 
 		//! Returns the first scene node with the specified id.
-		virtual ISceneNode* getSceneNodeFromId(s32 id, ISceneNode* start=0) _IRR_OVERRIDE_;
+		ISceneNode* getSceneNodeFromId(s32 id, ISceneNode* start=0) override;
 
 		//! Returns the first scene node with the specified name.
-		virtual ISceneNode* getSceneNodeFromName(const c8* name, ISceneNode* start=0) _IRR_OVERRIDE_;
+		ISceneNode* getSceneNodeFromName(const c8* name, ISceneNode* start=0) override;
 
 		//! Returns the first scene node with the specified type.
-		virtual ISceneNode* getSceneNodeFromType(scene::ESCENE_NODE_TYPE type, ISceneNode* start=0) _IRR_OVERRIDE_;
+		ISceneNode* getSceneNodeFromType(scene::ESCENE_NODE_TYPE type, ISceneNode* start=0) override;
 
 		//! returns scene nodes by type.
-		virtual void getSceneNodesFromType(ESCENE_NODE_TYPE type, core::array<scene::ISceneNode*>& outNodes, ISceneNode* start=0) _IRR_OVERRIDE_;
+		void getSceneNodesFromType(ESCENE_NODE_TYPE type, core::array<scene::ISceneNode*>& outNodes, ISceneNode* start=0) override;
 
 		//! Posts an input event to the environment. Usually you do not have to
 		//! use this method, it is used by the internal engine.
-		virtual bool postEventFromUser(const SEvent& event) _IRR_OVERRIDE_;
+		bool postEventFromUser(const SEvent& event) override;
 
 		//! Clears the whole scene. All scene nodes are removed.
-		virtual void clear() _IRR_OVERRIDE_;
+		void clear() override;
 
 		//! Removes all children of this scene node
-		virtual void removeAll() _IRR_OVERRIDE_;
+		void removeAll() override;
 
 		//! Returns interface to the parameters set in this scene.
-		virtual io::IAttributes* getParameters() _IRR_OVERRIDE_;
+		io::IAttributes* getParameters() override;
 
 		//! Returns current render pass.
-		virtual E_SCENE_NODE_RENDER_PASS getSceneNodeRenderPass() const _IRR_OVERRIDE_;
+		E_SCENE_NODE_RENDER_PASS getSceneNodeRenderPass() const override;
 
 		//! Creates a new scene manager.
-		virtual ISceneManager* createNewSceneManager(bool cloneContent) _IRR_OVERRIDE_;
+		ISceneManager* createNewSceneManager(bool cloneContent) override;
 
 		//! Returns type of the scene node
-		virtual ESCENE_NODE_TYPE getType() const _IRR_OVERRIDE_ { return ESNT_SCENE_MANAGER; }
+		ESCENE_NODE_TYPE getType() const override { return ESNT_SCENE_MANAGER; }
 
 		//! Returns a mesh writer implementation if available
-		virtual IMeshWriter* createMeshWriter(EMESH_WRITER_TYPE type) _IRR_OVERRIDE_;
+		IMeshWriter* createMeshWriter(EMESH_WRITER_TYPE type) override;
 
 		//! Get a skinned mesh, which is not available as header-only code
-		virtual ISkinnedMesh* createSkinnedMesh() _IRR_OVERRIDE_;
+		ISkinnedMesh* createSkinnedMesh() override;
 
 		//! Sets ambient color of the scene
-		virtual void setAmbientLight(const video::SColorf &ambientColor) _IRR_OVERRIDE_;
+		void setAmbientLight(const video::SColorf &ambientColor) override;
 
 		//! Returns ambient color of the scene
-		virtual const video::SColorf& getAmbientLight() const _IRR_OVERRIDE_;
+		const video::SColorf& getAmbientLight() const override;
 
 		//! Get current render time.
-		virtual E_SCENE_NODE_RENDER_PASS getCurrentRenderPass() const _IRR_OVERRIDE_ { return CurrentRenderPass; }
+		E_SCENE_NODE_RENDER_PASS getCurrentRenderPass() const override { return CurrentRenderPass; }
 
 		//! Set current render time.
-		virtual void setCurrentRenderPass(E_SCENE_NODE_RENDER_PASS nextPass) _IRR_OVERRIDE_ { CurrentRenderPass = nextPass; }
+		void setCurrentRenderPass(E_SCENE_NODE_RENDER_PASS nextPass) override { CurrentRenderPass = nextPass; }
 
 		//! returns if node is culled
-		virtual bool isCulled(const ISceneNode* node) const _IRR_OVERRIDE_;
+		bool isCulled(const ISceneNode* node) const override;
 
 	private:
 

--- a/source/Irrlicht/CSkinnedMesh.h
+++ b/source/Irrlicht/CSkinnedMesh.h
@@ -33,122 +33,122 @@ namespace scene
 		virtual ~CSkinnedMesh();
 
 		//! returns the amount of frames. If the amount is 1, it is a static (=non animated) mesh.
-		virtual u32 getFrameCount() const _IRR_OVERRIDE_;
+		u32 getFrameCount() const override;
 
 		//! Gets the default animation speed of the animated mesh.
 		/** \return Amount of frames per second. If the amount is 0, it is a static, non animated mesh. */
-		virtual f32 getAnimationSpeed() const _IRR_OVERRIDE_;
+		f32 getAnimationSpeed() const override;
 
 		//! Gets the frame count of the animated mesh.
 		/** \param fps Frames per second to play the animation with. If the amount is 0, it is not animated.
 		The actual speed is set in the scene node the mesh is instantiated in.*/
-		virtual void setAnimationSpeed(f32 fps) _IRR_OVERRIDE_;
+		void setAnimationSpeed(f32 fps) override;
 
 		//! returns the animated mesh based on a detail level (which is ignored)
-		virtual IMesh* getMesh(s32 frame, s32 detailLevel=255, s32 startFrameLoop=-1, s32 endFrameLoop=-1) _IRR_OVERRIDE_;
+		IMesh* getMesh(s32 frame, s32 detailLevel=255, s32 startFrameLoop=-1, s32 endFrameLoop=-1) override;
 
 		//! Animates this mesh's joints based on frame input
 		//! blend: {0-old position, 1-New position}
-		virtual void animateMesh(f32 frame, f32 blend) _IRR_OVERRIDE_;
+		void animateMesh(f32 frame, f32 blend) override;
 
 		//! Preforms a software skin on this mesh based of joint positions
-		virtual void skinMesh() _IRR_OVERRIDE_;
+		void skinMesh() override;
 
 		//! returns amount of mesh buffers.
-		virtual u32 getMeshBufferCount() const _IRR_OVERRIDE_;
+		u32 getMeshBufferCount() const override;
 
 		//! returns pointer to a mesh buffer
-		virtual IMeshBuffer* getMeshBuffer(u32 nr) const _IRR_OVERRIDE_;
+		IMeshBuffer* getMeshBuffer(u32 nr) const override;
 
 		//! Returns pointer to a mesh buffer which fits a material
 		/** \param material: material to search for
 		\return Returns the pointer to the mesh buffer or
 		NULL if there is no such mesh buffer. */
-		virtual IMeshBuffer* getMeshBuffer( const video::SMaterial &material) const _IRR_OVERRIDE_;
+		IMeshBuffer* getMeshBuffer( const video::SMaterial &material) const override;
 
 		//! returns an axis aligned bounding box
-		virtual const core::aabbox3d<f32>& getBoundingBox() const _IRR_OVERRIDE_;
+		const core::aabbox3d<f32>& getBoundingBox() const override;
 
 		//! set user axis aligned bounding box
-		virtual void setBoundingBox( const core::aabbox3df& box) _IRR_OVERRIDE_;
+		void setBoundingBox( const core::aabbox3df& box) override;
 
 		//! sets a flag of all contained materials to a new value
-		virtual void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) _IRR_OVERRIDE_;
+		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override;
 
 		//! set the hardware mapping hint, for driver
-		virtual void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_;
+		void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) override;
 
 		//! flags the meshbuffer as changed, reloads hardware buffers
-		virtual void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) _IRR_OVERRIDE_;
+		void setDirty(E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) override;
 
 		//! Returns the type of the animated mesh.
-		virtual E_ANIMATED_MESH_TYPE getMeshType() const _IRR_OVERRIDE_;
+		E_ANIMATED_MESH_TYPE getMeshType() const override;
 
 		//! Gets joint count.
-		virtual u32 getJointCount() const _IRR_OVERRIDE_;
+		u32 getJointCount() const override;
 
 		//! Gets the name of a joint.
-		virtual const c8* getJointName(u32 number) const _IRR_OVERRIDE_;
+		const c8* getJointName(u32 number) const override;
 
 		//! Gets a joint number from its name
-		virtual s32 getJointNumber(const c8* name) const _IRR_OVERRIDE_;
+		s32 getJointNumber(const c8* name) const override;
 
 		//! uses animation from another mesh
-		virtual bool useAnimationFrom(const ISkinnedMesh *mesh) _IRR_OVERRIDE_;
+		bool useAnimationFrom(const ISkinnedMesh *mesh) override;
 
 		//! Update Normals when Animating
 		//! False= Don't (default)
 		//! True = Update normals, slower
-		virtual void updateNormalsWhenAnimating(bool on) _IRR_OVERRIDE_;
+		void updateNormalsWhenAnimating(bool on) override;
 
 		//! Sets Interpolation Mode
-		virtual void setInterpolationMode(E_INTERPOLATION_MODE mode) _IRR_OVERRIDE_;
+		void setInterpolationMode(E_INTERPOLATION_MODE mode) override;
 
 		//! Convertes the mesh to contain tangent information
-		virtual void convertMeshToTangents() _IRR_OVERRIDE_;
+		void convertMeshToTangents() override;
 
 		//! Does the mesh have no animation
-		virtual bool isStatic() _IRR_OVERRIDE_;
+		bool isStatic() override;
 
 		//! (This feature is not implemented in irrlicht yet)
-		virtual bool setHardwareSkinning(bool on) _IRR_OVERRIDE_;
+		bool setHardwareSkinning(bool on) override;
 
 		//! Refreshes vertex data cached in joints such as positions and normals
-		virtual void refreshJointCache() _IRR_OVERRIDE_;
+		void refreshJointCache() override;
 
 		//! Moves the mesh into static position.
-		virtual void resetAnimation() _IRR_OVERRIDE_;
+		void resetAnimation() override;
 
 		//Interface for the mesh loaders (finalize should lock these functions, and they should have some prefix like loader_
 		//these functions will use the needed arrays, set values, etc to help the loaders
 
 		//! exposed for loaders to add mesh buffers
-		virtual core::array<SSkinMeshBuffer*> &getMeshBuffers() _IRR_OVERRIDE_;
+		core::array<SSkinMeshBuffer*> &getMeshBuffers() override;
 
 		//! alternative method for adding joints
-		virtual core::array<SJoint*> &getAllJoints() _IRR_OVERRIDE_;
+		core::array<SJoint*> &getAllJoints() override;
 
 		//! alternative method for adding joints
-		virtual const core::array<SJoint*> &getAllJoints() const _IRR_OVERRIDE_;
+		const core::array<SJoint*> &getAllJoints() const override;
 
 		//! loaders should call this after populating the mesh
-		virtual void finalize() _IRR_OVERRIDE_;
+		void finalize() override;
 
 		//! Adds a new meshbuffer to the mesh, access it as last one
-		virtual SSkinMeshBuffer *addMeshBuffer() _IRR_OVERRIDE_;
+		SSkinMeshBuffer *addMeshBuffer() override;
 
 		//! Adds a new joint to the mesh, access it as last one
-		virtual SJoint *addJoint(SJoint *parent=0) _IRR_OVERRIDE_;
+		SJoint *addJoint(SJoint *parent=0) override;
 
 		//! Adds a new position key to the mesh, access it as last one
-		virtual SPositionKey *addPositionKey(SJoint *joint) _IRR_OVERRIDE_;
+		SPositionKey *addPositionKey(SJoint *joint) override;
 		//! Adds a new rotation key to the mesh, access it as last one
-		virtual SRotationKey *addRotationKey(SJoint *joint) _IRR_OVERRIDE_;
+		SRotationKey *addRotationKey(SJoint *joint) override;
 		//! Adds a new scale key to the mesh, access it as last one
-		virtual SScaleKey *addScaleKey(SJoint *joint) _IRR_OVERRIDE_;
+		SScaleKey *addScaleKey(SJoint *joint) override;
 
 		//! Adds a new weight to the mesh, access it as last one
-		virtual SWeight *addWeight(SJoint *joint) _IRR_OVERRIDE_;
+		SWeight *addWeight(SJoint *joint) override;
 
 		virtual void updateBoundingBox(void);
 

--- a/source/Irrlicht/CTimer.h
+++ b/source/Irrlicht/CTimer.h
@@ -24,13 +24,13 @@ namespace irr
 		/** This value does not start with 0 when the application starts.
 		For example in one implementation the value returned could be the
 		amount of milliseconds which have elapsed since the system was started. */
-		virtual u32 getRealTime() const _IRR_OVERRIDE_
+		u32 getRealTime() const override
 		{
 			return os::Timer::getRealTime();
 		}
 
 		//! Get current time and date in calendar form
-		virtual RealTimeDate getRealTimeAndDate() const _IRR_OVERRIDE_
+		RealTimeDate getRealTimeAndDate() const override
 		{
 			return os::Timer::getRealTimeAndDate();
 		}
@@ -39,13 +39,13 @@ namespace irr
 		/** This value starts with 0 and can be manipulated using setTime(), stopTimer(),
 		startTimer(), etc. This value depends on the set speed of the timer if the timer
 		is stopped, etc. If you need the system time, use getRealTime() */
-		virtual u32 getTime() const _IRR_OVERRIDE_
+		u32 getTime() const override
 		{
 			return os::Timer::getTime();
 		}
 
 		//! sets current virtual time
-		virtual void setTime(u32 time) _IRR_OVERRIDE_
+		void setTime(u32 time) override
 		{
 			os::Timer::setTime(time);
 		}
@@ -54,7 +54,7 @@ namespace irr
 		/** The timer is reference counted, which means everything which calls
 		stopTimer() will also have to call startTimer(), otherwise the timer may not start/stop
 		corretly again. */
-		virtual void stop() _IRR_OVERRIDE_
+		void stop() override
 		{
 			os::Timer::stopTimer();
 		}
@@ -63,7 +63,7 @@ namespace irr
 		/** The timer is reference counted, which means everything which calls
 		stopTimer() will also have to call startTimer(), otherwise the timer may not start/stop
 		corretly again. */
-		virtual void start() _IRR_OVERRIDE_
+		void start() override
 		{
 			os::Timer::startTimer();
 		}
@@ -71,7 +71,7 @@ namespace irr
 		//! Sets the speed of the timer
 		/** The speed is the factor with which the time is running faster or slower then the
 		real system time. */
-		virtual void setSpeed(f32 speed = 1.0f) _IRR_OVERRIDE_
+		void setSpeed(f32 speed = 1.0f) override
 		{
 			os::Timer::setSpeed(speed);
 		}
@@ -79,13 +79,13 @@ namespace irr
 		//! Returns current speed of the timer
 		/** The speed is the factor with which the time is running faster or slower then the
 		real system time. */
-		virtual f32 getSpeed() const _IRR_OVERRIDE_
+		f32 getSpeed() const override
 		{
 			return os::Timer::getSpeed();
 		}
 
 		//! Returns if game timer is currently stopped
-		virtual bool isStopped() const _IRR_OVERRIDE_
+		bool isStopped() const override
 		{
 			bool ret = os::Timer::isStopped();
 			return ret;
@@ -95,7 +95,7 @@ namespace irr
 		/** Makes the virtual timer update the time value based on the real time. This is
 		called automatically when calling IrrlichtDevice::run(), but you can call it manually
 		if you don't use this method. */
-		virtual void tick() _IRR_OVERRIDE_
+		void tick() override
 		{
 			os::Timer::tick();
 		}

--- a/source/Irrlicht/CWGLManager.h
+++ b/source/Irrlicht/CWGLManager.h
@@ -33,34 +33,34 @@ namespace video
 		~CWGLManager();
 
         // Initialize
-        virtual bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) _IRR_OVERRIDE_;
+        bool initialize(const SIrrlichtCreationParameters& params, const SExposedVideoData& data) override;
 
         // Terminate
-        virtual void terminate() _IRR_OVERRIDE_;
+        void terminate() override;
 
         // Create surface.
-        virtual bool generateSurface() _IRR_OVERRIDE_;
+        bool generateSurface() override;
 
         // Destroy surface.
-        virtual void destroySurface() _IRR_OVERRIDE_;
+        void destroySurface() override;
 
         // Create context.
-        virtual bool generateContext() _IRR_OVERRIDE_;
+        bool generateContext() override;
 
         // Destroy EGL context.
-        virtual void destroyContext() _IRR_OVERRIDE_;
+        void destroyContext() override;
 
 		//! Get current context
-		virtual const SExposedVideoData& getContext() const _IRR_OVERRIDE_;
+		const SExposedVideoData& getContext() const override;
 
 		//! Change render context, disable old and activate new defined by videoData
-		virtual bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) _IRR_OVERRIDE_;
+		bool activateContext(const SExposedVideoData& videoData, bool restorePrimaryOnZero) override;
 
 		// Get procedure address.
-		virtual void* getProcAddress(const std::string &procName) _IRR_OVERRIDE_;
+		void* getProcAddress(const std::string &procName) override;
 
         // Swap buffers.
-        virtual bool swapBuffers() _IRR_OVERRIDE_;
+        bool swapBuffers() override;
 
     private:
         SIrrlichtCreationParameters Params;

--- a/source/Irrlicht/CWebGL1Driver.h
+++ b/source/Irrlicht/CWebGL1Driver.h
@@ -37,10 +37,10 @@ namespace video
 		virtual ~CWebGL1Driver();
 
 		//! Returns type of video driver
-		virtual E_DRIVER_TYPE getDriverType() const _IRR_OVERRIDE_;
+		E_DRIVER_TYPE getDriverType() const override;
 
 		//! Is VBO recommended on this mesh?
-		virtual bool isHardwareBufferRecommend(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_
+		bool isHardwareBufferRecommend(const scene::IMeshBuffer* mb) override
 		{
 			// All buffers must be bound, WebGL doesn't allow sending unbound buffers at all.
 			return true;
@@ -49,22 +49,22 @@ namespace video
 		//! draws a vertex primitive list
 		virtual void drawVertexPrimitiveList(const void* vertices, u32 vertexCount,
 				const void* indexList, u32 primitiveCount,
-				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) _IRR_OVERRIDE_;
+				E_VERTEX_TYPE vType, scene::E_PRIMITIVE_TYPE pType, E_INDEX_TYPE iType) override;
 
 		//! Draws a mesh buffer
-		virtual void drawMeshBuffer(const scene::IMeshBuffer* mb) _IRR_OVERRIDE_;
+		void drawMeshBuffer(const scene::IMeshBuffer* mb) override;
 
 		virtual void draw2DImage(const video::ITexture* texture,
 				const core::position2d<s32>& destPos,
 				const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-				SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255), bool useAlphaChannelOfTexture = false) override;
 
 		virtual void draw2DImage(const video::ITexture* texture, const core::rect<s32>& destRect,
 			const core::rect<s32>& sourceRect, const core::rect<s32>* clipRect = 0,
-			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+			const video::SColor* const colors = 0, bool useAlphaChannelOfTexture = false) override;
 
 		// internally used
-		virtual void draw2DImage(const video::ITexture* texture, u32 layer, bool flip)  _IRR_OVERRIDE_;
+		void draw2DImage(const video::ITexture* texture, u32 layer, bool flip)  override;
 
 		//! draws a set of 2d images
 		virtual void draw2DImageBatch(const video::ITexture* texture,
@@ -73,58 +73,58 @@ namespace video
 				const core::array<s32>& indices, s32 kerningWidth = 0,
 				const core::rect<s32>* clipRect = 0,
 				SColor color = SColor(255, 255, 255, 255),
-				bool useAlphaChannelOfTexture = false) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture = false) override;
 
 		void draw2DImageBatch(const video::ITexture* texture,
 				const core::array<core::position2d<s32> >& positions,
 				const core::array<core::rect<s32> >& sourceRects,
 				const core::rect<s32>* clipRect,
 				SColor color,
-				bool useAlphaChannelOfTexture) _IRR_OVERRIDE_;
+				bool useAlphaChannelOfTexture) override;
 
 		//! draw an 2d rectangle
 		virtual void draw2DRectangle(SColor color, const core::rect<s32>& pos,
-				const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip = 0) override;
 
 		//!Draws an 2d rectangle with a gradient.
 		virtual void draw2DRectangle(const core::rect<s32>& pos,
 				SColor colorLeftUp, SColor colorRightUp, SColor colorLeftDown, SColor colorRightDown,
-				const core::rect<s32>* clip = 0) _IRR_OVERRIDE_;
+				const core::rect<s32>* clip = 0) override;
 
 		//! Draws a 2d line.
 		virtual void draw2DLine(const core::position2d<s32>& start,
 				const core::position2d<s32>& end,
-				SColor color = SColor(255, 255, 255, 255)) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255)) override;
 
 		//! Draws a single pixel
-		virtual void drawPixel(u32 x, u32 y, const SColor & color) _IRR_OVERRIDE_;
+		void drawPixel(u32 x, u32 y, const SColor & color) override;
 
 		//! Draws a 3d line.
 		virtual void draw3DLine(const core::vector3df& start,
 				const core::vector3df& end,
-				SColor color = SColor(255, 255, 255, 255)) _IRR_OVERRIDE_;
+				SColor color = SColor(255, 255, 255, 255)) override;
 
 		//! Draws a shadow volume into the stencil buffer.
-		virtual void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) _IRR_OVERRIDE_;
+		void drawStencilShadowVolume(const core::array<core::vector3df>& triangles, bool zfail, u32 debugDataVisible=0) override;
 
 		//! Fills the stencil shadow with color.
 		virtual void drawStencilShadow(bool clearStencilBuffer=false,
 			video::SColor leftUpEdge = video::SColor(0,0,0,0),
 			video::SColor rightUpEdge = video::SColor(0,0,0,0),
 			video::SColor leftDownEdge = video::SColor(0,0,0,0),
-			video::SColor rightDownEdge = video::SColor(0,0,0,0)) _IRR_OVERRIDE_;
+			video::SColor rightDownEdge = video::SColor(0,0,0,0)) override;
 
 		//! Get ZBuffer bits.
-		virtual GLenum getZBufferBits() const _IRR_OVERRIDE_;
+		GLenum getZBufferBits() const override;
 
 		virtual bool getColorFormatParameters(ECOLOR_FORMAT format, GLint& internalFormat, GLenum& pixelFormat,
-			GLenum& pixelType, void(**converter)(const void*, s32, void*)) const _IRR_OVERRIDE_;
+			GLenum& pixelType, void(**converter)(const void*, s32, void*)) const override;
 
 	protected:
 		// create a meshbuffer which has as many vertices as indices
 		scene::SMeshBuffer* createSimpleMeshBuffer(irr::u32 numVertices, scene::E_PRIMITIVE_TYPE primitiveType, scene::E_HARDWARE_MAPPING vertexMappingHint=scene::EHM_STREAM, scene::E_HARDWARE_MAPPING indexMappingHint=scene::EHM_STATIC) const;
 
-		virtual bool genericDriverInit(const core::dimension2d<u32>& screenSize, bool stencilBuffer) _IRR_OVERRIDE_;
+		bool genericDriverInit(const core::dimension2d<u32>& screenSize, bool stencilBuffer) override;
 		void initWebGLExtensions();
 
 	private:

--- a/source/Irrlicht/CWriteFile.h
+++ b/source/Irrlicht/CWriteFile.h
@@ -27,19 +27,19 @@ namespace io
 		virtual ~CWriteFile();
 
 		//! Reads an amount of bytes from the file.
-		virtual size_t write(const void* buffer, size_t sizeToWrite) _IRR_OVERRIDE_;
+		size_t write(const void* buffer, size_t sizeToWrite) override;
 
 		//! Changes position in file, returns true if successful.
-		virtual bool seek(long finalPos, bool relativeMovement = false) _IRR_OVERRIDE_;
+		bool seek(long finalPos, bool relativeMovement = false) override;
 
 		//! Returns the current position in the file.
-		virtual long getPos() const _IRR_OVERRIDE_;
+		long getPos() const override;
 
 		//! Returns name of file.
-		virtual const io::path& getFileName() const _IRR_OVERRIDE_;
+		const io::path& getFileName() const override;
 
 		//! Flush the content of the buffer in the file
-		virtual bool flush() _IRR_OVERRIDE_;
+		bool flush() override;
 
 		//! returns if file is open
 		bool isOpen() const;

--- a/source/Irrlicht/CXMeshFileLoader.h
+++ b/source/Irrlicht/CXMeshFileLoader.h
@@ -31,13 +31,13 @@ public:
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".cob")
-	virtual bool isALoadableFileExtension(const io::path& filename) const _IRR_OVERRIDE_;
+	bool isALoadableFileExtension(const io::path& filename) const override;
 
 	//! creates/loads an animated mesh from the file.
 	//! \return Pointer to the created mesh. Returns 0 if loading failed.
 	//! If you no longer need the mesh, you should call IAnimatedMesh::drop().
 	//! See IReferenceCounted::drop() for more information.
-	virtual IAnimatedMesh* createMesh(io::IReadFile* file) _IRR_OVERRIDE_;
+	IAnimatedMesh* createMesh(io::IReadFile* file) override;
 
 	struct SXMesh
 	{

--- a/source/Irrlicht/CZipReader.h
+++ b/source/Irrlicht/CZipReader.h
@@ -145,28 +145,28 @@ namespace io
 
 		//! returns true if the file maybe is able to be loaded by this class
 		//! based on the file extension (e.g. ".zip")
-		virtual bool isALoadableFileFormat(const io::path& filename) const _IRR_OVERRIDE_;
+		bool isALoadableFileFormat(const io::path& filename) const override;
 
 		//! Check if the file might be loaded by this class
 		/** Check might look into the file.
 		\param file File handle to check.
 		\return True if file seems to be loadable. */
-		virtual bool isALoadableFileFormat(io::IReadFile* file) const _IRR_OVERRIDE_;
+		bool isALoadableFileFormat(io::IReadFile* file) const override;
 
 		//! Check to see if the loader can create archives of this type.
 		/** Check based on the archive type.
 		\param fileType The archive type to check.
 		\return True if the archile loader supports this type, false if not */
-		virtual bool isALoadableFileFormat(E_FILE_ARCHIVE_TYPE fileType) const _IRR_OVERRIDE_;
+		bool isALoadableFileFormat(E_FILE_ARCHIVE_TYPE fileType) const override;
 
 		//! Creates an archive from the filename
 		/** \param file File handle to check.
 		\return Pointer to newly created archive, or 0 upon error. */
-		virtual IFileArchive* createArchive(const io::path& filename, bool ignoreCase, bool ignorePaths) const _IRR_OVERRIDE_;
+		IFileArchive* createArchive(const io::path& filename, bool ignoreCase, bool ignorePaths) const override;
 
 		//! creates/loads an archive from the file.
 		//! \return Pointer to the created archive. Returns 0 if loading failed.
-		virtual io::IFileArchive* createArchive(io::IReadFile* file, bool ignoreCase, bool ignorePaths) const _IRR_OVERRIDE_;
+		io::IFileArchive* createArchive(io::IReadFile* file, bool ignoreCase, bool ignorePaths) const override;
 
 	private:
 		io::IFileSystem* FileSystem;
@@ -186,19 +186,19 @@ namespace io
 		virtual ~CZipReader();
 
 		//! opens a file by file name
-		virtual IReadFile* createAndOpenFile(const io::path& filename) _IRR_OVERRIDE_;
+		IReadFile* createAndOpenFile(const io::path& filename) override;
 
 		//! opens a file by index
-		virtual IReadFile* createAndOpenFile(u32 index) _IRR_OVERRIDE_;
+		IReadFile* createAndOpenFile(u32 index) override;
 
 		//! returns the list of files
-		virtual const IFileList* getFileList() const _IRR_OVERRIDE_;
+		const IFileList* getFileList() const override;
 
 		//! get the archive type
-		virtual E_FILE_ARCHIVE_TYPE getType() const _IRR_OVERRIDE_;
+		E_FILE_ARCHIVE_TYPE getType() const override;
 
 		//! return the id of the file Archive
-		virtual const io::path& getArchiveName() const _IRR_OVERRIDE_ {return Path;}
+		const io::path& getArchiveName() const override {return Path;}
 
 	protected:
 


### PR DESCRIPTION
The commit also establishes a precedent of leaving off the `virtual` keyword in overrides. Although not strictly necessary, I believe this is good for readability because it makes it clear it is an override and not a pure virtual function, and it helps keep line lengths shorter.