### PR TITLE
feat(win32): Add basic IME supports for Windows

### DIFF
--- a/include/CIrrWin32IME.h
+++ b/include/CIrrWin32IME.h
@@ -1,0 +1,24 @@
+#ifndef __C_IRR_WIN32_IME_H_INCLUDED__
+#define __C_IRR_WIN32_IME_H_INCLUDED__
+
+#include "IrrCompileConfig.h"
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
+
+#include <windows.h>
+
+namespace irr
+{
+  extern "C" IRRLICHT_API void initIme(HWND value);
+  extern "C" IRRLICHT_API bool isImeEnabled();
+  extern "C" IRRLICHT_API void updateCompositionWindow(void* hWnd, s32 x, s32 y, s32 height);
+  extern "C" IRRLICHT_API void cancelImeEdit();
+  extern "C" IRRLICHT_API void enableIME(bool enabled, HWND hWnd);
+  extern "C" IRRLICHT_API void createIMEContent(HWND hWnd);
+  extern "C" IRRLICHT_API void clearIMEContent();
+  extern "C" IRRLICHT_API LONG getStringFromIme(HIMC imm_context, WPARAM lparam,
+                        int type, const wchar_t* result, LONG string_size);
+  extern "C" IRRLICHT_API LONG getResultFromIme(HIMC imm_context, WPARAM lparam, const wchar_t* result, LONG string_size);
+}
+
+#endif // _IRR_COMPILE_WITH_WINDOWS_DEVICE_
+#endif // __C_IRR_WIN32_IME_H_INCLUDED__

--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -86,12 +86,6 @@ namespace irr
 		//! Application state events like a resume, pause etc.
 		EET_APPLICATION_EVENT,
 
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-		//! A input method event
-		//! Input method events are created by the input method message and passed to IrrlichtDevice::postEventFromUser.
-		EET_IMPUT_METHOD_EVENT,
-#endif
-
 		//! This enum is never used, it only forces the compiler to
 		//! compile these enumeration values to 32 bit.
 		EGUIET_FORCE_32_BIT = 0x7fffffff
@@ -229,17 +223,6 @@ namespace irr
 		//! No real event, but to get number of event types.
 		EAET_COUNT
 	};
-
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-	//! Enumeration for all input method events
-	enum EINPUT_METHOD_EVENT
-	{
-		//! change position of composition window
-		EIME_CHANGE_POS,
-
-		EIME_FORCE_32_BIT = 0x7fffffff
-	};
-#endif
 
 	namespace gui
 	{
@@ -544,17 +527,6 @@ struct SEvent
 		size_t UserData2;
 	};
 
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-	struct SInputMethodEvent
-	{
-		//! Parent window handle for IMM functions (Windows only)
-		void* Handle;
-
-		//! Type of input method event
-		EINPUT_METHOD_EVENT Event;
-	};
-#endif
-
 	// Raw events from the OS
 	struct SSystemEvent
 	{
@@ -596,9 +568,6 @@ struct SEvent
 		struct SUserEvent UserEvent;
 		struct SSystemEvent SystemEvent;
 		struct SApplicationEvent ApplicationEvent;
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-		struct SInputMethodEvent InputMethodEvent;
-#endif
 	};
 
 };

--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -86,6 +86,12 @@ namespace irr
 		//! Application state events like a resume, pause etc.
 		EET_APPLICATION_EVENT,
 
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+		//! A input method event
+		//! Input method events are created by the input method message and passed to IrrlichtDevice::postEventFromUser.
+		EET_IMPUT_METHOD_EVENT,
+#endif
+
 		//! This enum is never used, it only forces the compiler to
 		//! compile these enumeration values to 32 bit.
 		EGUIET_FORCE_32_BIT = 0x7fffffff
@@ -223,6 +229,17 @@ namespace irr
 		//! No real event, but to get number of event types.
 		EAET_COUNT
 	};
+
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+	//! Enumeration for all input method events
+	enum EINPUT_METHOD_EVENT
+	{
+		//! change position of composition window
+		EIME_CHANGE_POS,
+
+		EIME_FORCE_32_BIT = 0x7fffffff
+	};
+#endif
 
 	namespace gui
 	{
@@ -527,6 +544,17 @@ struct SEvent
 		size_t UserData2;
 	};
 
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+	struct SInputMethodEvent
+	{
+		//! Parent window handle for IMM functions (Windows only)
+		void* Handle;
+
+		//! Type of input method event
+		EINPUT_METHOD_EVENT Event;
+	};
+#endif
+
 	// Raw events from the OS
 	struct SSystemEvent
 	{
@@ -568,6 +596,9 @@ struct SEvent
 		struct SUserEvent UserEvent;
 		struct SSystemEvent SystemEvent;
 		struct SApplicationEvent ApplicationEvent;
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+		struct SInputMethodEvent InputMethodEvent;
+#endif
 	};
 
 };

--- a/include/IGUIElement.h
+++ b/include/IGUIElement.h
@@ -237,12 +237,27 @@ public:
 	virtual void updateAbsolutePosition()
 	{
 		recalculateAbsolutePosition(false);
+		updateImePosition();
 
 		// update all children
 		for (auto child : Children)
 		{
 			child->updateAbsolutePosition();
 		}
+	}
+
+
+	//! Gets the position of this input composition window
+	core::position2di getImePosition() const
+	{
+		return ImePosition;
+	}
+
+	//! update the position of input composition window
+	virtual core::position2di updateImePosition()
+	{
+		ImePosition = AbsoluteRect.LowerRightCorner;
+		return ImePosition;
 	}
 
 
@@ -1026,6 +1041,8 @@ protected:
 
 	//! type of element
 	EGUI_ELEMENT_TYPE Type;
+
+	core::position2di ImePosition;
 };
 
 

--- a/include/IrrCompileConfig.h
+++ b/include/IrrCompileConfig.h
@@ -297,6 +297,11 @@ you will not be able to use anything provided by the GUI Environment, including 
 #undef _IRR_COMPILE_WITH_GUI_
 #endif
 
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_)
+/** This enables the engine to intercept input method messages on Win32. */
+#define _IRR_USE_WIN32_IME
+#endif
+
 //! Define _IRR_COMPILE_WITH_LIBJPEG_ to enable compiling the engine using libjpeg.
 /** This enables the engine to read jpeg images. If you comment this out,
 the engine will no longer read .jpeg images. */

--- a/scripts/ci-build-mingw.sh
+++ b/scripts/ci-build-mingw.sh
@@ -20,6 +20,12 @@ tmp=
 	wget "http://minetest.kitsunemimi.pw/${tmp}libpng-$libpng_version-$variant.zip" -O libpng.zip
 [ -e zlib.zip ] || \
 	wget "http://minetest.kitsunemimi.pw/${tmp}zlib-$zlib_version-$variant.zip" -O zlib.zip
+[ -e imm32_32.lib ] || \
+	wget "https://github.com/tpn/winsdk-7/raw/master/v7.1A/Lib/Imm32.Lib" -O imm32_32.lib
+[ -e imm32_64.lib ] || \
+	wget "https://github.com/tpn/winsdk-7/raw/master/v7.1A/Lib/x64/Imm32.Lib" -O imm32_64.lib
+[ "$variant" == win64 ] && cp imm32_64.lib imm32.lib
+[ "$variant" != win64 ] && cp imm32_32.lib imm32.lib
 [ -d libjpeg ] || unzip -o libjpeg.zip -d libjpeg
 [ -d libpng ] || unzip -o libpng.zip -d libpng
 [ -d zlib ] || unzip -o zlib.zip -d zlib
@@ -27,6 +33,7 @@ popd
 
 tmp=(
 	-DCMAKE_SYSTEM_NAME=Windows \
+	-DIMM32_LIBRARY=$libs/imm32.lib \
 	-DPNG_LIBRARY=$libs/libpng/lib/libpng.dll.a \
 	-DPNG_PNG_INCLUDE_DIR=$libs/libpng/include \
 	-DJPEG_LIBRARY=$libs/libjpeg/lib/libjpeg.dll.a \

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -252,14 +252,12 @@ bool CGUIEditBox::OnEvent(const SEvent& event)
 #endif
 			}
 			else if (event.GUIEvent.EventType == EGET_ELEMENT_FOCUSED) {
+				bool isImeAccepted = acceptsIME();
 #if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-				irr::enableIME(!PasswordBox, nullptr);
+				irr::enableIME(isImeAccepted, nullptr);
 #endif
-				if (!PasswordBox) {
-					core::position2di pos = updateImePosition();
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-					// irr::updateCompositionWindow(nullptr, pos.X, pos.Y, 0);
-#endif
+				if (isImeAccepted) {
+					updateImePosition();
 				}
 			}
 			break;

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -251,15 +251,17 @@ bool CGUIEditBox::OnEvent(const SEvent& event)
 				irr::enableIME(false, nullptr);
 #endif
 			}
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
 			else if (event.GUIEvent.EventType == EGET_ELEMENT_FOCUSED) {
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
 				irr::enableIME(!PasswordBox, nullptr);
+#endif
 				if (!PasswordBox) {
 					core::position2di pos = updateImePosition();
-					irr::updateCompositionWindow(nullptr, pos.X, pos.Y, 0);
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+					// irr::updateCompositionWindow(nullptr, pos.X, pos.Y, 0);
+#endif
 				}
 			}
-#endif
 			break;
 		case EET_KEY_INPUT_EVENT:
 			if (processKey(event))
@@ -790,7 +792,6 @@ bool CGUIEditBox::keyDelete()
 	return false;
 }
 
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
 //! calculate the position of input composition window
 core::position2di CGUIEditBox::updateImePosition()
 {
@@ -815,10 +816,7 @@ core::position2di CGUIEditBox::updateImePosition()
 
 	ImePosition = pos;
 	return ImePosition;
-
-	// return new irr::core::position2di(pos);
 }
-#endif
 
 //! draws the element and its children
 void CGUIEditBox::draw()

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -255,18 +255,12 @@ bool CGUIEditBox::OnEvent(const SEvent& event)
 			else if (event.GUIEvent.EventType == EGET_ELEMENT_FOCUSED) {
 				irr::enableIME(!PasswordBox, nullptr);
 				if (!PasswordBox) {
-					core::position2di pos = calculateImePos();
-					irr::updateCompositionWindow(nullptr, pos.X,pos.Y, 0);
+					core::position2di pos = updateImePosition();
+					irr::updateCompositionWindow(nullptr, pos.X, pos.Y, 0);
 				}
 			}
 #endif
 			break;
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-		case EET_IMPUT_METHOD_EVENT:
-			if (processIMEEvent(event))
-				return true;
-			break;
-#endif
 		case EET_KEY_INPUT_EVENT:
 			if (processKey(event))
 				return true;
@@ -797,33 +791,8 @@ bool CGUIEditBox::keyDelete()
 }
 
 #if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-bool CGUIEditBox::processIMEEvent(const SEvent& event)
-{
-	switch(event.InputMethodEvent.Event)
-	{
-		case EIME_CHANGE_POS:
-			{
-				core::position2di pos = calculateImePos();
-
-				IGUIFont* font = OverrideFont;
-				IGUISkin* skin = Environment->getSkin();
-
-				if (!OverrideFont)
-					font = skin->getFont();
-
-				irr::updateCompositionWindow(event.InputMethodEvent.Handle, pos.X,pos.Y, font->getDimension(L"|").Height);
-
-				return true;
-			}
-		default:
-			break;
-	}
-
-	return false;
-}
-
 //! calculate the position of input composition window
-irr::core::position2di CGUIEditBox::calculateImePos()
+core::position2di CGUIEditBox::updateImePosition()
 {
 	irr::core::position2di pos;
 	IGUIFont* font = OverrideFont;
@@ -844,7 +813,10 @@ irr::core::position2di CGUIEditBox::calculateImePos()
 		pos.Y = AbsoluteRect.getCenter().Y + (Border ? 3 : 0); //bug? The text is always drawn in the height of the center. SetTextAlignment() doesn't influence.
 	}
 
-	return pos;
+	ImePosition = pos;
+	return ImePosition;
+
+	// return new irr::core::position2di(pos);
 }
 #endif
 

--- a/source/Irrlicht/CGUIEditBox.h
+++ b/source/Irrlicht/CGUIEditBox.h
@@ -142,6 +142,11 @@ namespace gui
 		//! Returns whether the element takes input from the IME
 		bool acceptsIME() override;
 
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+		//! calculates the input composition position
+		virtual core::position2di updateImePosition() _IRR_OVERRIDE_;
+#endif
+
 	protected:
 		//! Breaks the single text line.
 		void breakText();
@@ -166,11 +171,6 @@ namespace gui
 
 		bool processKey(const SEvent& event);
 		bool processMouse(const SEvent& event);
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
-		bool processIMEEvent(const SEvent& event);
-		//! calculates the input composition position
-		core::position2di calculateImePos();
-#endif
 		s32 getCursorPos(s32 x, s32 y);
 
 		bool OverwriteMode;

--- a/source/Irrlicht/CGUIEditBox.h
+++ b/source/Irrlicht/CGUIEditBox.h
@@ -166,6 +166,11 @@ namespace gui
 
 		bool processKey(const SEvent& event);
 		bool processMouse(const SEvent& event);
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
+		bool processIMEEvent(const SEvent& event);
+		//! calculates the input composition position
+		core::position2di calculateImePos();
+#endif
 		s32 getCursorPos(s32 x, s32 y);
 
 		bool OverwriteMode;

--- a/source/Irrlicht/CGUIEditBox.h
+++ b/source/Irrlicht/CGUIEditBox.h
@@ -142,10 +142,8 @@ namespace gui
 		//! Returns whether the element takes input from the IME
 		bool acceptsIME() override;
 
-#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) && defined(_IRR_USE_WIN32_IME)
 		//! calculates the input composition position
-		virtual core::position2di updateImePosition() _IRR_OVERRIDE_;
-#endif
+		core::position2di updateImePosition() override;
 
 	protected:
 		//! Breaks the single text line.

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1148,10 +1148,11 @@ bool CIrrDeviceLinux::run()
 				gui::IGUIElement *elem = GUIEnvironment->getFocus();
 				if (elem && elem->acceptsIME())
 				{
-					core::rect<s32> r = elem->getAbsolutePosition();
+					// core::rect<s32> r = elem->getAbsolutePosition();
+					core::position2di pos = elem->updateImePosition();
 					XPoint p;
-					p.x = (short)r.UpperLeftCorner.X;
-					p.y = (short)r.LowerRightCorner.Y;
+					p.x = (short)pos.X;
+					p.y = (short)pos.Y;
 					XSetICFocus(XInputContext);
 					XVaNestedList l = XVaCreateNestedList(0, XNSpotLocation, &p, NULL);
 					XSetICValues(XInputContext, XNPreeditAttributes, l, NULL);

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -853,7 +853,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 					LONG length_with_null = (str_size / sizeof(wchar_t)) + 1;
 					wchar_t wBuf[length_with_null];
 					if (irr::getResultFromIme(hIMC, lParam, wBuf, str_size)) {
-						wBuf[length_with_null-1] = 0;
+						wBuf[length_with_null-1] = (wchar_t) 0;
 						// Multiple characters: send string event
 						event.EventType = irr::EET_STRING_INPUT_EVENT;
 						event.StringInput.Str = new irr::core::stringw(wBuf);

--- a/source/Irrlicht/CIrrWin32IME.cpp
+++ b/source/Irrlicht/CIrrWin32IME.cpp
@@ -13,7 +13,7 @@ namespace irr
 {
     static HWND                     gDefaultImeWnd = nullptr;
     static HIMC                     gDefaultIMC = nullptr;
-    static HIMC                     gPrevIMC = nullptr;
+    // static HIMC                     gPrevIMC = nullptr;
     static HWND                     gCurrentWnd;
     static bool                     gImeEnabled = false;
 

--- a/source/Irrlicht/CIrrWin32IME.cpp
+++ b/source/Irrlicht/CIrrWin32IME.cpp
@@ -1,0 +1,122 @@
+#include "IrrCompileConfig.h"
+
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
+
+#include <math.h>
+#include <msctf.h>
+#include <malloc.h>
+#include "os.h"
+#include "IEventReceiver.h"
+#include "CIrrWin32IME.h"
+
+namespace irr
+{
+    static HWND                     gDefaultImeWnd = nullptr;
+    static HIMC                     gDefaultIMC = nullptr;
+    static HIMC                     gPrevIMC = nullptr;
+    static HWND                     gCurrentWnd;
+    static bool                     gImeEnabled = false;
+
+    void initIme(HWND value) {
+        gCurrentWnd = value;
+        gDefaultImeWnd = ImmGetDefaultIMEWnd(nullptr);
+        gDefaultIMC = ImmGetContext(value);
+        ImmReleaseContext(value, gDefaultIMC);
+    }
+
+    bool isImeEnabled() {
+        return gImeEnabled;
+    }
+
+    void cancelImeEdit() {
+        if (!gImeEnabled) return;
+        HIMC vIMC = ImmGetContext(gCurrentWnd);
+        if (vIMC) {
+            ImmNotifyIME(vIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+            ImmReleaseContext(gCurrentWnd, vIMC);
+        }
+    }
+
+    void clearIMEContent() {
+        if (gCurrentWnd) {
+            HIMC vIMC = ImmGetContext(gCurrentWnd);
+            if (vIMC) {
+                ImmSetOpenStatus( vIMC, false );
+                ImmReleaseContext(gCurrentWnd, vIMC);
+            }
+            ImmAssociateContext(gCurrentWnd, nullptr);
+        }
+    }
+
+    void createIMEContent(HWND hWnd) {
+        if (hWnd == nullptr) {
+            hWnd = gCurrentWnd;
+        } else if (hWnd != gCurrentWnd) {
+            gCurrentWnd = hWnd;
+        }
+        if (hWnd ==nullptr) return;
+        if (gDefaultIMC) ImmAssociateContext(gCurrentWnd, gDefaultIMC);
+
+        HIMC vIMC = ImmGetContext(hWnd);
+        if (vIMC) {
+            ImmSetOpenStatus(vIMC, true);
+            ImmReleaseContext(hWnd, vIMC);
+        }
+    }
+
+    void enableIME(bool enabled, HWND hWnd) {
+        if (!enabled) {
+            clearIMEContent();
+        } else {
+            clearIMEContent();
+            createIMEContent(hWnd);
+        }
+        gImeEnabled = enabled;
+        return;
+    }
+
+    LONG getStringFromIme(HIMC imm_context, WPARAM lparam,
+                int type, const wchar_t* result, LONG string_size) {
+        if (string_size <= 0)
+            return ::ImmGetCompositionStringW(imm_context, type, NULL, 0);
+
+        return ::ImmGetCompositionStringW(imm_context, type, const_cast<wchar_t*>(result), string_size);
+    }
+
+    LONG getResultFromIme(HIMC imm_context, WPARAM lparam, const wchar_t* result, LONG string_size) {
+        if (!(lparam & GCS_RESULTSTR)) return IMM_ERROR_NODATA;
+
+        LONG ret = getStringFromIme(imm_context, lparam, GCS_RESULTSTR, result, string_size);
+        return ret;
+    }
+
+    void updateCompositionWindow(void* hWnd, s32 x, s32 y, s32 height)
+    {
+        if (gCurrentWnd != hWnd) {
+            enableIME(gImeEnabled, (HWND)hWnd);
+        }
+        if (!gImeEnabled) return;
+
+        COMPOSITIONFORM cf;
+        static bool bNoReentrance = false;
+        if (bNoReentrance) return;
+        bNoReentrance = true;
+        HIMC hIMC = ImmGetContext(gCurrentWnd);
+        if(hIMC)
+        {
+            cf.dwStyle = CFS_POINT | CFS_FORCE_POSITION;
+            cf.ptCurrentPos.x = x;
+            cf.ptCurrentPos.y = y;// - height;
+
+            auto lRet = ImmSetCompositionWindow(hIMC, &cf);
+            if (!lRet) {
+                char s[32];
+                snprintf(s, sizeof(s), "ImmSetCompositionWindow failed\n");
+                irr::os::Printer::log((char*)&s, irr::ELL_ERROR);
+            }
+            ImmReleaseContext(gCurrentWnd, hIMC);
+        }
+        bNoReentrance = false;
+    }
+}
+#endif

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -140,6 +140,7 @@ set(link_libs
 	"${JPEG_LIBRARY}"
 	"${PNG_LIBRARY}"
 	"${SDL2_LIBRARIES}"
+	"${IMM32_LIBRARY}"
 
 	${OPENGL_LIBRARIES}
 	${OPENGLES_LIBRARY}
@@ -237,6 +238,7 @@ add_library(IRROTHEROBJ OBJECT
 	CIrrDeviceLinux.cpp
 	CIrrDeviceStub.cpp
 	CIrrDeviceWin32.cpp
+	CIrrWin32IME.cpp
 	CLogger.cpp
 	COSOperator.cpp
 	Irrlicht.cpp


### PR DESCRIPTION
The IME can be used basically on Windows.

dependency PR: GH-138

+ add `_IRR_USE_WIN32_IME` compiler directive, defaults to true
+ add `CIrrWin32IME.cpp/.h` for Windows IME helper functions
  * have to export for minetest's guiChatConsole
  * Maybe need to refact an abstract CGUIEditable class

Note: Sometime, some IMEs can not get char from `WM_IME_CHAR` message, so I have to use WM_IME_COMPOSITION to get it.

Anyway, It's worked basically.