### PR TITLE
Add window-maximization creation-param, and isWindowMaximized()

### DIFF
--- a/include/IrrCompileConfig.h
+++ b/include/IrrCompileConfig.h
@@ -45,7 +45,7 @@
 //! Example: NO_IRR_COMPILE_WITH_X11_ would disable X11
 
 //! Uncomment this line to compile with the SDL device
-//#define _IRR_COMPILE_WITH_SDL_DEVICE_
+#define _IRR_COMPILE_WITH_SDL_DEVICE_
 #ifdef NO_IRR_COMPILE_WITH_SDL_DEVICE_
 #undef _IRR_COMPILE_WITH_SDL_DEVICE_
 #endif

--- a/include/IrrCompileConfig.h
+++ b/include/IrrCompileConfig.h
@@ -45,7 +45,7 @@
 //! Example: NO_IRR_COMPILE_WITH_X11_ would disable X11
 
 //! Uncomment this line to compile with the SDL device
-#define _IRR_COMPILE_WITH_SDL_DEVICE_
+//#define _IRR_COMPILE_WITH_SDL_DEVICE_
 #ifdef NO_IRR_COMPILE_WITH_SDL_DEVICE_
 #undef _IRR_COMPILE_WITH_SDL_DEVICE_
 #endif

--- a/include/IrrlichtDevice.h
+++ b/include/IrrlichtDevice.h
@@ -156,6 +156,11 @@ namespace irr
 		/** \return True if window is minimized. */
 		virtual bool isWindowMinimized() const = 0;
 
+		//! Checks if the Irrlicht window is maximized
+		//! Only works on SDL. Always returns false on other backends.
+		/** \return True if window is maximized. */
+		virtual bool isWindowMaximized() const = 0;
+
 		//! Checks if the Irrlicht window is running in fullscreen mode
 		/** \return True if window is fullscreen. */
 		virtual bool isFullscreen() const = 0;

--- a/include/IrrlichtDevice.h
+++ b/include/IrrlichtDevice.h
@@ -157,7 +157,8 @@ namespace irr
 		virtual bool isWindowMinimized() const = 0;
 
 		//! Checks if the Irrlicht window is maximized
-		//! Only works on SDL. Always returns false on other backends.
+		//! Only fully works on SDL. Returns false, or the last value set via
+		//! maximizeWindow() and restoreWindow(), on other backends.
 		/** \return True if window is maximized. */
 		virtual bool isWindowMaximized() const = 0;
 

--- a/include/SIrrCreationParameters.h
+++ b/include/SIrrCreationParameters.h
@@ -30,6 +30,7 @@ namespace irr
 			Bits(32),
 			ZBufferBits(24),
 			Fullscreen(false),
+			WindowMaximized(false),
 			WindowResizable(2),
 			Stencilbuffer(true),
 			Vsync(false),
@@ -73,6 +74,7 @@ namespace irr
 			Bits = other.Bits;
 			ZBufferBits = other.ZBufferBits;
 			Fullscreen = other.Fullscreen;
+			WindowMaximized = other.WindowMaximized;
 			WindowResizable = other.WindowResizable;
 			Stencilbuffer = other.Stencilbuffer;
 			Vsync = other.Vsync;
@@ -126,6 +128,9 @@ namespace irr
 		//! Should be set to true if the device should run in fullscreen.
 		/** Otherwise the device runs in windowed mode. Default: false. */
 		bool Fullscreen;
+
+		//! Maximised window. (Only supported on SDL.) Default: false
+		bool WindowMaximized;
 
 		//! Should a non-fullscreen window be resizable.
 		/** Might not be supported by all devices. Ignored when Fullscreen is true.

--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -118,7 +118,7 @@ CIrrDeviceLinux::CIrrDeviceLinux(const SIrrlichtCreationParameters& param)
 	currentTouchedCount(0),
 #endif
 	Width(param.WindowSize.Width), Height(param.WindowSize.Height),
-	WindowHasFocus(false), WindowMinimized(false),
+	WindowHasFocus(false), WindowMinimized(false), WindowMaximized(param.WindowMaximized),
 	ExternalWindow(false), AutorepeatSupport(0)
 {
 	#ifdef _DEBUG
@@ -168,6 +168,9 @@ CIrrDeviceLinux::CIrrDeviceLinux(const SIrrlichtCreationParameters& param)
 		return;
 
 	createGUIAndScene();
+
+	if (param.WindowMaximized)
+		maximizeWindow();
 }
 
 
@@ -1200,6 +1203,13 @@ bool CIrrDeviceLinux::isWindowMinimized() const
 }
 
 
+//! returns last state from maximizeWindow() and restoreWindow()
+bool CIrrDeviceLinux::isWindowMaximized() const
+{
+	return WindowMaximized;
+}
+
+
 //! returns color format of the window.
 video::ECOLOR_FORMAT CIrrDeviceLinux::getColorFormat() const
 {
@@ -1284,6 +1294,8 @@ void CIrrDeviceLinux::maximizeWindow()
 	}
 
 	XMapWindow(XDisplay, XWindow);
+
+	WindowMaximized = true;
 #endif
 }
 
@@ -1310,6 +1322,8 @@ void CIrrDeviceLinux::restoreWindow()
 	}
 
 	XMapWindow(XDisplay, XWindow);
+
+	WindowMaximized = false;
 #endif
 }
 

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -64,6 +64,9 @@ namespace irr
 		//! returns if window is minimized.
 		bool isWindowMinimized() const override;
 
+		//! returns last state from maximizeWindow() and restoreWindow()
+		bool isWindowMaximized() const override;
+
 		//! returns color format of the window.
 		video::ECOLOR_FORMAT getColorFormat() const override;
 
@@ -415,6 +418,7 @@ namespace irr
 		u32 Width, Height;
 		bool WindowHasFocus;
 		bool WindowMinimized;
+		bool WindowMaximized;
 		bool ExternalWindow;
 		int AutorepeatSupport;
 

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -77,7 +77,7 @@ namespace irr
 		void restoreWindow() override;
 
 		//! Checks if the window is maximized.
-		virtual bool isWindowMaximized() const _IRR_OVERRIDE_;
+		bool isWindowMaximized() const override;
 
 		//! Checks if the Irrlicht window is running in fullscreen mode
 		/** \return True if window is fullscreen. */

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -76,6 +76,9 @@ namespace irr
 		//! Restores the window size.
 		void restoreWindow() override;
 
+		//! Checks if the window is maximized.
+		virtual bool isWindowMaximized() const _IRR_OVERRIDE_;
+
 		//! Checks if the Irrlicht window is running in fullscreen mode
 		/** \return True if window is fullscreen. */
 		bool isFullscreen() const override;
@@ -283,7 +286,6 @@ namespace irr
 		u32 Width, Height;
 
 		bool Resizable;
-		bool WindowMinimized;
 
 		struct SKeyMap
 		{

--- a/source/Irrlicht/CIrrDeviceStub.cpp
+++ b/source/Irrlicht/CIrrDeviceStub.cpp
@@ -272,6 +272,13 @@ void CIrrDeviceStub::setInputReceivingSceneManager(scene::ISceneManager* sceneMa
 }
 
 
+//! Checks if the window is maximized.
+bool CIrrDeviceStub::isWindowMaximized() const
+{
+	return false;
+}
+
+
 //! Checks if the window is running in fullscreen mode
 bool CIrrDeviceStub::isFullscreen() const
 {

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -139,6 +139,9 @@ namespace irr
 		//! Is device motion active.
 		bool isDeviceMotionActive() override;
 
+		//! Is device motion available.
+		bool isDeviceMotionAvailable() override;
+
 		//! Set the maximal elapsed time between 2 clicks to generate doubleclicks for the mouse. It also affects tripleclick behavior.
 		//! When set to 0 no double- and tripleclicks will be generated.
 		void setDoubleClickTime( u32 timeMs ) override;

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -94,6 +94,9 @@ namespace irr
 		//! Returns the operation system opertator object.
 		IOSOperator* getOSOperator() override;
 
+		//! Checks if the window is maximized.
+		bool isWindowMaximized() const override;
+
 		//! Checks if the window is running in fullscreen mode.
 		bool isFullscreen() const override;
 
@@ -103,41 +106,38 @@ namespace irr
 		//! Activate any joysticks, and generate events for them.
 		bool activateJoysticks(core::array<SJoystickInfo> & joystickInfo) override;
 
-        //! Activate accelerometer.
-        bool activateAccelerometer(float updateInterval = 0.016666f) override;
-        
-        //! Deactivate accelerometer.
-        bool deactivateAccelerometer() override;
-        
-        //! Is accelerometer active.
-        bool isAccelerometerActive() override;
-        
-        //! Is accelerometer available.
-        bool isAccelerometerAvailable() override;
-        
-        //! Activate gyroscope.
-        bool activateGyroscope(float updateInterval = 0.016666f) override;
-        
-        //! Deactivate gyroscope.
-        bool deactivateGyroscope() override;
-        
-        //! Is gyroscope active.
-        bool isGyroscopeActive() override;
-        
-        //! Is gyroscope available.
-        bool isGyroscopeAvailable() override;
-        
-        //! Activate device motion.
-        bool activateDeviceMotion(float updateInterval = 0.016666f) override;
-        
-        //! Deactivate device motion.
-        bool deactivateDeviceMotion() override;
-        
-        //! Is device motion active.
-        bool isDeviceMotionActive() override;
-        
-        //! Is device motion available.
-        bool isDeviceMotionAvailable() override;
+		//! Activate accelerometer.
+		bool activateAccelerometer(float updateInterval = 0.016666f) override;
+
+		//! Deactivate accelerometer.
+		bool deactivateAccelerometer() override;
+
+		//! Is accelerometer active.
+		bool isAccelerometerActive() override;
+
+		//! Is accelerometer available.
+		bool isAccelerometerAvailable() override;
+
+		//! Activate gyroscope.
+		bool activateGyroscope(float updateInterval = 0.016666f) override;
+
+		//! Deactivate gyroscope.
+		bool deactivateGyroscope() override;
+
+		//! Is gyroscope active.
+		bool isGyroscopeActive() override;
+
+		//! Is gyroscope available.
+		bool isGyroscopeAvailable() override;
+
+		//! Activate device motion.
+		bool activateDeviceMotion(float updateInterval = 0.016666f) override;
+
+		//! Deactivate device motion.
+		bool deactivateDeviceMotion() override;
+
+		//! Is device motion active.
+		bool isDeviceMotionActive() override;
 
 		//! Set the maximal elapsed time between 2 clicks to generate doubleclicks for the mouse. It also affects tripleclick behavior.
 		//! When set to 0 no double- and tripleclicks will be generated.

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -784,7 +784,8 @@ namespace irr
 //! constructor
 CIrrDeviceWin32::CIrrDeviceWin32(const SIrrlichtCreationParameters& params)
 : CIrrDeviceStub(params), HWnd(0), Resized(false),
-	ExternalWindow(false), Win32CursorControl(0), JoyControl(0)
+	ExternalWindow(false), Win32CursorControl(0), JoyControl(0),
+	WindowMaximized(params.WindowMaximized)
 {
 	#ifdef _DEBUG
 	setDebugName("CIrrDeviceWin32");
@@ -923,6 +924,9 @@ CIrrDeviceWin32::CIrrDeviceWin32(const SIrrlichtCreationParameters& params)
 
 	// inform driver about the window size etc.
 	resizeIfNecessary();
+
+	if (params.WindowMaximized)
+		maximizeWindow();
 }
 
 
@@ -1154,6 +1158,13 @@ bool CIrrDeviceWin32::isWindowMinimized() const
 }
 
 
+//! returns last state from maximizeWindow() and restoreWindow()
+bool CIrrDeviceWin32::isWindowMaximized() const
+{
+	return WindowMaximized;
+}
+
+
 //! switches to fullscreen
 bool CIrrDeviceWin32::switchToFullScreen()
 {
@@ -1278,6 +1289,8 @@ void CIrrDeviceWin32::maximizeWindow()
 	GetWindowPlacement(HWnd, &wndpl);
 	wndpl.showCmd = SW_SHOWMAXIMIZED;
 	SetWindowPlacement(HWnd, &wndpl);
+
+	WindowMaximized = true;
 }
 
 
@@ -1289,6 +1302,8 @@ void CIrrDeviceWin32::restoreWindow()
 	GetWindowPlacement(HWnd, &wndpl);
 	wndpl.showCmd = SW_SHOWNORMAL;
 	SetWindowPlacement(HWnd, &wndpl);
+
+	WindowMaximized = false;
 }
 
 core::position2di CIrrDeviceWin32::getWindowPosition()

--- a/source/Irrlicht/CIrrDeviceWin32.h
+++ b/source/Irrlicht/CIrrDeviceWin32.h
@@ -57,6 +57,9 @@ namespace irr
 		//! returns if window is minimized
 		bool isWindowMinimized() const override;
 
+		//! returns last state from maximizeWindow() and restoreWindow()
+		bool isWindowMaximized() const override;
+
 		//! notifies the device that it should close itself
 		void closeDevice() override;
 
@@ -413,6 +416,8 @@ namespace irr
 		CCursorControl* Win32CursorControl;
 
 		SJoystickWin32Control* JoyControl;
+
+		bool WindowMaximized;
 	};
 
 } // end namespace irr


### PR DESCRIPTION
Needed because big centered windows don't work well.

<details>

In X11 we don't support centering the window, instead we always use pos (0,0). In SDL, the window can be (and is, because we use pos (-1,-1) in minetest) centered, but it centers into the middle of display area, not usable display area (the usable one doesn't include the panel), which is better for small windows, but completely wrong for big ones, that almost fill the usable area. And changing that (in SDL) would require repositioning the window when the window decoration is added. All in all, it would be complicated, and it's hard to decide *when* to center with respect to which area.

Fix: Keep centering the window in SDL, but store whether the window is maximised (just like `screen_[h,w]`), and maximise window on startup again accordingly.

</details>

See also: https://github.com/minetest/minetest/pull/12861

**Edit: Please don't merge yet.**