### PR TITLE
Point to Irrlicht license in root

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+doc/irrlicht-license.txt


### PR DESCRIPTION
This PR creates a symlink to the license file provided by Irrlicht. This should fix #143.