### PR TITLE
Avoid reskinning joints for animated meshes twice for each frame.

### DIFF
--- a/source/Irrlicht/CAnimatedMeshSceneNode.cpp
+++ b/source/Irrlicht/CAnimatedMeshSceneNode.cpp
@@ -236,15 +236,6 @@ void CAnimatedMeshSceneNode::OnAnimate(u32 timeMs)
 
 	// set CurrentFrameNr
 	buildFrameNr(timeMs-LastTimeMs);
-
-	// update bbox
-	if (Mesh)
-	{
-		scene::IMesh * mesh = getMeshForCurrentFrame();
-
-		if (mesh)
-			Box = mesh->getBoundingBox();
-	}
 	LastTimeMs = timeMs;
 
 	IAnimatedMeshSceneNode::OnAnimate(timeMs);


### PR DESCRIPTION
Needs testing.

The only point to getting the mesh in onAnimate seems to be recalculate the bounding box, which render does again.
Getting an animated mesh reskins it every time. And, worse, onAnimate is called when the mesh is not visible.