### PR TITLE
SDL: Use SDL_WINDOW_FULLSCREEN_DESKTOP, and allow to maximize and fullscreen at once

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -145,12 +145,12 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters& param)
 #else
 		SDL_Flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 #endif
-	} else  {
-		if (Resizable)
-			SDL_Flags |= SDL_WINDOW_RESIZABLE;
-		if (CreationParams.WindowMaximized)
-			SDL_Flags |= SDL_WINDOW_MAXIMIZED;
 	}
+	if (Resizable)
+		SDL_Flags |= SDL_WINDOW_RESIZABLE;
+	if (CreationParams.WindowMaximized)
+		SDL_Flags |= SDL_WINDOW_MAXIMIZED;
+
 	if (CreationParams.DriverType == video::EDT_OPENGL)
 	{
 		SDL_Flags |= SDL_WINDOW_OPENGL;

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -140,7 +140,11 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters& param)
 	createKeyMap();
 
 	if (CreationParams.Fullscreen) {
+#ifdef _IRR_EMSCRIPTEN_PLATFORM_
+		SDL_Flags |= SDL_WINDOW_FULLSCREEN;
+#else
 		SDL_Flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#endif
 	} else  {
 		if (Resizable)
 			SDL_Flags |= SDL_WINDOW_RESIZABLE;

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -140,7 +140,7 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters& param)
 	createKeyMap();
 
 	if (CreationParams.Fullscreen) {
-		SDL_Flags |= SDL_WINDOW_FULLSCREEN;
+		SDL_Flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 	} else  {
 		if (Resizable)
 			SDL_Flags |= SDL_WINDOW_RESIZABLE;


### PR DESCRIPTION
`SDL_WINDOW_FULLSCREEN` changes the screen resolution, and it stays so even after minetest is closed.

Testing instructions:
* Enable autosave screensize.
* Make the window small.
* Enable fullscreen.
* Restart minetest.
* master: Minetest is in low resolution. If you close it, everything is still in this resolution. This is bad.
* PR: Desktop resolution is used.

=> This is a bugfix for SDL.

Note that emscriptem still uses `SDL_WINDOW_FULLSCREEN`. `isFullscreen()` is only implemented in emscriptem, and emscriptem uses `isFullscreen()` for other things, so I didn't want to break anything there.
Testing for `SDL_WINDOW_FULLSCREEN_DESKTOP` in `isFullscreen()` didn't work for me btw. (X11 with openbox). The bit was never set. Hence I didn't implement it.

-----

It is now also possible to set maximized and fullscreen at once.
Sadly however, this isn't correctly stored in SDL's window flags, so autosaving maximized will disable it every time. But well, maybe someone wants to enable fullscreen and maximized and disable autosaving.
