### PR TITLE
Remove unused dependencies from SceneManager

### DIFF
--- a/examples/AutomatedTest/main.cpp
+++ b/examples/AutomatedTest/main.cpp
@@ -85,8 +85,12 @@ int main(int argc, char *argv[])
 
 	const io::path mediaPath = getExampleMediaPath();
 
-	scene::IAnimatedMesh* mesh = smgr->getMesh(mediaPath + "coolguy_opt.x");
+	auto mesh_file = device->getFileSystem()->createAndOpenFile(mediaPath + "coolguy_opt.x");
+	check(mesh_file, "mesh file loading");
+	scene::IAnimatedMesh* mesh = smgr->getMesh(mesh_file);
 	check(mesh, "mesh loading");
+	if (mesh_file)
+		mesh_file->drop();
 	if (mesh)
 	{
 		video::ITexture* tex = driver->getTexture(mediaPath + "cooltexture.png");

--- a/include/ISceneManager.h
+++ b/include/ISceneManager.h
@@ -318,20 +318,10 @@ namespace scene
 		 * \endcode
 		 * If you would like to implement and add your own file format loader to Irrlicht,
 		 * see addExternalMeshLoader().
-		 * \param filename: Filename of the mesh to load.
-		 * \param alternativeCacheName: In case you want to have the mesh under another name in the cache (to create real copies)
+		 * \param file File handle of the mesh to load.
 		 * \return Null if failed, otherwise pointer to the mesh.
 		 * This pointer should not be dropped. See IReferenceCounted::drop() for more information.
 		 **/
-		virtual IAnimatedMesh* getMesh(const io::path& filename, const io::path& alternativeCacheName=io::path("")) = 0;
-
-		//! Get pointer to an animateable mesh. Loads the file if not loaded already.
-		/** Works just as getMesh(const char* filename). If you want to
-		remove a loaded mesh from the cache again, use removeMesh().
-		\param file File handle of the mesh to load.
-		\return NULL if failed and pointer to the mesh if successful.
-		This pointer should not be dropped. See
-		IReferenceCounted::drop() for more information. */
 		virtual IAnimatedMesh* getMesh(io::IReadFile* file) = 0;
 
 		//! Get interface to the mesh cache which is shared between all existing scene managers.
@@ -344,11 +334,6 @@ namespace scene
 		/** \return Pointer to the video Driver.
 		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
 		virtual video::IVideoDriver* getVideoDriver() = 0;
-
-		//! Get the active FileSystem
-		/** \return Pointer to the FileSystem
-		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
-		virtual io::IFileSystem* getFileSystem() = 0;
 
 		//! Adds a scene node for rendering an animated mesh model.
 		/** \param mesh: Pointer to the loaded animated mesh to be displayed.

--- a/include/ISceneManager.h
+++ b/include/ISceneManager.h
@@ -345,11 +345,6 @@ namespace scene
 		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
 		virtual video::IVideoDriver* getVideoDriver() = 0;
 
-		//! Get the active GUIEnvironment
-		/** \return Pointer to the GUIEnvironment
-		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
-		virtual gui::IGUIEnvironment* getGUIEnvironment() = 0;
-
 		//! Get the active FileSystem
 		/** \return Pointer to the FileSystem
 		This pointer should not be dropped. See IReferenceCounted::drop() for more information. */

--- a/source/Irrlicht/CIrrDeviceStub.cpp
+++ b/source/Irrlicht/CIrrDeviceStub.cpp
@@ -92,7 +92,7 @@ void CIrrDeviceStub::createGUIAndScene()
 	GUIEnvironment = gui::createGUIEnvironment(FileSystem, VideoDriver, Operator);
 
 	// create Scene manager
-	SceneManager = scene::createSceneManager(VideoDriver, FileSystem, CursorControl, GUIEnvironment);
+	SceneManager = scene::createSceneManager(VideoDriver, FileSystem, CursorControl);
 
 	setEventReceiver(UserReceiver);
 }

--- a/source/Irrlicht/CIrrDeviceStub.cpp
+++ b/source/Irrlicht/CIrrDeviceStub.cpp
@@ -92,7 +92,7 @@ void CIrrDeviceStub::createGUIAndScene()
 	GUIEnvironment = gui::createGUIEnvironment(FileSystem, VideoDriver, Operator);
 
 	// create Scene manager
-	SceneManager = scene::createSceneManager(VideoDriver, FileSystem, CursorControl);
+	SceneManager = scene::createSceneManager(VideoDriver, CursorControl);
 
 	setEventReceiver(UserReceiver);
 }

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -24,7 +24,7 @@ namespace irr
 
 	namespace scene
 	{
-		ISceneManager* createSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs, gui::ICursorControl* cc);
+		ISceneManager* createSceneManager(video::IVideoDriver* driver, gui::ICursorControl* cc);
 	}
 
 	namespace io

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -24,8 +24,7 @@ namespace irr
 
 	namespace scene
 	{
-		ISceneManager* createSceneManager(video::IVideoDriver* driver,
-			io::IFileSystem* fs, gui::ICursorControl* cc, gui::IGUIEnvironment *gui);
+		ISceneManager* createSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs, gui::ICursorControl* cc);
 	}
 
 	namespace io

--- a/source/Irrlicht/COBJMeshFileLoader.cpp
+++ b/source/Irrlicht/COBJMeshFileLoader.cpp
@@ -24,23 +24,18 @@ namespace scene
 #endif
 
 //! Constructor
-COBJMeshFileLoader::COBJMeshFileLoader(scene::ISceneManager* smgr, io::IFileSystem* fs)
-: SceneManager(smgr), FileSystem(fs)
+COBJMeshFileLoader::COBJMeshFileLoader(scene::ISceneManager* smgr)
+: SceneManager(smgr)
 {
 	#ifdef _DEBUG
 	setDebugName("COBJMeshFileLoader");
 	#endif
-
-	if (FileSystem)
-		FileSystem->grab();
 }
 
 
 //! destructor
 COBJMeshFileLoader::~COBJMeshFileLoader()
 {
-	if (FileSystem)
-		FileSystem->drop();
 }
 
 
@@ -76,7 +71,6 @@ IAnimatedMesh* COBJMeshFileLoader::createMesh(io::IReadFile* file)
 	u32 smoothingGroup=0;
 
 	const io::path fullName = file->getFileName();
-	const io::path relPath = FileSystem->getFileDir(fullName)+"/";
 
 	c8* buf = new c8[filesize];
 	memset(buf, 0, filesize);

--- a/source/Irrlicht/COBJMeshFileLoader.h
+++ b/source/Irrlicht/COBJMeshFileLoader.h
@@ -7,7 +7,6 @@
 
 #include <map>
 #include "IMeshLoader.h"
-#include "IFileSystem.h"
 #include "ISceneManager.h"
 #include "irrString.h"
 #include "SMeshBuffer.h"
@@ -23,7 +22,7 @@ class COBJMeshFileLoader : public IMeshLoader
 public:
 
 	//! Constructor
-	COBJMeshFileLoader(scene::ISceneManager* smgr, io::IFileSystem* fs);
+	COBJMeshFileLoader(scene::ISceneManager* smgr);
 
 	//! destructor
 	virtual ~COBJMeshFileLoader();
@@ -104,7 +103,6 @@ private:
 	void cleanUp();
 
 	scene::ISceneManager* SceneManager;
-	io::IFileSystem* FileSystem;
 
 	core::array<SObjMtl*> Materials;
 };

--- a/source/Irrlicht/CSceneManager.cpp
+++ b/source/Irrlicht/CSceneManager.cpp
@@ -79,8 +79,8 @@ CSceneManager::CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
 	// TODO: now that we have multiple scene managers, these should be
 	// shallow copies from the previous manager if there is one.
 
-	MeshLoaderList.push_back(new CXMeshFileLoader(this, FileSystem));
-	MeshLoaderList.push_back(new COBJMeshFileLoader(this, FileSystem));
+	MeshLoaderList.push_back(new CXMeshFileLoader(this));
+	MeshLoaderList.push_back(new COBJMeshFileLoader(this));
 	MeshLoaderList.push_back(new CB3DMeshFileLoader(this));
 }
 

--- a/source/Irrlicht/CSceneManager.cpp
+++ b/source/Irrlicht/CSceneManager.cpp
@@ -34,9 +34,8 @@ namespace scene
 
 //! constructor
 CSceneManager::CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
-		gui::ICursorControl* cursorControl, IMeshCache* cache,
-		gui::IGUIEnvironment* gui)
-: ISceneNode(0, 0), Driver(driver), FileSystem(fs), GUIEnvironment(gui),
+		gui::ICursorControl* cursorControl, IMeshCache* cache)
+: ISceneNode(0, 0), Driver(driver), FileSystem(fs),
 	CursorControl(cursorControl),
 	ActiveCamera(0), ShadowColor(150,0,0,0), AmbientLight(0,0,0,0), Parameters(0),
 	MeshCache(cache), CurrentRenderPass(ESNRP_NONE)
@@ -57,9 +56,6 @@ CSceneManager::CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
 
 	if (CursorControl)
 		CursorControl->grab();
-
-	if (GUIEnvironment)
-		GUIEnvironment->grab();
 
 	// create mesh cache if not there already
 	if (!MeshCache)
@@ -104,9 +100,6 @@ CSceneManager::~CSceneManager()
 
 	if (CollisionManager)
 		CollisionManager->drop();
-
-	if (GUIEnvironment)
-		GUIEnvironment->drop();
 
 	u32 i;
 	for (i=0; i<MeshLoaderList.size(); ++i)
@@ -208,12 +201,6 @@ video::IVideoDriver* CSceneManager::getVideoDriver()
 	return Driver;
 }
 
-
-//! returns the GUI Environment
-gui::IGUIEnvironment* CSceneManager::getGUIEnvironment()
-{
-	return GUIEnvironment;
-}
 
 //! Get the active FileSystem
 /** \return Pointer to the FileSystem
@@ -888,7 +875,7 @@ IMeshCache* CSceneManager::getMeshCache()
 //! Creates a new scene manager.
 ISceneManager* CSceneManager::createNewSceneManager(bool cloneContent)
 {
-	CSceneManager* manager = new CSceneManager(Driver, FileSystem, CursorControl, MeshCache, GUIEnvironment);
+	CSceneManager* manager = new CSceneManager(Driver, FileSystem, CursorControl, MeshCache);
 
 	if (cloneContent)
 		manager->cloneMembers(this, manager);
@@ -926,10 +913,9 @@ IMeshWriter* CSceneManager::createMeshWriter(EMESH_WRITER_TYPE type)
 
 // creates a scenemanager
 ISceneManager* createSceneManager(video::IVideoDriver* driver,
-		io::IFileSystem* fs, gui::ICursorControl* cursorcontrol,
-		gui::IGUIEnvironment *guiEnvironment)
+		io::IFileSystem* fs, gui::ICursorControl* cursorcontrol)
 {
-	return new CSceneManager(driver, fs, cursorcontrol, 0, guiEnvironment );
+	return new CSceneManager(driver, fs, cursorcontrol, nullptr);
 }
 
 

--- a/source/Irrlicht/CSceneManager.cpp
+++ b/source/Irrlicht/CSceneManager.cpp
@@ -33,9 +33,9 @@ namespace scene
 {
 
 //! constructor
-CSceneManager::CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
+CSceneManager::CSceneManager(video::IVideoDriver* driver,
 		gui::ICursorControl* cursorControl, IMeshCache* cache)
-: ISceneNode(0, 0), Driver(driver), FileSystem(fs),
+: ISceneNode(0, 0), Driver(driver),
 	CursorControl(cursorControl),
 	ActiveCamera(0), ShadowColor(150,0,0,0), AmbientLight(0,0,0,0), Parameters(0),
 	MeshCache(cache), CurrentRenderPass(ESNRP_NONE)
@@ -50,9 +50,6 @@ CSceneManager::CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
 
 	if (Driver)
 		Driver->grab();
-
-	if (FileSystem)
-		FileSystem->grab();
 
 	if (CursorControl)
 		CursorControl->grab();
@@ -92,9 +89,6 @@ CSceneManager::~CSceneManager()
 	if (Driver)
 		Driver->removeAllHardwareBuffers();
 
-	if (FileSystem)
-		FileSystem->drop();
-
 	if (CursorControl)
 		CursorControl->drop();
 
@@ -122,29 +116,6 @@ CSceneManager::~CSceneManager()
 
 	if (Driver)
 		Driver->drop();
-}
-
-
-//! gets an animateable mesh. loads it if needed. returned pointer must not be dropped.
-IAnimatedMesh* CSceneManager::getMesh(const io::path& filename, const io::path& alternativeCacheName)
-{
-	io::path cacheName = alternativeCacheName.empty() ? filename : alternativeCacheName;
-	IAnimatedMesh* msh = MeshCache->getMeshByName(cacheName);
-	if (msh)
-		return msh;
-
-	io::IReadFile* file = FileSystem->createAndOpenFile(filename);
-	if (!file)
-	{
-		os::Printer::log("Could not load mesh, because file could not be opened: ", filename, ELL_ERROR);
-		return 0;
-	}
-
-	msh = getUncachedMesh(file, filename, cacheName);
-
-	file->drop();
-
-	return msh;
 }
 
 
@@ -199,15 +170,6 @@ IAnimatedMesh* CSceneManager::getUncachedMesh(io::IReadFile* file, const io::pat
 video::IVideoDriver* CSceneManager::getVideoDriver()
 {
 	return Driver;
-}
-
-
-//! Get the active FileSystem
-/** \return Pointer to the FileSystem
-This pointer should not be dropped. See IReferenceCounted::drop() for more information. */
-io::IFileSystem* CSceneManager::getFileSystem()
-{
-	return FileSystem;
 }
 
 
@@ -875,7 +837,7 @@ IMeshCache* CSceneManager::getMeshCache()
 //! Creates a new scene manager.
 ISceneManager* CSceneManager::createNewSceneManager(bool cloneContent)
 {
-	CSceneManager* manager = new CSceneManager(Driver, FileSystem, CursorControl, MeshCache);
+	CSceneManager* manager = new CSceneManager(Driver, CursorControl, MeshCache);
 
 	if (cloneContent)
 		manager->cloneMembers(this, manager);
@@ -912,10 +874,9 @@ IMeshWriter* CSceneManager::createMeshWriter(EMESH_WRITER_TYPE type)
 
 
 // creates a scenemanager
-ISceneManager* createSceneManager(video::IVideoDriver* driver,
-		io::IFileSystem* fs, gui::ICursorControl* cursorcontrol)
+ISceneManager* createSceneManager(video::IVideoDriver* driver, gui::ICursorControl* cursorcontrol)
 {
-	return new CSceneManager(driver, fs, cursorcontrol, nullptr);
+	return new CSceneManager(driver, cursorcontrol, nullptr);
 }
 
 

--- a/source/Irrlicht/CSceneManager.h
+++ b/source/Irrlicht/CSceneManager.h
@@ -32,8 +32,7 @@ namespace scene
 
 		//! constructor
 		CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
-			gui::ICursorControl* cursorControl, IMeshCache* cache = 0,
-			gui::IGUIEnvironment *guiEnvironment = 0);
+			gui::ICursorControl* cursorControl, IMeshCache* cache = nullptr);
 
 		//! destructor
 		virtual ~CSceneManager();
@@ -49,9 +48,6 @@ namespace scene
 
 		//! returns the video driver
 		video::IVideoDriver* getVideoDriver() override;
-
-		//! return the gui environment
-		gui::IGUIEnvironment* getGUIEnvironment() override;
 
 		//! return the filesystem
 		io::IFileSystem* getFileSystem() override;
@@ -284,9 +280,6 @@ namespace scene
 
 		//! file system
 		io::IFileSystem* FileSystem;
-
-		//! GUI Enviroment ( Debug Purpose )
-		gui::IGUIEnvironment* GUIEnvironment;
 
 		//! cursor control
 		gui::ICursorControl* CursorControl;

--- a/source/Irrlicht/CSceneManager.h
+++ b/source/Irrlicht/CSceneManager.h
@@ -31,14 +31,10 @@ namespace scene
 	public:
 
 		//! constructor
-		CSceneManager(video::IVideoDriver* driver, io::IFileSystem* fs,
-			gui::ICursorControl* cursorControl, IMeshCache* cache = nullptr);
+		CSceneManager(video::IVideoDriver* driver, gui::ICursorControl* cursorControl, IMeshCache* cache = 0);
 
 		//! destructor
 		virtual ~CSceneManager();
-
-		//! gets an animateable mesh. loads it if needed. returned pointer must not be dropped.
-		IAnimatedMesh* getMesh(const io::path& filename, const io::path& alternativeCacheName) override;
 
 		//! gets an animateable mesh. loads it if needed. returned pointer must not be dropped.
 		IAnimatedMesh* getMesh(io::IReadFile* file) override;
@@ -48,9 +44,6 @@ namespace scene
 
 		//! returns the video driver
 		video::IVideoDriver* getVideoDriver() override;
-
-		//! return the filesystem
-		io::IFileSystem* getFileSystem() override;
 
 		//! adds a scene node for rendering an animated mesh model
 		virtual IAnimatedMeshSceneNode* addAnimatedMeshSceneNode(IAnimatedMesh* mesh, ISceneNode* parent=0, s32 id=-1,
@@ -277,9 +270,6 @@ namespace scene
 
 		//! video driver
 		video::IVideoDriver* Driver;
-
-		//! file system
-		io::IFileSystem* FileSystem;
 
 		//! cursor control
 		gui::ICursorControl* CursorControl;

--- a/source/Irrlicht/CXMeshFileLoader.cpp
+++ b/source/Irrlicht/CXMeshFileLoader.cpp
@@ -10,7 +10,6 @@
 #include "coreutil.h"
 #include "ISceneManager.h"
 #include "IVideoDriver.h"
-#include "IFileSystem.h"
 #include "IReadFile.h"
 
 #ifdef _DEBUG
@@ -24,7 +23,7 @@ namespace scene
 {
 
 //! Constructor
-CXMeshFileLoader::CXMeshFileLoader(scene::ISceneManager* smgr, io::IFileSystem* fs)
+CXMeshFileLoader::CXMeshFileLoader(scene::ISceneManager* smgr)
 : AnimatedMesh(0), Buffer(0), P(0), End(0), BinaryNumCount(0), Line(0),
 	CurFrame(0), MajorVersion(0), MinorVersion(0), BinaryFormat(false), FloatSize(0)
 {

--- a/source/Irrlicht/CXMeshFileLoader.h
+++ b/source/Irrlicht/CXMeshFileLoader.h
@@ -14,7 +14,6 @@ namespace irr
 {
 namespace io
 {
-	class IFileSystem;
 	class IReadFile;
 } // end namespace io
 namespace scene
@@ -27,7 +26,7 @@ class CXMeshFileLoader : public IMeshLoader
 public:
 
 	//! Constructor
-	CXMeshFileLoader(scene::ISceneManager* smgr, io::IFileSystem* fs);
+	CXMeshFileLoader(scene::ISceneManager* smgr);
 
 	//! returns true if the file maybe is able to be loaded by this class
 	//! based on the file extension (e.g. ".cob")


### PR DESCRIPTION
Ready for Review.

Note: SceneManager::getMesh is only used in Client::getMesh and only with a RAM file.
