### PR TITLE
Use non-static member vars for SDL clipboard / primary selection buffers

### DIFF
--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -23,7 +23,7 @@ public:
 #endif
 	COSOperator(const core::stringc& osversion);
 
-	~COSOperator() override;
+	~COSOperator();
 
 	COSOperator(const COSOperator &) = delete;
 	COSOperator &operator=(const COSOperator &) = delete;

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -23,6 +23,11 @@ public:
 #endif
 	COSOperator(const core::stringc& osversion);
 
+	~COSOperator() override;
+
+	COSOperator(const COSOperator &) = delete;
+	COSOperator &operator=(const COSOperator &) = delete;
+
 	//! returns the current operation system version as string.
 	const core::stringc& getOperatingSystemVersion() const override;
 
@@ -54,6 +59,12 @@ private:
 
 #ifdef  _IRR_WINDOWS_API_
 	mutable core::stringc ClipboardBuf;
+#endif
+
+#ifdef _IRR_COMPILE_WITH_SDL_DEVICE_
+	// These need to be freed with SDL_free
+	mutable char *ClipboardSelectionText = nullptr;
+	mutable char *PrimarySelectionText = nullptr;
 #endif
 
 };


### PR DESCRIPTION
Fixes <https://github.com/minetest/irrlicht/pull/132#discussion_r1147855997>.
(I don't remember why I used static vars in the first place...)

(Also removed the null-checks before `SDL_free`, as they're not required.)