### PR TITLE
[NOSQUASH] Move stuff from renderingengine

### DIFF
--- a/include/IImage.h
+++ b/include/IImage.h
@@ -329,6 +329,12 @@ public:
 	//! Sets a pixel
 	virtual void setPixel(u32 x, u32 y, const SColor &color, bool blend = false ) = 0;
 
+	//! Copies this surface into another, if it has the exact same size and format.
+	/**	NOTE: mipmaps are ignored
+	\return True if it was copied, false otherwise.
+	*/
+	virtual bool copyToNoScaling(void *target, u32 width, u32 height, ECOLOR_FORMAT format=ECF_A8R8G8B8, u32 pitch=0) const = 0;
+
 	//! Copies the image into the target, scaling the image to fit
 	/**	NOTE: mipmaps are ignored */
 	virtual void copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT format=ECF_A8R8G8B8, u32 pitch=0) =0;

--- a/include/IrrlichtDevice.h
+++ b/include/IrrlichtDevice.h
@@ -132,6 +132,11 @@ namespace irr
 		/** \param text: New text of the window caption. */
 		virtual void setWindowCaption(const wchar_t* text) = 0;
 
+		//! Sets the window icon.
+		/** \param img The icon texture.
+		\return False if no icon was set. */
+		virtual bool setWindowIcon(const video::IImage *img) = 0;
+
 		//! Returns if the window is active.
 		/** If the window is inactive,
 		nothing needs to be drawn. So if you don't want to draw anything
@@ -306,6 +311,10 @@ namespace irr
 		/** This allows the user to check which windowing system is currently being
 		used. */
 		virtual E_DEVICE_TYPE getType() const = 0;
+
+		//! Get the display density in dots per inch.
+		//! Returns 0.0f on failure.
+		virtual float getDisplayDensity() const = 0;
 
 		//! Check if a driver type is supported by the engine.
 		/** Even if true is returned the driver may not be available

--- a/source/Irrlicht/CImage.cpp
+++ b/source/Irrlicht/CImage.cpp
@@ -173,6 +173,50 @@ void CImage::copyToWithAlpha(IImage* target, const core::position2d<s32>& pos, c
 }
 
 
+//! copies this surface into another, if it has the exact same size and format.
+bool CImage::copyToNoScaling(void *target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch) const
+{
+	if (IImage::isCompressedFormat(Format))
+	{
+		os::Printer::log("IImage::copyToNoScaling method doesn't work with compressed images.", ELL_WARNING);
+		return false;
+	}
+
+	if (!target || !width || !height || !Size.Width || !Size.Height)
+		return false;
+
+	const u32 bpp=getBitsPerPixelFromFormat(format)/8;
+	if (0==pitch)
+		pitch = width*bpp;
+
+	if (!(Format==format && Size.Width==width && Size.Height==height))
+		return false;
+
+	if (pitch==Pitch)
+	{
+		memcpy(target, Data, (size_t)height*pitch);
+	}
+	else
+	{
+		u8* tgtpos = (u8*) target;
+		u8* srcpos = Data;
+		const u32 bwidth = width*bpp;
+		const u32 rest = pitch-bwidth;
+		for (u32 y=0; y<height; ++y)
+		{
+			// copy scanline
+			memcpy(tgtpos, srcpos, bwidth);
+			// clear pitch
+			memset(tgtpos+bwidth, 0, rest);
+			tgtpos += pitch;
+			srcpos += Pitch;
+		}
+	}
+
+	return true;
+}
+
+
 //! copies this surface into another, scaling it to the target image size
 // note: this is very very slow.
 void CImage::copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch)
@@ -190,31 +234,8 @@ void CImage::copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT fo
 	if (0==pitch)
 		pitch = width*bpp;
 
-	if (Format==format && Size.Width==width && Size.Height==height)
-	{
-		if (pitch==Pitch)
-		{
-			memcpy(target, Data, (size_t)height*pitch);
-			return;
-		}
-		else
-		{
-			u8* tgtpos = (u8*) target;
-			u8* srcpos = Data;
-			const u32 bwidth = width*bpp;
-			const u32 rest = pitch-bwidth;
-			for (u32 y=0; y<height; ++y)
-			{
-				// copy scanline
-				memcpy(tgtpos, srcpos, bwidth);
-				// clear pitch
-				memset(tgtpos+bwidth, 0, rest);
-				tgtpos += pitch;
-				srcpos += Pitch;
-			}
-			return;
-		}
-	}
+	if (copyToNoScaling(target, width, height, format, pitch))
+		return;
 
 	// NOTE: Scaling is coded to keep the border pixels intact.
 	// Alternatively we could for example work with first pixel being taken at half step-size.

--- a/source/Irrlicht/CImage.h
+++ b/source/Irrlicht/CImage.h
@@ -42,6 +42,9 @@ public:
 	//! sets a pixel
 	void setPixel(u32 x, u32 y, const SColor &color, bool blend = false ) override;
 
+	//! copies this surface into another, if it has the exact same size and format.
+	bool copyToNoScaling(void *target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch=0) const override;
+
 	//! copies this surface into another, scaling it to fit.
 	void copyToScaling(void* target, u32 width, u32 height, ECOLOR_FORMAT format, u32 pitch=0) override;
 

--- a/source/Irrlicht/CIrrDeviceLinux.h
+++ b/source/Irrlicht/CIrrDeviceLinux.h
@@ -54,6 +54,9 @@ namespace irr
 		//! sets the caption of the window
 		void setWindowCaption(const wchar_t* text) override;
 
+		//! Sets the window icon.
+		bool setWindowIcon(const video::IImage *img) override;
+
 		//! returns if window is active. if not, nothing need to be drawn
 		bool isWindowActive() const override;
 
@@ -120,6 +123,9 @@ namespace irr
 			return EIDT_X11;
 		}
 
+		//! Get the display density in dots per inch.
+		float getDisplayDensity() const override;
+
 #ifdef _IRR_COMPILE_WITH_X11_
 		// convert an Irrlicht texture to a X11 cursor
 		Cursor TextureToCursor(irr::video::ITexture * tex, const core::rect<s32>& sourceRect, const core::position2d<s32> &hotspot);
@@ -145,6 +151,8 @@ namespace irr
 		void initXInput2();
 
 		bool switchToFullscreen();
+
+		void setupTopLevelXorgWindow();
 
 #ifdef _IRR_COMPILE_WITH_X11_
 		bool createInputContext();

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -48,6 +48,9 @@ namespace irr
 		//! sets the caption of the window
 		void setWindowCaption(const wchar_t* text) override;
 
+		//! Sets the window icon.
+		bool setWindowIcon(const video::IImage *img) override;
+
 		//! returns if window is active. if not, nothing need to be drawn
 		bool isWindowActive() const override;
 
@@ -93,6 +96,9 @@ namespace irr
 		{
 			return EIDT_SDL;
 		}
+
+		//! Get the display density in dots per inch.
+		float getDisplayDensity() const override;
 
 		void SwapWindow();
 

--- a/source/Irrlicht/CIrrDeviceStub.cpp
+++ b/source/Irrlicht/CIrrDeviceStub.cpp
@@ -136,6 +136,13 @@ ITimer* CIrrDeviceStub::getTimer()
 }
 
 
+//! Sets the window icon.
+bool CIrrDeviceStub::setWindowIcon(const video::IImage *img)
+{
+	return false;
+}
+
+
 //! Returns the version of the engine.
 const char* CIrrDeviceStub::getVersion() const
 {
@@ -383,6 +390,12 @@ u32 CIrrDeviceStub::getDoubleClickTime() const
 //! Remove all messages pending in the system message loop
 void CIrrDeviceStub::clearSystemMessages()
 {
+}
+
+//! Get the display density in dots per inch.
+float CIrrDeviceStub::getDisplayDensity() const
+{
+	return 0.0f;
 }
 
 //! Checks whether the input device should take input from the IME

--- a/source/Irrlicht/CIrrDeviceStub.h
+++ b/source/Irrlicht/CIrrDeviceStub.h
@@ -71,6 +71,9 @@ namespace irr
 		//! Returns a pointer to the ITimer object. With it the current Time can be received.
 		ITimer* getTimer() override;
 
+		//! Sets the window icon.
+		bool setWindowIcon(const video::IImage *img) override;
+
 		//! Returns the version of the engine.
 		const char* getVersion() const override;
 
@@ -150,6 +153,9 @@ namespace irr
 
 		//! Remove all messages pending in the system message loop
 		void clearSystemMessages() override;
+
+		//! Get the display density in dots per inch.
+		float getDisplayDensity() const override;
 
 		//! Resize the render window.
 		void setWindowSize(const irr::core::dimension2d<u32>& size) override {}

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -1112,6 +1112,26 @@ void CIrrDeviceWin32::setWindowCaption(const wchar_t* text)
 }
 
 
+//! Sets the window icon.
+bool CIrrDeviceWin32::setWindowIcon(const video::IImage *img)
+{
+	// Ignore the img, instead load the ICON from resource file
+	// (This is minetest-specific!)
+	const HICON hicon = LoadIcon(GetModuleHandle(NULL),
+			MAKEINTRESOURCE(130) // The ID of the ICON defined in
+					     // winresource.rc
+	);
+
+	if (hicon) {
+		SendMessage(HWnd, WM_SETICON, ICON_BIG, reinterpret_cast<LPARAM>(hicon));
+		SendMessage(HWnd, WM_SETICON, ICON_SMALL,
+				reinterpret_cast<LPARAM>(hicon));
+		return true;
+	}
+	return false;
+}
+
+
 //! notifies the device that it should close itself
 void CIrrDeviceWin32::closeDevice()
 {
@@ -1372,6 +1392,17 @@ void CIrrDeviceWin32::clearSystemMessages()
 	while (PeekMessage(&msg, NULL, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE))
 	{}
 }
+
+
+//! Get the display density in dots per inch.
+float CIrrDeviceWin32::getDisplayDensity() const
+{
+	HDC hdc = GetDC(HWnd);
+	float dpi = GetDeviceCaps(hdc, LOGPIXELSX);
+	ReleaseDC(HWnd, hdc);
+	return dpi;
+}
+
 
 // Convert an Irrlicht texture to a Windows cursor
 // Based on http://www.codeguru.com/cpp/w-p/win32/cursors/article.php/c4529/

--- a/source/Irrlicht/CIrrDeviceWin32.h
+++ b/source/Irrlicht/CIrrDeviceWin32.h
@@ -47,6 +47,9 @@ namespace irr
 		//! sets the caption of the window
 		void setWindowCaption(const wchar_t* text) override;
 
+		//! Sets the window icon.
+		bool setWindowIcon(const video::IImage *img) override;
+
 		//! returns if window is active. if not, nothing need to be drawn
 		bool isWindowActive() const override;
 
@@ -95,6 +98,9 @@ namespace irr
 		{
 			return EIDT_WIN32;
 		}
+
+		//! Get the display density in dots per inch.
+		float getDisplayDensity() const override;
 
 		//! Compares to the last call of this function to return double and triple clicks.
 		//! \return Returns only 1,2 or 3. A 4th click will start with 1 again.


### PR DESCRIPTION
Moves the platform dependent stuff from renderingengine.cpp. Also implements the stuff for SDL (2nd commit).
This fixes the remaining point in #137.

~~I don't know how to implement `getDisplayDensity` properly. `SDL_GetDisplayDPI` doesn't seem to be what we need. **Please help.**~~

FYI, this doesn't break anything if merged without https://github.com/minetest/minetest/pull/13348. (The X11 setup stuff is done twice, but that doesn't seem to hurt.)

(The X11 class name and the windows icon thing are hardcoded to minetest's values. I don't think passing the values to irrlicht is worth doing, as we're planning to drop non-SDL backends anyway.)

It would be nice if someone could test this with Windows.