### PR TITLE
Drop obsolete loadImages and createImagesFromFile

### DIFF
--- a/include/IImageLoader.h
+++ b/include/IImageLoader.h
@@ -45,17 +45,6 @@ public:
 	/** \param file File handle to check.
 	\return Pointer to newly created image, or 0 upon error. */
 	virtual IImage* loadImage(io::IReadFile* file) const = 0;
-
-	//! Creates a multiple surfaces from the file eg. whole cube map.
-	/** \param file File handle to check.
-	\param type Pointer to E_TEXTURE_TYPE where a recommended type of the texture will be stored.
-	\return Array of pointers to newly created images. */
-	virtual core::array<IImage*> loadImages(io::IReadFile* file, E_TEXTURE_TYPE* type) const
-	{
-		core::array<IImage*> image;
-
-		return image;
-	}
 };
 
 

--- a/include/IVideoDriver.h
+++ b/include/IVideoDriver.h
@@ -959,28 +959,6 @@ namespace video
 		\return The current texture creation flag enabled mode. */
 		virtual bool getTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag) const =0;
 
-		//! Creates a software images from a file.
-		/** No hardware texture will be created for those images. This
-		method is useful for example if you want to read a heightmap
-		for a terrain renderer.
-		\param filename Name of the file from which the images are created.
-		\param type Pointer to E_TEXTURE_TYPE where a recommended type of the texture will be stored.
-		\return The array of created images.
-		If you no longer need those images, you should call IImage::drop() on each of them.
-		See IReferenceCounted::drop() for more information. */
-		virtual core::array<IImage*> createImagesFromFile(const io::path& filename, E_TEXTURE_TYPE* type = 0) = 0;
-
-		//! Creates a software images from a file.
-		/** No hardware texture will be created for those images. This
-		method is useful for example if you want to read a heightmap
-		for a terrain renderer.
-		\param file File from which the image is created.
-		\param type Pointer to E_TEXTURE_TYPE where a recommended type of the texture will be stored.
-		\return The array of created images.
-		If you no longer need those images, you should call IImage::drop() on each of them.
-		See IReferenceCounted::drop() for more information. */
-		virtual core::array<IImage*> createImagesFromFile(io::IReadFile* file, E_TEXTURE_TYPE* type = 0) = 0;
-
 		//! Creates a software image from a file.
 		/** No hardware texture will be created for this image. This
 		method is useful for example if you want to read a heightmap
@@ -990,15 +968,7 @@ namespace video
 		\return The created image.
 		If you no longer need the image, you should call IImage::drop().
 		See IReferenceCounted::drop() for more information. */
-		IImage* createImageFromFile(const io::path& filename)
-		{
-			core::array<IImage*> imageArray = createImagesFromFile(filename);
-
-			for (u32 i = 1; i < imageArray.size(); ++i)
-				imageArray[i]->drop();
-
-			return (imageArray.size() > 0) ? imageArray[0] : 0;
-		}
+		virtual IImage* createImageFromFile(const io::path& filename) = 0;
 
 		//! Creates a software image from a file.
 		/** No hardware texture will be created for this image. This
@@ -1008,15 +978,7 @@ namespace video
 		\return The created image.
 		If you no longer need the image, you should call IImage::drop().
 		See IReferenceCounted::drop() for more information. */
-		IImage* createImageFromFile(io::IReadFile* file)
-		{
-			core::array<IImage*> imageArray = createImagesFromFile(file);
-
-			for (u32 i = 1; i < imageArray.size(); ++i)
-				imageArray[i]->drop();
-
-			return (imageArray.size() > 0) ? imageArray[0] : 0;
-		}
+		virtual IImage* createImageFromFile(io::IReadFile* file) = 0;
 
 		//! Writes the provided image to a file.
 		/** Requires that there is a suitable image writer registered

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -1196,57 +1196,33 @@ core::array<IImage*> CNullDriver::createImagesFromFile(io::IReadFile* file, E_TE
 
 	core::array<IImage*> imageArray;
 
-	if (file)
-	{
-		s32 i;
+	if (!file)
+		return imageArray;
 
-		// try to load file based on file extension
-		for (i = SurfaceLoader.size() - 1; i >= 0; --i)
-		{
-			if (SurfaceLoader[i]->isALoadableFileExtension(file->getFileName()))
-			{
-				// reset file position which might have changed due to previous loadImage calls
-				file->seek(0);
-				imageArray = SurfaceLoader[i]->loadImages(file, type);
+	// try to load file based on file extension
+	for (int i = SurfaceLoader.size() - 1; i >= 0; --i) {
+		if (!SurfaceLoader[i]->isALoadableFileExtension(file->getFileName()))
+			continue;
 
-				if (imageArray.size() == 0)
-				{
-					file->seek(0);
-					IImage* image = SurfaceLoader[i]->loadImage(file);
-
-					if (image)
-						imageArray.push_back(image);
-				}
-
-				if (imageArray.size() > 0)
-					return imageArray;
-			}
+		file->seek(0); // reset file position which might have changed due to previous loadImage calls
+		if (IImage *image = SurfaceLoader[i]->loadImage(file)) {
+			imageArray.push_back(image);
+			return imageArray;
 		}
+	}
 
-		// try to load file based on what is in it
-		for (i = SurfaceLoader.size() - 1; i >= 0; --i)
-		{
-			// dito
-			file->seek(0);
-			if (SurfaceLoader[i]->isALoadableFileFormat(file)
-				&& !SurfaceLoader[i]->isALoadableFileExtension(file->getFileName())	// extension was tried above already
-				)
-			{
-				file->seek(0);
-				imageArray = SurfaceLoader[i]->loadImages(file, type);
+	// try to load file based on what is in it
+	for (int i = SurfaceLoader.size() - 1; i >= 0; --i) {
+		if (SurfaceLoader[i]->isALoadableFileExtension(file->getFileName()))
+			continue; // extension was tried above already
+		file->seek(0); // dito
+		if (!SurfaceLoader[i]->isALoadableFileFormat(file))
+			continue;
 
-				if (imageArray.size() == 0)
-				{
-					file->seek(0);
-					IImage* image = SurfaceLoader[i]->loadImage(file);
-
-					if (image)
-						imageArray.push_back(image);
-				}
-
-				if (imageArray.size() > 0)
-					return imageArray;
-			}
+		file->seek(0);
+		if (IImage *image = SurfaceLoader[i]->loadImage(file)) {
+			imageArray.push_back(image);
+			return imageArray;
 		}
 	}
 

--- a/source/Irrlicht/CNullDriver.h
+++ b/source/Irrlicht/CNullDriver.h
@@ -670,6 +670,8 @@ namespace video
 		//! checks triangle count and print warning if wrong
 		bool checkPrimitiveCount(u32 prmcnt) const;
 
+		bool checkImage(IImage *image) const;
+
 		bool checkImage(const core::array<IImage*>& image) const;
 
 		// adds a material renderer and drops it afterwards. To be used for internal creation

--- a/source/Irrlicht/CNullDriver.h
+++ b/source/Irrlicht/CNullDriver.h
@@ -314,9 +314,9 @@ namespace video
 		//! Returns if a texture creation flag is enabled or disabled.
 		bool getTextureCreationFlag(E_TEXTURE_CREATION_FLAG flag) const override;
 
-		core::array<IImage*> createImagesFromFile(const io::path& filename, E_TEXTURE_TYPE* type = 0) override;
+		IImage *createImageFromFile(const io::path& filename) override;
 
-		core::array<IImage*> createImagesFromFile(io::IReadFile* file, E_TEXTURE_TYPE* type = 0) override;
+		IImage *createImageFromFile(io::IReadFile* file) override;
 
 		//! Creates a software image from a byte array.
 		/** \param useForeignMemory: If true, the image will use the data pointer


### PR DESCRIPTION
They were to load several images from a single file. But IrrlichtMt doesn’t support such image formats.

Minetest doesn’t use these functions. It does use singular variants, however.

Note: review with “hide whitespace.“