### PR TITLE
Fix ComboBox changing on scroll when in a scroll container

### DIFF
--- a/source/Irrlicht/CGUIComboBox.cpp
+++ b/source/Irrlicht/CGUIComboBox.cpp
@@ -320,6 +320,10 @@ bool CGUIComboBox::OnEvent(const SEvent& event)
 				}
 			case EMIE_MOUSE_WHEEL:
 				{
+					// Try scrolling parent first
+					if (IGUIElement::OnEvent(event))
+						return true;
+
 					s32 oldSelected = Selected;
 					setSelected( Selected + ((event.MouseInput.Wheel < 0) ? 1 : -1));
 
@@ -329,11 +333,12 @@ bool CGUIComboBox::OnEvent(const SEvent& event)
 					if (Selected >= (s32)Items.size())
 						setSelected((s32)Items.size() -1);
 
-					if (Selected != oldSelected)
-					{
+					if (Selected != oldSelected) {
 						sendSelectionChangedEvent();
 						return true;
 					}
+
+					return false;
 				}
 			default:
 				break;


### PR DESCRIPTION
You can mouse wheel scroll on a combobox/dropdown to change it.
This disables combobox scrolling when in a scroll container.

Ideally, the combobox scrolling would only work when you start scrolling with the mouse over the combobox. But that would require some way of keeping track of scroll actions.

Alternatively, this behaviour could be removed completely

## How to test

* Check out https://github.com/minetest/minetest/pull/12480
* Open settings menu, make sure that scrolling through the right scroll container doesn't change dropdowns when your mouse goes over them
* Open Content > Browse online, scrolling on combobox still changes it