### PR TITLE
OpenGL3: New extension listing system

### DIFF
--- a/source/Irrlicht/COGLESCoreExtensionHandler.h
+++ b/source/Irrlicht/COGLESCoreExtensionHandler.h
@@ -334,8 +334,6 @@ namespace video
 			IRR_GL_SUN_multi_draw_arrays, // 69
 			IRR_GL_VIV_shader_binary, // 85
 			WGL_ARB_context_flush_control, // 191
-			IRR_GL_EXT_draw_range_elements, // 112 again?
-			IRR_GL_ARB_framebuffer_object, // 45 again?
 
 			IRR_OGLES_Feature_Count
 		};
@@ -687,9 +685,7 @@ namespace video
 				"GL_QCOM_writeonly_rendering",
 				"GL_SUN_multi_draw_arrays",
 				"GL_VIV_shader_binary",
-				"WGL_ARB_context_flush_control",
-				"GL_EXT_draw_range_elements",
-				"GL_ARB_framebuffer_object",
+				"WGL_ARB_context_flush_control"
 			};
 
 			return OGLESFeatureStrings[index];

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -1504,16 +1504,14 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 				}
 			}
 
-	#ifdef GL_EXT_texture_filter_anisotropic
-			if (FeatureAvailable[COGLESCoreExtensionHandler::IRR_GL_EXT_texture_filter_anisotropic] &&
+			if (AnisotropicFilterSupported &&
 				(!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_MAX_ANISOTROPY_EXT,
+				glTexParameteri(tmpTextureType, GL.TEXTURE_MAX_ANISOTROPY,
 					material.TextureLayer[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayer[i].AnisotropicFilter) : 1);
 
 				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayer[i].AnisotropicFilter;
 			}
-	#endif
 
 			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
 			{

--- a/source/Irrlicht/OpenGL/ExtensionHandler.cpp
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.cpp
@@ -20,11 +20,11 @@ namespace video
 		auto extensions_string = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
 		const char *pos = extensions_string;
 		while (const char *next = strchr(pos, ' ')) {
-			std::string name{pos, next};
-			addExtension(name.c_str());
+			addExtension(std::string{pos, next});
 			pos = next + 1;
 		}
 		addExtension(pos);
+		updateLegacyExtensionList();
 	}
 
 	void COpenGL3ExtensionHandler::initExtensionsNew()
@@ -32,15 +32,21 @@ namespace video
 		int ext_count = GetInteger(GL_NUM_EXTENSIONS);
 		for (int k = 0; k < ext_count; k++)
 			addExtension(reinterpret_cast<const char *>(GL.GetStringi(GL_EXTENSIONS, k)));
+		updateLegacyExtensionList();
 	}
 
-	void COpenGL3ExtensionHandler::addExtension(const char *name) {
-		for (size_t j=0; j<IRR_OGLES_Feature_Count; ++j) {
-			if (!strcmp(getFeatureString(j), name)) {
-				FeatureAvailable[j] = true;
-				break;
-			}
-		}
+	void COpenGL3ExtensionHandler::addExtension(std::string name) {
+		Extensions.emplace(std::move(name));
 	}
+
+	bool COpenGL3ExtensionHandler::queryExtension(const std::string &name) const{
+		return Extensions.find(name) != Extensions.end();
+	}
+
+	void COpenGL3ExtensionHandler::updateLegacyExtensionList() {
+		for (size_t j = 0; j < IRR_OGLES_Feature_Count; ++j)
+			FeatureAvailable[j] = queryExtension(getFeatureString(j));
+	}
+
 } // end namespace video
 } // end namespace irr

--- a/source/Irrlicht/OpenGL/ExtensionHandler.h
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "EDriverFeatures.h"
 #include "irrTypes.h"
 #include "os.h"
@@ -27,6 +29,9 @@ namespace video
 
 		void initExtensionsOld();
 		void initExtensionsNew();
+
+		/// Checks whether a named extension is present
+		bool queryExtension(const std::string &name) const noexcept;
 
 		bool queryFeature(video::E_VIDEO_DRIVER_FEATURE feature) const
 		{
@@ -160,8 +165,13 @@ namespace video
 			glBlendEquation(mode);
 		}
 
+		bool AnisotropicFilterSupported = false;
+
 	private:
-		void addExtension(const char *name);
+		void addExtension(std::string name);
+		void updateLegacyExtensionList();
+
+		std::unordered_set<std::string> Extensions;
 	};
 
 }

--- a/source/Irrlicht/OpenGL3/Driver.cpp
+++ b/source/Irrlicht/OpenGL3/Driver.cpp
@@ -4,6 +4,7 @@
 
 #include "Driver.h"
 #include <cassert>
+#include "mt_opengl.h"
 
 namespace irr {
 namespace video {
@@ -32,6 +33,8 @@ namespace video {
 		assert (isVersionAtLeast(3, 2));
 		initExtensionsNew();
 
+		AnisotropicFilterSupported = isVersionAtLeast(4, 6) || queryExtension("GL_ARB_texture_filter_anisotropic") || queryExtension("GL_EXT_texture_filter_anisotropic");
+
 		// COGLESCoreExtensionHandler::Feature
 		static_assert(MATERIAL_MAX_TEXTURES <= 16, "Only up to 16 textures are guaranteed");
 		Feature.BlendOperation = true;
@@ -40,8 +43,8 @@ namespace video {
 		Feature.MultipleRenderTarget = GetInteger(GL_MAX_DRAW_BUFFERS);
 
 		// COGLESCoreExtensionHandler
-		if (FeatureAvailable[IRR_GL_EXT_texture_filter_anisotropic])
-			MaxAnisotropy = GetInteger(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT);
+		if (AnisotropicFilterSupported)
+			MaxAnisotropy = GetInteger(GL.MAX_TEXTURE_MAX_ANISOTROPY);
 		MaxIndices = GetInteger(GL_MAX_ELEMENTS_INDICES);
 		MaxTextureSize = GetInteger(GL_MAX_TEXTURE_SIZE);
 		glGetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);

--- a/source/Irrlicht/OpenGLES2/Driver.cpp
+++ b/source/Irrlicht/OpenGLES2/Driver.cpp
@@ -30,23 +30,27 @@ namespace video {
 		else
 			initExtensionsOld();
 
+		const bool MRTSupported = Version.Major >= 3 || queryExtension("GL_EXT_draw_buffers");
+		AnisotropicFilterSupported = queryExtension("GL_EXT_texture_filter_anisotropic");
+		const bool TextureLODBiasSupported = queryExtension("GL_EXT_texture_lod_bias");
+
 		// COGLESCoreExtensionHandler::Feature
 		static_assert(MATERIAL_MAX_TEXTURES <= 8, "Only up to 8 textures are guaranteed");
 		Feature.BlendOperation = true;
 		Feature.ColorAttachment = 1;
-		if (Version.Major >= 3 || FeatureAvailable[IRR_GL_EXT_draw_buffers])
+		if (MRTSupported)
 			Feature.ColorAttachment = GetInteger(GL_MAX_COLOR_ATTACHMENTS);
 		Feature.MaxTextureUnits = MATERIAL_MAX_TEXTURES;
-		if (Version.Major >= 3 || FeatureAvailable[IRR_GL_EXT_draw_buffers])
+		if (MRTSupported)
 			Feature.MultipleRenderTarget = GetInteger(GL_MAX_DRAW_BUFFERS);
 
 		// COGLESCoreExtensionHandler
-		if (FeatureAvailable[IRR_GL_EXT_texture_filter_anisotropic])
+		if (AnisotropicFilterSupported)
 			MaxAnisotropy = GetInteger(GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT);
-		if (Version.Major >= 3 || FeatureAvailable[IRR_GL_EXT_draw_range_elements])
+		if (Version.Major >= 3 || queryExtension("GL_EXT_draw_range_elements"))
 			MaxIndices = GetInteger(GL_MAX_ELEMENTS_INDICES);
 		MaxTextureSize = GetInteger(GL_MAX_TEXTURE_SIZE);
-		if (FeatureAvailable[IRR_GL_EXT_texture_lod_bias])
+		if (TextureLODBiasSupported)
 			glGetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);
 		glGetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, DimAliasedLine); // NOTE: this is not in the OpenGL ES 2.0 spec...
 		glGetFloatv(GL_ALIASED_POINT_SIZE_RANGE, DimAliasedPoint);


### PR DESCRIPTION
~~Based on #193. May be considered an alternative.~~ UPD: #193 merged
~~[Diff against #193](https://github.com/numberZero/irrlicht/pull/26/files).~~ UPD: obsolete due to rebase

Current extension handling is relying on the hard-coded possible extension list. Runtime checks check extension availability in this list.

The new code lists all extensions actually available, and at initialization time derives which features to enable (for now, only `AnisotropicFilterSupported` actually replaces an extension check).