### PR TITLE
OpenGL3: Support min/max blend modes

### DIFF
--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -1405,6 +1405,18 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			case EBO_REVSUBTRACT:
 				CacheHandler->setBlendEquation(GL_FUNC_REVERSE_SUBTRACT);
 				break;
+			case EBO_MIN:
+				if (BlendMinMaxSupported)
+					CacheHandler->setBlendEquation(GL_MIN);
+				else
+					os::Printer::log("Attempt to use EBO_MIN without driver support", ELL_WARNING);
+				break;
+			case EBO_MAX:
+				if (BlendMinMaxSupported)
+					CacheHandler->setBlendEquation(GL_MAX);
+				else
+					os::Printer::log("Attempt to use EBO_MAX without driver support", ELL_WARNING);
+				break;
 			default:
 				break;
 			}

--- a/source/Irrlicht/OpenGL/ExtensionHandler.h
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.h
@@ -166,6 +166,7 @@ namespace video
 		}
 
 		bool AnisotropicFilterSupported = false;
+		bool BlendMinMaxSupported = false;
 
 	private:
 		void addExtension(std::string name);

--- a/source/Irrlicht/OpenGL3/Driver.cpp
+++ b/source/Irrlicht/OpenGL3/Driver.cpp
@@ -34,6 +34,7 @@ namespace video {
 		initExtensionsNew();
 
 		AnisotropicFilterSupported = isVersionAtLeast(4, 6) || queryExtension("GL_ARB_texture_filter_anisotropic") || queryExtension("GL_EXT_texture_filter_anisotropic");
+		BlendMinMaxSupported = true;
 
 		// COGLESCoreExtensionHandler::Feature
 		static_assert(MATERIAL_MAX_TEXTURES <= 16, "Only up to 16 textures are guaranteed");

--- a/source/Irrlicht/OpenGLES2/Driver.cpp
+++ b/source/Irrlicht/OpenGLES2/Driver.cpp
@@ -32,6 +32,7 @@ namespace video {
 
 		const bool MRTSupported = Version.Major >= 3 || queryExtension("GL_EXT_draw_buffers");
 		AnisotropicFilterSupported = queryExtension("GL_EXT_texture_filter_anisotropic");
+		BlendMinMaxSupported = (Version.Major >= 3) || FeatureAvailable[IRR_GL_EXT_blend_minmax];
 		const bool TextureLODBiasSupported = queryExtension("GL_EXT_texture_lod_bias");
 
 		// COGLESCoreExtensionHandler::Feature


### PR DESCRIPTION
~~Requires #193 or #194.~~ UPD: merged
~~[Diff against #193](https://github.com/numberZero/irrlicht/pull/28/files)~~ UPD: obsolete, due to rebase

`EBO_MIN` is necessary for dynamic shadows as they are implemented in Minetest.