### PR TITLE
Android CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,10 +208,14 @@ jobs:
           path: artifact/
 
   android:
+    name: Android ${{ matrix.arch }}
     runs-on: ubuntu-20.04
     env:
        ndk_version: "r25c"
-       ANDROID_NDK: ${{ env.HOME }}/android-ndk
+       ANDROID_NDK: ${{ github.workspace }}/android-ndk
+    strategy:
+      matrix:
+        arch: [armeabi-v7a, arm64-v8a, x86, x86_64]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -237,24 +241,11 @@ jobs:
           rm "android-ndk-${ndk_version}-linux.zip"
           mv "android-ndk-${ndk_version}" "${ANDROID_NDK}"
 
-      - name: "Build → armeabi-v7a"
-        run: |
-          ./scripts/ci-build-android.sh armeabi-v7a
-
-      - name: "Build → arm64-v8a"
-        run: |
-          ./scripts/ci-build-android.sh arm64-v8a
-
-      - name: "Build → x86"
-        run: |
-          ./scripts/ci-build-android.sh x86
-
-      - name: "Build → x86_64"
-        run: |
-          ./scripts/ci-build-android.sh x86_64
+      - name: Build
+        run: ./scripts/ci-build-android.sh ${{ matrix.arch }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: irrlicht-android
-          path: ${{ runner.temp }}/pkg
+          name: irrlicht-android-${{ matrix.arch }}
+          path: ${{ runner.temp }}/pkg/${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,19 +233,19 @@ jobs:
           key: android-ndk-${{ env.ndk_version }}-linux
           path: ${{ env.ANDROID_NDK }}
 
-      - if: ${{ steps.cache-ndk.outputs.cache-hit != 'true' }}
-        name: Install NDK
+      - name: Install NDK
         run: |
           wget --progress=bar:force "http://dl.google.com/android/repository/android-ndk-${ndk_version}-linux.zip"
           unzip -q "android-ndk-${ndk_version}-linux.zip"
           rm "android-ndk-${ndk_version}-linux.zip"
           mv "android-ndk-${ndk_version}" "${ANDROID_NDK}"
+        if: ${{ steps.cache-ndk.outputs.cache-hit != 'true' }}
 
       - name: Build
         run: ./scripts/ci-build-android.sh ${{ matrix.arch }}
 
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: irrlicht-android-${{ matrix.arch }}
-          path: ${{ runner.temp }}/pkg/${{ matrix.arch }}
+      #- name: Upload Artifact
+      #  uses: actions/upload-artifact@v3
+      #  with:
+      #    name: irrlicht-android-${{ matrix.arch }}
+      #    path: ${{ runner.temp }}/pkg/${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,3 +206,47 @@ jobs:
         with:
           name: msvc-${{ matrix.config.arch }}
           path: artifact/
+
+  android:
+    runs-on: ubuntu-20.04
+    env:
+       ndk_version: "r25c"
+       ANDROID_NDK: ${{ github.workspace }}/android-ndk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install deps
+        run: |
+          sudo rm /var/lib/man-db/auto-update
+          sudo apt-get update
+          sudo apt-get install -qyy wget unzip zip gcc-multilib make cmake
+
+      - name: Install NDK
+        run: |
+          wget --progress=bar:force "http://dl.google.com/android/repository/android-ndk-${ndk_version}-linux.zip"
+          unzip -q "android-ndk-${ndk_version}-linux.zip"
+          rm "android-ndk-${ndk_version}-linux.zip"
+          mv "android-ndk-${ndk_version}" "${ANDROID_NDK}"
+
+      - name: "Build → armeabi-v7a"
+        run: |
+          ./scripts/ci-build-android.sh armeabi-v7a
+
+      - name: "Build → arm64-v8a"
+        run: |
+          ./scripts/ci-build-android.sh arm64-v8a
+
+      - name: "Build → x86"
+        run: |
+          ./scripts/ci-build-android.sh x86
+
+      - name: "Build → x86_64"
+        run: |
+          ./scripts/ci-build-android.sh x86_64
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: irrlicht-android
+          path: ${{ runner.temp }}/pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
     runs-on: ubuntu-20.04
     env:
        ndk_version: "r25c"
-       ANDROID_NDK: ${{ github.workspace }}/android-ndk
+       ANDROID_NDK: ${{ env.HOME }}/android-ndk
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -222,7 +222,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qyy wget unzip zip gcc-multilib make cmake
 
-      - name: Install NDK
+      - name: Cache NDK
+        id: cache-ndk
+        uses: actions/cache@v3
+        with:
+          key: android-ndk-${{ env.ndk_version }}-linux
+          path: ${{ env.ANDROID_NDK }}
+
+      - if: ${{ steps.cache-ndk.outputs.cache-hit != 'true' }}
+        name: Install NDK
         run: |
           wget --progress=bar:force "http://dl.google.com/android/repository/android-ndk-${ndk_version}-linux.zip"
           unzip -q "android-ndk-${ndk_version}-linux.zip"

--- a/scripts/ci-build-android.sh
+++ b/scripts/ci-build-android.sh
@@ -1,0 +1,123 @@
+#!/bin/bash -e
+
+# NOTE: this code is mostly copied from minetest_android_deps
+# (https://github.com/minetest/minetest_android_deps)
+
+png_ver=1.6.37
+jpeg_ver=2.1.4
+
+download () {
+	get_tar_archive libpng "https://download.sourceforge.net/libpng/libpng-${png_ver}.tar.gz"
+	get_tar_archive libjpeg "https://download.sourceforge.net/libjpeg-turbo/libjpeg-turbo-${jpeg_ver}.tar.gz"
+}
+
+build () {
+	# Build libjpg and libpng first because Irrlicht needs them
+	mkdir -p libpng
+	pushd libpng
+	$srcdir/libpng/configure --host=$CROSS_PREFIX
+	make && make DESTDIR=$PWD install
+	popd
+
+	mkdir -p libjpeg
+	pushd libjpeg
+	cmake $srcdir/libjpeg "${CMAKE_FLAGS[@]}" -DENABLE_SHARED=OFF
+	make && make DESTDIR=$PWD install
+	popd
+
+	local libpng=$PWD/libpng/usr/local/lib/libpng.a
+	local libjpeg=$(echo $PWD/libjpeg/opt/libjpeg-turbo/lib*/libjpeg.a)
+	cmake $srcdir/irrlicht "${CMAKE_FLAGS[@]}" \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DPNG_LIBRARY=$libpng \
+		-DPNG_PNG_INCLUDE_DIR=$(dirname "$libpng")/../include \
+		-DJPEG_LIBRARY=$libjpeg \
+		-DJPEG_INCLUDE_DIR=$(dirname "$libjpeg")/../include
+	make
+
+	cp -p lib/Android/libIrrlichtMt.a $libpng $libjpeg $pkgdir/
+	cp -a $srcdir/irrlicht/include $pkgdir/include
+	cp -a $srcdir/irrlicht/media/Shaders $pkgdir/Shaders
+}
+
+get_tar_archive () {
+	# $1: folder to extract to, $2: URL
+	local filename="${2##*/}"
+	[ -d "$1" ] && return 0
+	wget -c "$2" -O "$filename"
+	mkdir -p "$1"
+	tar -xaf "$filename" -C "$1" --strip-components=1
+	rm "$filename"
+}
+
+_setup_toolchain () {
+	local toolchain=$(echo "$ANDROID_NDK"/toolchains/llvm/prebuilt/*)
+	if [ ! -d "$toolchain" ]; then
+		echo "Android NDK path not specified or incorrect"; return 1
+	fi
+	export PATH="$toolchain/bin:$ANDROID_NDK:$PATH"
+
+	unset CFLAGS CPPFLAGS CXXFLAGS
+
+	TARGET_ABI="$1"
+	API=21
+	if [ "$TARGET_ABI" == armeabi-v7a ]; then
+		CROSS_PREFIX=armv7a-linux-androideabi
+		CFLAGS="-mthumb"
+		CXXFLAGS="-mthumb"
+	elif [ "$TARGET_ABI" == arm64-v8a ]; then
+		CROSS_PREFIX=aarch64-linux-android
+	elif [ "$TARGET_ABI" == x86 ]; then
+		CROSS_PREFIX=i686-linux-android
+		CFLAGS="-mssse3 -mfpmath=sse"
+		CXXFLAGS="-mssse3 -mfpmath=sse"
+	elif [ "$TARGET_ABI" == x86_64 ]; then
+		CROSS_PREFIX=x86_64-linux-android
+	else
+		echo "Invalid ABI given"; return 1
+	fi
+	export CC=$CROSS_PREFIX$API-clang
+	export CXX=$CROSS_PREFIX$API-clang++
+	export AR=llvm-ar
+	export RANLIB=llvm-ranlib
+	export CFLAGS="-fPIC ${CFLAGS}"
+	export CXXFLAGS="-fPIC ${CXXFLAGS}"
+
+	CMAKE_FLAGS=(
+		"-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+		"-DANDROID_ABI=$TARGET_ABI" "-DANDROID_NATIVE_API_LEVEL=$API"
+		"-DCMAKE_BUILD_TYPE=Release"
+	)
+
+	# make sure pkg-config doesn't interfere
+	export PKG_CONFIG=/bin/false
+
+	export MAKEFLAGS="-j$(nproc)"
+}
+
+_run_build () {
+	abi=$1
+	irrdir=$PWD
+
+	mkdir -p $RUNNER_TEMP/src
+	cd $RUNNER_TEMP/src
+	srcdir=$PWD
+	[ -d irrlicht ] || ln -s $irrdir irrlicht
+	download
+
+	builddir=$RUNNER_TEMP/build/irrlicht-$abi
+	pkgdir=$RUNNER_TEMP/pkg/$abi/Irrlicht
+	rm -rf "$pkgdir"
+	mkdir -p "$builddir" "$pkgdir"
+
+	cd "$builddir"
+	build
+}
+
+if [ $# -lt 1 ]; then
+	echo "Usage: ci-build-android.sh <ABI>"
+	exit 1
+fi
+
+_setup_toolchain $1
+_run_build $1

--- a/scripts/ci-build-android.sh
+++ b/scripts/ci-build-android.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -e
 
 # NOTE: this code is mostly copied from minetest_android_deps
-# (https://github.com/minetest/minetest_android_deps)
+# <https://github.com/minetest/minetest_android_deps>
 
-png_ver=1.6.37
-jpeg_ver=2.1.4
+png_ver=1.6.40
+jpeg_ver=3.0.1
 
 download () {
 	get_tar_archive libpng "https://download.sourceforge.net/libpng/libpng-${png_ver}.tar.gz"
@@ -85,7 +85,6 @@ _setup_toolchain () {
 
 	CMAKE_FLAGS=(
 		"-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake"
-		"-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF"
 		"-DANDROID_ABI=$TARGET_ABI" "-DANDROID_NATIVE_API_LEVEL=$API"
 		"-DCMAKE_BUILD_TYPE=Release"
 	)
@@ -97,7 +96,7 @@ _setup_toolchain () {
 }
 
 _run_build () {
-	abi=$1
+	local abi=$1
 	irrdir=$PWD
 
 	mkdir -p $RUNNER_TEMP/src

--- a/scripts/ci-build-android.sh
+++ b/scripts/ci-build-android.sh
@@ -85,6 +85,7 @@ _setup_toolchain () {
 
 	CMAKE_FLAGS=(
 		"-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake"
+		"-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF"
 		"-DANDROID_ABI=$TARGET_ABI" "-DANDROID_NATIVE_API_LEVEL=$API"
 		"-DCMAKE_BUILD_TYPE=Release"
 	)


### PR DESCRIPTION
Add Android CI. Mostly a copy from [minetest_android_deps](https://github.com/minetest/minetest_android_deps) where Irrlicht was added before forking.

An alternative would be to use [build.sh](https://github.com/minetest/minetest_android_deps/blob/master/build.sh) directly from that repo. But keeping the build script separate from own code makes little sense IMO. A better approach could be to only import `_setup_toolchain` to ensure compatibility but that requires some changes in the deps repo.