### PR TITLE
Refactor parts of the material system and set min filter to bilinear for 2D graphics

### DIFF
--- a/examples/AutomatedTest/main.cpp
+++ b/examples/AutomatedTest/main.cpp
@@ -100,10 +100,12 @@ int main(int argc, char *argv[])
 		scene::IAnimatedMeshSceneNode* node = smgr->addAnimatedMeshSceneNode(mesh);
 		if (node)
 		{
-			node->setMaterialFlag(video::EMF_LIGHTING, false);
+			node->forEachMaterial([tex] (video::SMaterial &mat) {
+				mat.Lighting = false;
+				mat.setTexture(0, tex);
+			});
 			node->setFrameLoop(0, 29);
 			node->setAnimationSpeed(30);
-			node->setMaterialTexture(0, tex);
 		}
 	}
 

--- a/include/EMaterialFlags.h
+++ b/include/EMaterialFlags.h
@@ -13,83 +13,69 @@ namespace video
 	//! Material flags
 	enum E_MATERIAL_FLAG
 	{
-		//! Draw as wireframe or filled triangles? Default: false
+		//! Corresponds to SMaterial::Wireframe.
 		EMF_WIREFRAME = 0x1,
 
-		//! Draw as point cloud or filled triangles? Default: false
+		//! Corresponds to SMaterial::PointCloud.
 		EMF_POINTCLOUD = 0x2,
 
-		//! Flat or Gouraud shading? Default: true
+		//! Corresponds to SMaterial::GouraudShading.
 		EMF_GOURAUD_SHADING = 0x4,
 
-		//! Will this material be lighted? Default: true
+		//! Corresponds to SMaterial::Lighting.
 		EMF_LIGHTING = 0x8,
 
-		//! Is the ZBuffer enabled? Default: true
+		//! Corresponds to SMaterial::ZBuffer.
 		EMF_ZBUFFER = 0x10,
 
-		//! May be written to the zbuffer or is it readonly. Default: true
-		/** This flag is ignored, if the material type is a transparent type. */
+		//! Corresponds to SMaterial::ZWriteEnable.
 		EMF_ZWRITE_ENABLE = 0x20,
 
-		//! Is backface culling enabled? Default: true
+		//! Corresponds to SMaterial::BackfaceCulling.
 		EMF_BACK_FACE_CULLING = 0x40,
 
-		//! Is frontface culling enabled? Default: false
-		/** Overrides EMF_BACK_FACE_CULLING if both are enabled. */
+		//! Corresponds to SMaterial::FrontfaceCulling.
 		EMF_FRONT_FACE_CULLING = 0x80,
 
-		//! Is bilinear filtering enabled? Default: true
+		//! Corresponds to SMaterialLayer::BilinearFilter.
 		EMF_BILINEAR_FILTER = 0x100,
 
-		//! Is trilinear filtering enabled? Default: false
-		/** If the trilinear filter flag is enabled,
-		the bilinear filtering flag is ignored. */
+		//! Corresponds to SMaterialLayer::TrilinearFilter.
 		EMF_TRILINEAR_FILTER = 0x200,
 
-		//! Is anisotropic filtering? Default: false
-		/** In Irrlicht you can use anisotropic texture filtering in
-		conjunction with bilinear or trilinear texture filtering
-		to improve rendering results. Primitives will look less
-		blurry with this flag switched on. */
+		//! Corresponds to SMaterialLayer::AnisotropicFilter.
 		EMF_ANISOTROPIC_FILTER = 0x400,
 
-		//! Is fog enabled? Default: false
+		//! Corresponds to SMaterial::FogEnable.
 		EMF_FOG_ENABLE = 0x800,
 
-		//! Normalizes normals. Default: false
-		/** You can enable this if you need to scale a dynamic lighted
-		model. Usually, its normals will get scaled too then and it
-		will get darker. If you enable the EMF_NORMALIZE_NORMALS flag,
-		the normals will be normalized again, and the model will look
-		as bright as it should. */
+		//! Corresponds to SMaterial::NormalizeNormals.
 		EMF_NORMALIZE_NORMALS = 0x1000,
 
-		//! Access to all layers texture wrap settings. Overwrites separate layer settings.
-		/** Note that if you want to change TextureWrapU, TextureWrapV, TextureWrapW 
-		independently, then you can't work with this flag, but will have to set the variables
-		directly. */
+		//! Corresponds to SMaterialLayer::TextureWrapU, TextureWrapV and
+		//! TextureWrapW.
 		EMF_TEXTURE_WRAP = 0x2000,
 
-		//! AntiAliasing mode
+		//! Corresponds to SMaterial::AntiAliasing.
 		EMF_ANTI_ALIASING = 0x4000,
 
-		//! ColorMask bits, for enabling the color planes
+		//! Corresponds to SMaterial::ColorMask.
 		EMF_COLOR_MASK = 0x8000,
 
-		//! ColorMaterial enum for vertex color interpretation
+		//! Corresponds to SMaterial::ColorMaterial.
 		EMF_COLOR_MATERIAL = 0x10000,
 
-		//! Flag for enabling/disabling mipmap usage
+		//! Corresponds to SMaterial::UseMipMaps.
 		EMF_USE_MIP_MAPS = 0x20000,
 
-		//! Flag for blend operation
+		//! Corresponds to SMaterial::BlendOperation.
 		EMF_BLEND_OPERATION = 0x40000,
 
-		//! Flag for polygon offset
+		//! Corresponds to SMaterial::PolygonOffsetFactor, PolygonOffsetDirection,
+		//! PolygonOffsetDepthBias and PolygonOffsetSlopeScale.
 		EMF_POLYGON_OFFSET = 0x80000,
 
-        //! Flag for blend factor
+		//! Corresponds to SMaterial::BlendFactor.
 		EMF_BLEND_FACTOR = 0x160000
 	};
 

--- a/include/EMaterialFlags.h
+++ b/include/EMaterialFlags.h
@@ -37,11 +37,11 @@ namespace video
 		//! Corresponds to SMaterial::FrontfaceCulling.
 		EMF_FRONT_FACE_CULLING = 0x80,
 
-		//! Corresponds to SMaterialLayer::BilinearFilter.
-		EMF_BILINEAR_FILTER = 0x100,
+		//! Corresponds to SMaterialLayer::MinFilter.
+		EMF_MIN_FILTER = 0x100,
 
-		//! Corresponds to SMaterialLayer::TrilinearFilter.
-		EMF_TRILINEAR_FILTER = 0x200,
+		//! Corresponds to SMaterialLayer::MagFilter.
+		EMF_MAG_FILTER = 0x200,
 
 		//! Corresponds to SMaterialLayer::AnisotropicFilter.
 		EMF_ANISOTROPIC_FILTER = 0x400,

--- a/include/EMaterialProps.h
+++ b/include/EMaterialProps.h
@@ -76,7 +76,7 @@ namespace video
 		EMP_POLYGON_OFFSET = 0x80000,
 
 		//! Corresponds to SMaterial::BlendFactor.
-		EMP_BLEND_FACTOR = 0x160000
+		EMP_BLEND_FACTOR = 0x100000,
 	};
 
 } // end namespace video

--- a/include/EMaterialProps.h
+++ b/include/EMaterialProps.h
@@ -2,86 +2,86 @@
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
-#ifndef __E_MATERIAL_FLAGS_H_INCLUDED__
-#define __E_MATERIAL_FLAGS_H_INCLUDED__
+#ifndef __E_MATERIAL_PROPS_H_INCLUDED__
+#define __E_MATERIAL_PROPS_H_INCLUDED__
 
 namespace irr
 {
 namespace video
 {
 
-	//! Material flags
-	enum E_MATERIAL_FLAG
+	//! Material properties
+	enum E_MATERIAL_PROP
 	{
 		//! Corresponds to SMaterial::Wireframe.
-		EMF_WIREFRAME = 0x1,
+		EMP_WIREFRAME = 0x1,
 
 		//! Corresponds to SMaterial::PointCloud.
-		EMF_POINTCLOUD = 0x2,
+		EMP_POINTCLOUD = 0x2,
 
 		//! Corresponds to SMaterial::GouraudShading.
-		EMF_GOURAUD_SHADING = 0x4,
+		EMP_GOURAUD_SHADING = 0x4,
 
 		//! Corresponds to SMaterial::Lighting.
-		EMF_LIGHTING = 0x8,
+		EMP_LIGHTING = 0x8,
 
 		//! Corresponds to SMaterial::ZBuffer.
-		EMF_ZBUFFER = 0x10,
+		EMP_ZBUFFER = 0x10,
 
 		//! Corresponds to SMaterial::ZWriteEnable.
-		EMF_ZWRITE_ENABLE = 0x20,
+		EMP_ZWRITE_ENABLE = 0x20,
 
 		//! Corresponds to SMaterial::BackfaceCulling.
-		EMF_BACK_FACE_CULLING = 0x40,
+		EMP_BACK_FACE_CULLING = 0x40,
 
 		//! Corresponds to SMaterial::FrontfaceCulling.
-		EMF_FRONT_FACE_CULLING = 0x80,
+		EMP_FRONT_FACE_CULLING = 0x80,
 
 		//! Corresponds to SMaterialLayer::MinFilter.
-		EMF_MIN_FILTER = 0x100,
+		EMP_MIN_FILTER = 0x100,
 
 		//! Corresponds to SMaterialLayer::MagFilter.
-		EMF_MAG_FILTER = 0x200,
+		EMP_MAG_FILTER = 0x200,
 
 		//! Corresponds to SMaterialLayer::AnisotropicFilter.
-		EMF_ANISOTROPIC_FILTER = 0x400,
+		EMP_ANISOTROPIC_FILTER = 0x400,
 
 		//! Corresponds to SMaterial::FogEnable.
-		EMF_FOG_ENABLE = 0x800,
+		EMP_FOG_ENABLE = 0x800,
 
 		//! Corresponds to SMaterial::NormalizeNormals.
-		EMF_NORMALIZE_NORMALS = 0x1000,
+		EMP_NORMALIZE_NORMALS = 0x1000,
 
 		//! Corresponds to SMaterialLayer::TextureWrapU, TextureWrapV and
 		//! TextureWrapW.
-		EMF_TEXTURE_WRAP = 0x2000,
+		EMP_TEXTURE_WRAP = 0x2000,
 
 		//! Corresponds to SMaterial::AntiAliasing.
-		EMF_ANTI_ALIASING = 0x4000,
+		EMP_ANTI_ALIASING = 0x4000,
 
 		//! Corresponds to SMaterial::ColorMask.
-		EMF_COLOR_MASK = 0x8000,
+		EMP_COLOR_MASK = 0x8000,
 
 		//! Corresponds to SMaterial::ColorMaterial.
-		EMF_COLOR_MATERIAL = 0x10000,
+		EMP_COLOR_MATERIAL = 0x10000,
 
 		//! Corresponds to SMaterial::UseMipMaps.
-		EMF_USE_MIP_MAPS = 0x20000,
+		EMP_USE_MIP_MAPS = 0x20000,
 
 		//! Corresponds to SMaterial::BlendOperation.
-		EMF_BLEND_OPERATION = 0x40000,
+		EMP_BLEND_OPERATION = 0x40000,
 
 		//! Corresponds to SMaterial::PolygonOffsetFactor, PolygonOffsetDirection,
 		//! PolygonOffsetDepthBias and PolygonOffsetSlopeScale.
-		EMF_POLYGON_OFFSET = 0x80000,
+		EMP_POLYGON_OFFSET = 0x80000,
 
 		//! Corresponds to SMaterial::BlendFactor.
-		EMF_BLEND_FACTOR = 0x160000
+		EMP_BLEND_FACTOR = 0x160000
 	};
 
 } // end namespace video
 } // end namespace irr
 
 
-#endif // __E_MATERIAL_FLAGS_H_INCLUDED__
+#endif // __E_MATERIAL_PROPS_H_INCLUDED__
 

--- a/include/IMesh.h
+++ b/include/IMesh.h
@@ -97,11 +97,6 @@ namespace scene
 		/** \param box New bounding box to use for the mesh. */
 		virtual void setBoundingBox( const core::aabbox3df& box) = 0;
 
-		//! Sets a flag of all contained materials to a new value.
-		/** \param flag: Flag to set in all materials.
-		\param newvalue: New value to set in all materials. */
-		virtual void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) = 0;
-
 		//! Set the hardware mapping hint
 		/** This methods allows to define optimization hints for the
 		hardware. This enables, e.g., the use of hardware buffers on

--- a/include/ISceneNode.h
+++ b/include/ISceneNode.h
@@ -352,38 +352,14 @@ namespace scene
 		}
 
 
-		//! Sets all material flags at once to a new value.
-		/** Useful, for example, if you want the whole mesh to be
-		affected by light.
-		\param flag Which flag of all materials to be set.
-		\param newvalue New value of that flag. */
-		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue)
-		{
-			for (u32 i=0; i<getMaterialCount(); ++i)
-				getMaterial(i).setFlag(flag, newvalue);
-		}
-
-
-		//! Sets the texture of the specified layer in all materials of this scene node to the new texture.
-		/** \param textureLayer Layer of texture to be set. Must be a
-		value smaller than MATERIAL_MAX_TEXTURES.
-		\param texture New texture to be used. */
-		void setMaterialTexture(u32 textureLayer, video::ITexture* texture)
-		{
-			if (textureLayer >= video::MATERIAL_MAX_TEXTURES)
-				return;
-
-			for (u32 i=0; i<getMaterialCount(); ++i)
-				getMaterial(i).setTexture(textureLayer, texture);
-		}
-
-
-		//! Sets the material type of all materials in this scene node to a new material type.
-		/** \param newType New type of material to be set. */
-		void setMaterialType(video::E_MATERIAL_TYPE newType)
-		{
-			for (u32 i=0; i<getMaterialCount(); ++i)
-				getMaterial(i).MaterialType = newType;
+		//! Execute a function on all materials of this scene node.
+		/** Useful for setting material properties, e.g. if you want the whole
+		mesh to be affected by light. */
+		template <typename F>
+		void forEachMaterial(F &&fn) {
+			for (u32 i = 0; i < getMaterialCount(); i++) {
+				fn(getMaterial(i));
+			}
 		}
 
 

--- a/include/SAnimatedMesh.h
+++ b/include/SAnimatedMesh.h
@@ -147,13 +147,6 @@ namespace scene
 			return Meshes[0]->getMeshBuffer(material);
 		}
 
-		//! Set a material flag for all meshbuffers of this mesh.
-		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override
-		{
-			for (u32 i=0; i<Meshes.size(); ++i)
-				Meshes[i]->setMaterialFlag(flag, newvalue);
-		}
-
 		//! set the hardware mapping hint, for driver
 		void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) override
 		{

--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -303,7 +303,7 @@ namespace video
 		{ }
 
 		//! Texture layer array.
-		SMaterialLayer TextureLayer[MATERIAL_MAX_TEXTURES];
+		SMaterialLayer TextureLayers[MATERIAL_MAX_TEXTURES];
 
 		//! Type of the material. Specifies how everything is blended together
 		E_MATERIAL_TYPE MaterialType;
@@ -465,7 +465,7 @@ namespace video
 		template <typename F>
 		void forEachTexture(F &&fn) {
 			for (u32 i = 0; i < MATERIAL_MAX_TEXTURES; i++) {
-				fn(TextureLayer[i]);
+				fn(TextureLayers[i]);
 			}
 		}
 
@@ -474,7 +474,7 @@ namespace video
 		\return Texture matrix for texture level i. */
 		core::matrix4& getTextureMatrix(u32 i)
 		{
-			return TextureLayer[i].getTextureMatrix();
+			return TextureLayers[i].getTextureMatrix();
 		}
 
 		//! Gets the immutable texture transformation matrix for level i
@@ -483,7 +483,7 @@ namespace video
 		const core::matrix4& getTextureMatrix(u32 i) const
 		{
 			if (i<MATERIAL_MAX_TEXTURES)
-				return TextureLayer[i].getTextureMatrix();
+				return TextureLayers[i].getTextureMatrix();
 			else
 				return core::IdentityMatrix;
 		}
@@ -495,7 +495,7 @@ namespace video
 		{
 			if (i>=MATERIAL_MAX_TEXTURES)
 				return;
-			TextureLayer[i].setTextureMatrix(mat);
+			TextureLayers[i].setTextureMatrix(mat);
 		}
 
 		//! Gets the i-th texture
@@ -503,7 +503,7 @@ namespace video
 		\return Texture for texture level i, if defined, else 0. */
 		ITexture* getTexture(u32 i) const
 		{
-			return i < MATERIAL_MAX_TEXTURES ? TextureLayer[i].Texture : 0;
+			return i < MATERIAL_MAX_TEXTURES ? TextureLayers[i].Texture : 0;
 		}
 
 		//! Sets the i-th texture
@@ -514,7 +514,7 @@ namespace video
 		{
 			if (i>=MATERIAL_MAX_TEXTURES)
 				return;
-			TextureLayer[i].Texture = tex;
+			TextureLayers[i].Texture = tex;
 		}
 
 		//! Inequality operator
@@ -554,7 +554,7 @@ namespace video
 				;
 			for (u32 i=0; (i<MATERIAL_MAX_TEXTURES) && !different; ++i)
 			{
-				different |= (TextureLayer[i] != b.TextureLayer[i]);
+				different |= (TextureLayers[i] != b.TextureLayers[i]);
 			}
 			return different;
 		}

--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -10,7 +10,7 @@
 #include "irrArray.h"
 #include "irrMath.h"
 #include "EMaterialTypes.h"
-#include "EMaterialFlags.h"
+#include "EMaterialProps.h"
 #include "SMaterialLayer.h"
 #include "IrrCompileConfig.h" // for IRRLICHT_API
 

--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -426,7 +426,6 @@ namespace video
 		f32 PolygonOffsetSlopeScale;
 
 		//! Draw as wireframe or filled triangles? Default: false
-		/** The user can access a material flag using \code material.Wireframe = true; \endcode */
 		bool Wireframe:1;
 
 		//! Draw as point cloud or filled triangles? Default: false

--- a/include/SMaterialLayer.h
+++ b/include/SMaterialLayer.h
@@ -45,26 +45,28 @@ namespace video
 
 
 	//! Texture minification filter.
-	/** Used when scaling textures down. */
+	/** Used when scaling textures down. See the documentation on OpenGL's
+	`GL_TEXTURE_MIN_FILTER` for more information. */
 	enum E_TEXTURE_MIN_FILTER {
-		//! Nearest-neighbor interpolation.
-		ETMINF_NEAREST = 0,
-		//! Linear interpolation.
-		ETMINF_BILINEAR,
-		//! Linear interpolation across mipmaps.
-		/** Is equivalent to ETMINF_BILINEAR if mipmaps are disabled.
-		Only available as a minification filter since mipmaps are only used
-		when scaling down. */
-		ETMINF_TRILINEAR,
+		//! Aka nearest-neighbor.
+		ETMINF_NEAREST_MIPMAP_NEAREST = 0,
+		//! Aka bilinear.
+		ETMINF_LINEAR_MIPMAP_NEAREST,
+		//! Isn't known by any other name.
+		ETMINF_NEAREST_MIPMAP_LINEAR,
+		//! Aka trilinear.
+		ETMINF_LINEAR_MIPMAP_LINEAR,
 	};
 
 	//! Texture magnification filter.
-	/** Used when scaling textures up. */
+	/** Used when scaling textures up. See the documentation on OpenGL's
+	`GL_TEXTURE_MAG_FILTER` for more information.
+	Note that mipmaps are only used for minification, not for magnification. */
 	enum E_TEXTURE_MAG_FILTER {
-		//! Nearest-neighbor interpolation.
+		//! Aka nearest-neighbor.
 		ETMAGF_NEAREST = 0,
-		//! Linear interpolation.
-		ETMAGF_BILINEAR,
+		//! Aka bilinear.
+		ETMAGF_LINEAR,
 	};
 
 	//! Struct for holding material parameters which exist per texture layer
@@ -74,7 +76,7 @@ namespace video
 	public:
 		//! Default constructor
 		SMaterialLayer() : Texture(0), TextureWrapU(ETC_REPEAT), TextureWrapV(ETC_REPEAT), TextureWrapW(ETC_REPEAT),
-			MinFilter(ETMINF_BILINEAR), MagFilter(ETMAGF_BILINEAR), AnisotropicFilter(0), LODBias(0), TextureMatrix(0)
+			MinFilter(ETMINF_LINEAR_MIPMAP_NEAREST), MagFilter(ETMAGF_LINEAR), AnisotropicFilter(0), LODBias(0), TextureMatrix(0)
 		{
 		}
 
@@ -234,9 +236,9 @@ namespace video
 		//! to the three relevant boolean values found in the Minetest settings.
 		/** The value of `trilinear` takes precedence over the value of `bilinear`. */
 		void setFiltersMinetest(bool bilinear, bool trilinear, bool anisotropic) {
-			MinFilter = trilinear ? ETMINF_TRILINEAR :
-					(bilinear ? ETMINF_BILINEAR : ETMINF_NEAREST);
-			MagFilter = (trilinear || bilinear) ? ETMAGF_BILINEAR : ETMAGF_NEAREST;
+			MinFilter = trilinear ? ETMINF_LINEAR_MIPMAP_LINEAR :
+					(bilinear ? ETMINF_LINEAR_MIPMAP_NEAREST : ETMINF_NEAREST_MIPMAP_NEAREST);
+			MagFilter = (trilinear || bilinear) ? ETMAGF_LINEAR : ETMAGF_NEAREST;
 			AnisotropicFilter = anisotropic ? 0xFF : 0;
 		}
 

--- a/include/SMesh.h
+++ b/include/SMesh.h
@@ -117,13 +117,6 @@ namespace scene
 			}
 		}
 
-		//! sets a flag of all contained materials to a new value
-		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override
-		{
-			for (u32 i=0; i<MeshBuffers.size(); ++i)
-				MeshBuffers[i]->getMaterial().setFlag(flag, newvalue);
-		}
-
 		//! set the hardware mapping hint, for driver
 		void setHardwareMappingHint( E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX ) override
 		{

--- a/include/SOverrideMaterial.h
+++ b/include/SOverrideMaterial.h
@@ -109,7 +109,7 @@ namespace video
 							{
 								if ( EnableLayerProps[i] )
 								{
-									material.TextureLayer[i].MinFilter = Material.TextureLayer[i].MinFilter;
+									material.TextureLayers[i].MinFilter = Material.TextureLayers[i].MinFilter;
 								}
 							}
 							break;
@@ -118,7 +118,7 @@ namespace video
 							{
 								if ( EnableLayerProps[i] )
 								{
-									material.TextureLayer[i].MagFilter = Material.TextureLayer[i].MagFilter;
+									material.TextureLayers[i].MagFilter = Material.TextureLayers[i].MagFilter;
 								}
 							}
 							break;
@@ -127,7 +127,7 @@ namespace video
 							{
 								if ( EnableLayerProps[i] )
 								{
-									material.TextureLayer[i].AnisotropicFilter = Material.TextureLayer[i].AnisotropicFilter;
+									material.TextureLayers[i].AnisotropicFilter = Material.TextureLayers[i].AnisotropicFilter;
 								}
 							}
 							break;
@@ -138,9 +138,9 @@ namespace video
 							{
 								if ( EnableLayerProps[i] )
 								{
-									material.TextureLayer[i].TextureWrapU = Material.TextureLayer[i].TextureWrapU;
-									material.TextureLayer[i].TextureWrapV = Material.TextureLayer[i].TextureWrapV;
-									material.TextureLayer[i].TextureWrapW = Material.TextureLayer[i].TextureWrapW;
+									material.TextureLayers[i].TextureWrapU = Material.TextureLayers[i].TextureWrapU;
+									material.TextureLayers[i].TextureWrapV = Material.TextureLayers[i].TextureWrapV;
+									material.TextureLayers[i].TextureWrapW = Material.TextureLayers[i].TextureWrapW;
 								}
 							}
 							break;
@@ -163,11 +163,11 @@ namespace video
 				{
 					if ( EnableLayers[i] )
 					{
-						material.TextureLayer[i] = Material.TextureLayer[i];
+						material.TextureLayers[i] = Material.TextureLayers[i];
 					}
 					else if ( EnableTextures[i] )
 					{
-						material.TextureLayer[i].Texture = Material.TextureLayer[i].Texture;
+						material.TextureLayers[i].Texture = Material.TextureLayers[i].Texture;
 					}
 				}
 			}

--- a/include/SOverrideMaterial.h
+++ b/include/SOverrideMaterial.h
@@ -18,16 +18,16 @@ namespace video
 		SMaterial Material;
 
 		//! Which values are overridden
-		/** OR'ed values from E_MATERIAL_FLAGS. */
-		u32 EnableFlags;
+		/** OR'ed values from E_MATERIAL_PROPS. */
+		u32 EnableProps;
 
-		//! For those flags in EnableFlags which affect layers, set which of the layers are affected
-		bool EnableLayerFlags[MATERIAL_MAX_TEXTURES];
+		//! For those properties in EnableProps which affect layers, set which of the layers are affected
+		bool EnableLayerProps[MATERIAL_MAX_TEXTURES];
 
 		//! Which textures are overridden
 		bool EnableTextures[MATERIAL_MAX_TEXTURES];
 
-		//! Overwrite complete layers (settings of EnableLayerFlags and EnableTextures don't matter then for layer data)
+		//! Overwrite complete layers (settings of EnableLayerProps and EnableTextures don't matter then for layer data)
 		bool EnableLayers[MATERIAL_MAX_TEXTURES];
 
 		//! Set in which render passes the material override is active.
@@ -59,19 +59,19 @@ namespace video
 		core::array<SMaterialTypeReplacement> MaterialTypes;
 
 		//! Default constructor
-		SOverrideMaterial() : EnableFlags(0), EnablePasses(0), Enabled(false)
+		SOverrideMaterial() : EnableProps(0), EnablePasses(0), Enabled(false)
 		{
 		}
 
-		//! disable overrides and reset all flags
+		//! disable overrides and reset all properties
 		void reset()
 		{
-			EnableFlags = 0;
+			EnableProps = 0;
 			EnablePasses = 0;
 			Enabled = false;
 			for (u32 i = 0; i < MATERIAL_MAX_TEXTURES; ++i)
 			{
-				EnableLayerFlags[i] = true;	// doesn't do anything unless EnableFlags is set, just saying by default all texture layers are affected by flags
+				EnableLayerProps[i] = true; // doesn't do anything unless EnableProps is set, just saying by default all texture layers are affected by properties
 				EnableTextures[i] = false;
 				EnableLayers[i] = false;
 			}
@@ -92,51 +92,51 @@ namespace video
 				for (u32 f=0; f<32; ++f)
 				{
 					const u32 num=(1<<f);
-					if (EnableFlags & num)
+					if (EnableProps & num)
 					{
 						switch (num)
 						{
-						case EMF_WIREFRAME: material.Wireframe = Material.Wireframe; break;
-						case EMF_POINTCLOUD: material.PointCloud = Material.PointCloud; break;
-						case EMF_GOURAUD_SHADING: material.GouraudShading = Material.GouraudShading; break;
-						case EMF_LIGHTING: material.Lighting = Material.Lighting; break;
-						case EMF_ZBUFFER: material.ZBuffer = Material.ZBuffer; break;
-						case EMF_ZWRITE_ENABLE: material.ZWriteEnable = Material.ZWriteEnable; break;
-						case EMF_BACK_FACE_CULLING: material.BackfaceCulling = Material.BackfaceCulling; break;
-						case EMF_FRONT_FACE_CULLING: material.FrontfaceCulling = Material.FrontfaceCulling; break;
-						case EMF_MIN_FILTER:
+						case EMP_WIREFRAME: material.Wireframe = Material.Wireframe; break;
+						case EMP_POINTCLOUD: material.PointCloud = Material.PointCloud; break;
+						case EMP_GOURAUD_SHADING: material.GouraudShading = Material.GouraudShading; break;
+						case EMP_LIGHTING: material.Lighting = Material.Lighting; break;
+						case EMP_ZBUFFER: material.ZBuffer = Material.ZBuffer; break;
+						case EMP_ZWRITE_ENABLE: material.ZWriteEnable = Material.ZWriteEnable; break;
+						case EMP_BACK_FACE_CULLING: material.BackfaceCulling = Material.BackfaceCulling; break;
+						case EMP_FRONT_FACE_CULLING: material.FrontfaceCulling = Material.FrontfaceCulling; break;
+						case EMP_MIN_FILTER:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
-								if ( EnableLayerFlags[i] )
+								if ( EnableLayerProps[i] )
 								{
 									material.TextureLayer[i].MinFilter = Material.TextureLayer[i].MinFilter;
 								}
 							}
 							break;
-						case EMF_MAG_FILTER:
+						case EMP_MAG_FILTER:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
-								if ( EnableLayerFlags[i] )
+								if ( EnableLayerProps[i] )
 								{
 									material.TextureLayer[i].MagFilter = Material.TextureLayer[i].MagFilter;
 								}
 							}
 							break;
-						case EMF_ANISOTROPIC_FILTER:
+						case EMP_ANISOTROPIC_FILTER:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
-								if ( EnableLayerFlags[i] )
+								if ( EnableLayerProps[i] )
 								{
 									material.TextureLayer[i].AnisotropicFilter = Material.TextureLayer[i].AnisotropicFilter;
 								}
 							}
 							break;
-						case EMF_FOG_ENABLE: material.FogEnable = Material.FogEnable; break;
-						case EMF_NORMALIZE_NORMALS: material.NormalizeNormals = Material.NormalizeNormals; break;
-						case EMF_TEXTURE_WRAP:
+						case EMP_FOG_ENABLE: material.FogEnable = Material.FogEnable; break;
+						case EMP_NORMALIZE_NORMALS: material.NormalizeNormals = Material.NormalizeNormals; break;
+						case EMP_TEXTURE_WRAP:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
-								if ( EnableLayerFlags[i] )
+								if ( EnableLayerProps[i] )
 								{
 									material.TextureLayer[i].TextureWrapU = Material.TextureLayer[i].TextureWrapU;
 									material.TextureLayer[i].TextureWrapV = Material.TextureLayer[i].TextureWrapV;
@@ -144,13 +144,13 @@ namespace video
 								}
 							}
 							break;
-						case EMF_ANTI_ALIASING: material.AntiAliasing = Material.AntiAliasing; break;
-						case EMF_COLOR_MASK: material.ColorMask = Material.ColorMask; break;
-						case EMF_COLOR_MATERIAL: material.ColorMaterial = Material.ColorMaterial; break;
-						case EMF_USE_MIP_MAPS: material.UseMipMaps = Material.UseMipMaps; break;
-						case EMF_BLEND_OPERATION: material.BlendOperation = Material.BlendOperation; break;
-						case EMF_BLEND_FACTOR: material.BlendFactor = Material.BlendFactor; break;
-						case EMF_POLYGON_OFFSET:
+						case EMP_ANTI_ALIASING: material.AntiAliasing = Material.AntiAliasing; break;
+						case EMP_COLOR_MASK: material.ColorMask = Material.ColorMask; break;
+						case EMP_COLOR_MATERIAL: material.ColorMaterial = Material.ColorMaterial; break;
+						case EMP_USE_MIP_MAPS: material.UseMipMaps = Material.UseMipMaps; break;
+						case EMP_BLEND_OPERATION: material.BlendOperation = Material.BlendOperation; break;
+						case EMP_BLEND_FACTOR: material.BlendFactor = Material.BlendFactor; break;
+						case EMP_POLYGON_OFFSET:
 							material.PolygonOffsetDirection = Material.PolygonOffsetDirection;
 							material.PolygonOffsetFactor = Material.PolygonOffsetFactor;
 							material.PolygonOffsetDepthBias = Material.PolygonOffsetDepthBias;

--- a/include/SOverrideMaterial.h
+++ b/include/SOverrideMaterial.h
@@ -104,21 +104,21 @@ namespace video
 						case EMF_ZWRITE_ENABLE: material.ZWriteEnable = Material.ZWriteEnable; break;
 						case EMF_BACK_FACE_CULLING: material.BackfaceCulling = Material.BackfaceCulling; break;
 						case EMF_FRONT_FACE_CULLING: material.FrontfaceCulling = Material.FrontfaceCulling; break;
-						case EMF_BILINEAR_FILTER:
+						case EMF_MIN_FILTER:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
 								if ( EnableLayerFlags[i] )
 								{
-									material.TextureLayer[i].BilinearFilter = Material.TextureLayer[i].BilinearFilter;
+									material.TextureLayer[i].MinFilter = Material.TextureLayer[i].MinFilter;
 								}
 							}
 							break;
-						case EMF_TRILINEAR_FILTER:
+						case EMF_MAG_FILTER:
 							for ( u32 i=0; i<MATERIAL_MAX_TEXTURES; ++i)
 							{
 								if ( EnableLayerFlags[i] )
 								{
-									material.TextureLayer[i].TrilinearFilter = Material.TextureLayer[i].TrilinearFilter;
+									material.TextureLayer[i].MagFilter = Material.TextureLayer[i].MagFilter;
 								}
 							}
 							break;

--- a/include/irrlicht.h
+++ b/include/irrlicht.h
@@ -42,7 +42,7 @@
 #include "EGUIAlignment.h"
 #include "EGUIElementTypes.h"
 #include "EHardwareBufferFlags.h"
-#include "EMaterialFlags.h"
+#include "EMaterialProps.h"
 #include "EMaterialTypes.h"
 #include "EMeshWriterEnums.h"
 #include "ESceneNodeTypes.h"

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -103,7 +103,7 @@ CNullDriver::CNullDriver(io::IFileSystem* io, const core::dimension2d<u32>& scre
 	InitMaterial2D.ZBuffer = video::ECFN_DISABLED;
 	InitMaterial2D.UseMipMaps = false;
 	InitMaterial2D.forEachTexture([] (auto &tex) {
-		tex.MinFilter = video::ETMINF_NEAREST;
+		tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 		tex.MagFilter = video::ETMAGF_NEAREST;
 		tex.TextureWrapU = video::ETC_REPEAT;
 		tex.TextureWrapV = video::ETC_REPEAT;

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -103,7 +103,9 @@ CNullDriver::CNullDriver(io::IFileSystem* io, const core::dimension2d<u32>& scre
 	InitMaterial2D.ZBuffer = video::ECFN_DISABLED;
 	InitMaterial2D.UseMipMaps = false;
 	InitMaterial2D.forEachTexture([] (auto &tex) {
-		tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
+		// Using ETMINF_LINEAR_MIPMAP_NEAREST (bilinear) for 2D graphics looks
+		// much better and doesn't have any downsides (e.g. regarding pixel art).
+		tex.MinFilter = video::ETMINF_LINEAR_MIPMAP_NEAREST;
 		tex.MagFilter = video::ETMAGF_NEAREST;
 		tex.TextureWrapU = video::ETC_REPEAT;
 		tex.TextureWrapV = video::ETC_REPEAT;

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -97,19 +97,19 @@ CNullDriver::CNullDriver(io::IFileSystem* io, const core::dimension2d<u32>& scre
 	for (u32 i=0; i<video::EVDF_COUNT; ++i)
 		FeatureEnabled[i]=true;
 
-	InitMaterial2D.AntiAliasing=video::EAAM_OFF;
-	InitMaterial2D.Lighting=false;
-	InitMaterial2D.ZWriteEnable=video::EZW_OFF;
-	InitMaterial2D.ZBuffer=video::ECFN_DISABLED;
-	InitMaterial2D.UseMipMaps=false;
-	for (u32 i=0; i<video::MATERIAL_MAX_TEXTURES; ++i)
-	{
-		InitMaterial2D.TextureLayer[i].BilinearFilter=false;
-		InitMaterial2D.TextureLayer[i].TextureWrapU=video::ETC_REPEAT;
-		InitMaterial2D.TextureLayer[i].TextureWrapV=video::ETC_REPEAT;
-		InitMaterial2D.TextureLayer[i].TextureWrapW = video::ETC_REPEAT;
-	}
-	OverrideMaterial2D=InitMaterial2D;
+	InitMaterial2D.AntiAliasing = video::EAAM_OFF;
+	InitMaterial2D.Lighting = false;
+	InitMaterial2D.ZWriteEnable = video::EZW_OFF;
+	InitMaterial2D.ZBuffer = video::ECFN_DISABLED;
+	InitMaterial2D.UseMipMaps = false;
+	InitMaterial2D.forEachTexture([] (auto &tex) {
+		tex.MinFilter = video::ETMINF_NEAREST;
+		tex.MagFilter = video::ETMAGF_NEAREST;
+		tex.TextureWrapU = video::ETC_REPEAT;
+		tex.TextureWrapV = video::ETC_REPEAT;
+		tex.TextureWrapW = video::ETC_REPEAT;
+	});
+	OverrideMaterial2D = InitMaterial2D;
 }
 
 

--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -4,6 +4,7 @@
 // For conditions of distribution and use, see copyright notice in Irrlicht.h
 
 #include "COGLES2Driver.h"
+#include <cassert>
 #include "CNullDriver.h"
 #include "IContextManager.h"
 
@@ -1700,7 +1701,8 @@ COGLES2Driver::~COGLES2Driver()
 			{
 				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_NEAREST ? GL_NEAREST :
+					(assert(magFilter == ETMAGF_LINEAR), GL_LINEAR));
 
 				tmpTexture->getStatesCache().MagFilter = magFilter;
 			}
@@ -1712,9 +1714,10 @@ COGLES2Driver::~COGLES2Driver()
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
-						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
-						GL_NEAREST_MIPMAP_NEAREST);
+						minFilter == ETMINF_NEAREST_MIPMAP_NEAREST ? GL_NEAREST_MIPMAP_NEAREST :
+						minFilter == ETMINF_LINEAR_MIPMAP_NEAREST ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_NEAREST_MIPMAP_LINEAR ? GL_NEAREST_MIPMAP_LINEAR :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR_MIPMAP_LINEAR));
 
 					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = true;
@@ -1727,7 +1730,8 @@ COGLES2Driver::~COGLES2Driver()
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_NEAREST_MIPMAP_NEAREST || minFilter == ETMINF_NEAREST_MIPMAP_LINEAR) ? GL_NEAREST :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_NEAREST || minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR));
 
 					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = false;

--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -1696,41 +1696,40 @@ COGLES2Driver::~COGLES2Driver()
 			if (resetAllRenderstates)
 				tmpTexture->getStatesCache().IsCached = false;
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-				material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
 			{
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-					(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
 
-				tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-				tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+				tmpTexture->getStatesCache().MagFilter = magFilter;
 			}
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter || !tmpTexture->getStatesCache().MipMapStatus)
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+					!tmpTexture->getStatesCache().MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						material.TextureLayer[i].TrilinearFilter ? GL_LINEAR_MIPMAP_LINEAR :
-						material.TextureLayer[i].BilinearFilter ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
+						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
 						GL_NEAREST_MIPMAP_NEAREST);
 
-					tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = true;
 				}
 			}
 			else
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter || tmpTexture->getStatesCache().MipMapStatus)
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+					tmpTexture->getStatesCache().MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
-					tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = false;
 				}
 			}

--- a/source/Irrlicht/COGLES2Driver.cpp
+++ b/source/Irrlicht/COGLES2Driver.cpp
@@ -264,7 +264,7 @@ COGLES2Driver::~COGLES2Driver()
 
 	bool COGLES2Driver::setMaterialTexture(irr::u32 layerIdx, const irr::video::ITexture* texture)
 	{
-		Material.TextureLayer[layerIdx].Texture = const_cast<ITexture*>(texture); // function uses const-pointer for texture because all draw functions use const-pointers already
+		Material.TextureLayers[layerIdx].Texture = const_cast<ITexture*>(texture); // function uses const-pointer for texture because all draw functions use const-pointers already
 		return CacheHandler->getTextureCache().set(0, texture);
 	}
 
@@ -1696,9 +1696,9 @@ COGLES2Driver::~COGLES2Driver()
 			if (resetAllRenderstates)
 				tmpTexture->getStatesCache().IsCached = false;
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
 			{
-				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
 					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
 
@@ -1707,10 +1707,10 @@ COGLES2Driver::~COGLES2Driver()
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
 					!tmpTexture->getStatesCache().MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
 						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
@@ -1722,10 +1722,10 @@ COGLES2Driver::~COGLES2Driver()
 			}
 			else
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
 					tmpTexture->getStatesCache().MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
@@ -1736,25 +1736,25 @@ COGLES2Driver::~COGLES2Driver()
 
 	#ifdef GL_EXT_texture_filter_anisotropic
 			if (FeatureAvailable[COGLESCoreExtensionHandler::IRR_GL_EXT_texture_filter_anisotropic] &&
-				(!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
+				(!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
 			{
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-					material.TextureLayer[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayer[i].AnisotropicFilter) : 1);
+					material.TextureLayers[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayers[i].AnisotropicFilter) : 1);
 
-				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayer[i].AnisotropicFilter;
+				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayers[i].AnisotropicFilter;
 			}
 	#endif
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayer[i].TextureWrapU));
-				tmpTexture->getStatesCache().WrapU = material.TextureLayer[i].TextureWrapU;
+				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
+				tmpTexture->getStatesCache().WrapU = material.TextureLayers[i].TextureWrapU;
 			}
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].TextureWrapV != tmpTexture->getStatesCache().WrapV)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapV != tmpTexture->getStatesCache().WrapV)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayer[i].TextureWrapV));
-				tmpTexture->getStatesCache().WrapV = material.TextureLayer[i].TextureWrapV;
+				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
+				tmpTexture->getStatesCache().WrapV = material.TextureLayers[i].TextureWrapV;
 			}
 
 			tmpTexture->getStatesCache().IsCached = true;

--- a/source/Irrlicht/COGLES2FixedPipelineRenderer.cpp
+++ b/source/Irrlicht/COGLES2FixedPipelineRenderer.cpp
@@ -112,7 +112,7 @@ void COGLES2MaterialSolidCB::OnSetMaterial(const SMaterial& material)
 	COGLES2MaterialBaseCB::OnSetMaterial(material);
 
 	AlphaRef = material.MaterialTypeParam;
-	TextureUsage0 = (material.TextureLayer[0].Texture) ? 1 : 0;
+	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
 void COGLES2MaterialSolidCB::OnSetConstants(IMaterialRendererServices* services, s32 userData)
@@ -169,7 +169,7 @@ void COGLES2MaterialOneTextureBlendCB::OnSetMaterial(const SMaterial& material)
 		}
 	}
 
-	TextureUsage0 = (material.TextureLayer[0].Texture) ? 1 : 0;
+	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
 void COGLES2MaterialOneTextureBlendCB::OnSetConstants(IMaterialRendererServices* services, s32 userData)

--- a/source/Irrlicht/COGLES2Renderer2D.cpp
+++ b/source/Irrlicht/COGLES2Renderer2D.cpp
@@ -71,7 +71,7 @@ void COGLES2Renderer2D::OnSetMaterial(const video::SMaterial& material,
 
 	if ( WithTexture )
 	{
-		s32 TextureUsage = material.TextureLayer[0].Texture ? 1 : 0;
+		s32 TextureUsage = material.TextureLayers[0].Texture ? 1 : 0;
 		setPixelShaderConstant(TextureUsageID, &TextureUsage, 1);
 	}
 }

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -1841,7 +1841,7 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 
 	for (s32 i = Feature.MaxTextureUnits - 1; i >= 0; --i)
 	{
-		CacheHandler->getTextureCache().set(i, material.TextureLayer[i].Texture);
+		CacheHandler->getTextureCache().set(i, material.TextureLayers[i].Texture);
 
 		const COGLES1Texture* tmpTexture = CacheHandler->getTextureCache().get(i);
 
@@ -1878,24 +1878,24 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 #ifdef GL_VERSION_2_1
 		if (Version >= 210)
 		{
-			if (!statesCache.IsCached || material.TextureLayer[i].LODBias != statesCache.LODBias)
+			if (!statesCache.IsCached || material.TextureLayers[i].LODBias != statesCache.LODBias)
 			{
-				if (material.TextureLayer[i].LODBias)
+				if (material.TextureLayers[i].LODBias)
 				{
-					const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+					const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 					glTexParameterf(tmpTextureType, GL_TEXTURE_LOD_BIAS, tmp);
 				}
 				else
 					glTexParameterf(tmpTextureType, GL_TEXTURE_LOD_BIAS, 0.f);
 
-				statesCache.LODBias = material.TextureLayer[i].LODBias;
+				statesCache.LODBias = material.TextureLayers[i].LODBias;
 			}
 		}
 		else if (FeatureAvailable[IRR_EXT_texture_lod_bias])
 		{
-			if (material.TextureLayer[i].LODBias)
+			if (material.TextureLayers[i].LODBias)
 			{
-				const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+				const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 				glTexEnvf(GL_TEXTURE_FILTER_CONTROL_EXT, GL_TEXTURE_LOD_BIAS_EXT, tmp);
 			}
 			else
@@ -1904,9 +1904,9 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 #elif defined(GL_EXT_texture_lod_bias)
 		if (FeatureAvailable[COGLESCoreExtensionHandler::IRR_GL_EXT_texture_lod_bias])
 		{
-			if (material.TextureLayer[i].LODBias)
+			if (material.TextureLayers[i].LODBias)
 			{
-				const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+				const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 				glTexEnvf(GL_TEXTURE_FILTER_CONTROL_EXT, GL_TEXTURE_LOD_BIAS_EXT, tmp);
 			}
 			else
@@ -1914,9 +1914,9 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 		}
 #endif
 
-		if (!statesCache.IsCached || material.TextureLayer[i].MagFilter != statesCache.MagFilter)
+		if (!statesCache.IsCached || material.TextureLayers[i].MagFilter != statesCache.MagFilter)
 		{
-			E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
+			E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 			glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
 				magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
 
@@ -1925,10 +1925,10 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 
 		if (material.UseMipMaps && tmpTexture->hasMipMaps())
 		{
-			if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+			if (!statesCache.IsCached || material.TextureLayers[i].MinFilter != statesCache.MinFilter ||
 				!statesCache.MipMapStatus)
 			{
-				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 					minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
 					minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
@@ -1940,10 +1940,10 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 		}
 		else
 		{
-			if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+			if (!statesCache.IsCached || material.TextureLayers[i].MinFilter != statesCache.MinFilter ||
 				statesCache.MipMapStatus)
 			{
-				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 					(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
@@ -1954,25 +1954,25 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 
 #ifdef GL_EXT_texture_filter_anisotropic
 		if (FeatureAvailable[COGLESCoreExtensionHandler::IRR_GL_EXT_texture_filter_anisotropic] &&
-			(!statesCache.IsCached || material.TextureLayer[i].AnisotropicFilter != statesCache.AnisotropicFilter))
+			(!statesCache.IsCached || material.TextureLayers[i].AnisotropicFilter != statesCache.AnisotropicFilter))
 		{
 			glTexParameteri(tmpTextureType, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-				material.TextureLayer[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayer[i].AnisotropicFilter) : 1);
+				material.TextureLayers[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayers[i].AnisotropicFilter) : 1);
 
-			statesCache.AnisotropicFilter = material.TextureLayer[i].AnisotropicFilter;
+			statesCache.AnisotropicFilter = material.TextureLayers[i].AnisotropicFilter;
 		}
 #endif
 
-		if (!statesCache.IsCached || material.TextureLayer[i].TextureWrapU != statesCache.WrapU)
+		if (!statesCache.IsCached || material.TextureLayers[i].TextureWrapU != statesCache.WrapU)
 		{
-			glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayer[i].TextureWrapU));
-			statesCache.WrapU = material.TextureLayer[i].TextureWrapU;
+			glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
+			statesCache.WrapU = material.TextureLayers[i].TextureWrapU;
 		}
 
-		if (!statesCache.IsCached || material.TextureLayer[i].TextureWrapV != statesCache.WrapV)
+		if (!statesCache.IsCached || material.TextureLayers[i].TextureWrapV != statesCache.WrapV)
 		{
-			glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayer[i].TextureWrapV));
-			statesCache.WrapV = material.TextureLayer[i].TextureWrapV;
+			glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
+			statesCache.WrapV = material.TextureLayers[i].TextureWrapV;
 		}
 
 		statesCache.IsCached = true;
@@ -2013,7 +2013,7 @@ void COGLES1Driver::setRenderStates2DMode(bool alpha, bool texture, bool alphaCh
 
 	Material = (OverrideMaterial2DEnabled) ? OverrideMaterial2D : InitMaterial2D;
 	Material.Lighting = false;
-	Material.TextureLayer[0].Texture = (texture) ? const_cast<COGLES1Texture*>(CacheHandler->getTextureCache().get(0)) : 0;
+	Material.TextureLayers[0].Texture = (texture) ? const_cast<COGLES1Texture*>(CacheHandler->getTextureCache().get(0)) : 0;
 	setTransform(ETS_TEXTURE_0, core::IdentityMatrix);
 
 	setBasicRenderStates(Material, LastMaterial, false);

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -1914,41 +1914,40 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 		}
 #endif
 
-		if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-			material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter)
+		if (!statesCache.IsCached || material.TextureLayer[i].MagFilter != statesCache.MagFilter)
 		{
+			E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
 			glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-				(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+				magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
 
-			statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-			statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+			statesCache.MagFilter = magFilter;
 		}
 
 		if (material.UseMipMaps && tmpTexture->hasMipMaps())
 		{
-			if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-				material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter || !statesCache.MipMapStatus)
+			if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+				!statesCache.MipMapStatus)
 			{
+				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-					material.TextureLayer[i].TrilinearFilter ? GL_LINEAR_MIPMAP_LINEAR :
-					material.TextureLayer[i].BilinearFilter ? GL_LINEAR_MIPMAP_NEAREST :
+					minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
+					minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
 					GL_NEAREST_MIPMAP_NEAREST);
 
-				statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-				statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+				statesCache.MinFilter = minFilter;
 				statesCache.MipMapStatus = true;
 			}
 		}
 		else
 		{
-			if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-				material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter || statesCache.MipMapStatus)
+			if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+				statesCache.MipMapStatus)
 			{
+				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-					(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+					(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
-				statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-				statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+				statesCache.MinFilter = minFilter;
 				statesCache.MipMapStatus = false;
 			}
 		}

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -3,6 +3,7 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "COGLESDriver.h"
+#include <cassert>
 #include "CNullDriver.h"
 #include "IContextManager.h"
 
@@ -1918,7 +1919,8 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 		{
 			E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 			glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-				magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
+				magFilter == ETMAGF_NEAREST ? GL_NEAREST :
+				(assert(magFilter == ETMAGF_LINEAR), GL_LINEAR));
 
 			statesCache.MagFilter = magFilter;
 		}
@@ -1930,9 +1932,10 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 			{
 				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-					minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
-					minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
-					GL_NEAREST_MIPMAP_NEAREST);
+					minFilter == ETMINF_NEAREST_MIPMAP_NEAREST ? GL_NEAREST_MIPMAP_NEAREST :
+					minFilter == ETMINF_LINEAR_MIPMAP_NEAREST ? GL_LINEAR_MIPMAP_NEAREST :
+					minFilter == ETMINF_NEAREST_MIPMAP_LINEAR ? GL_NEAREST_MIPMAP_LINEAR :
+					(assert(minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR_MIPMAP_LINEAR));
 
 				statesCache.MinFilter = minFilter;
 				statesCache.MipMapStatus = true;
@@ -1945,7 +1948,9 @@ void COGLES1Driver::setTextureRenderStates(const SMaterial& material, bool reset
 			{
 				E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-					(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
+					(minFilter == ETMINF_NEAREST_MIPMAP_NEAREST || minFilter == ETMINF_NEAREST_MIPMAP_LINEAR) ? GL_NEAREST :
+					(assert(minFilter == ETMINF_LINEAR_MIPMAP_NEAREST || minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR));
+
 
 				statesCache.MinFilter = minFilter;
 				statesCache.MipMapStatus = false;

--- a/source/Irrlicht/COpenGLCoreCacheHandler.h
+++ b/source/Irrlicht/COpenGLCoreCacheHandler.h
@@ -590,9 +590,9 @@ public:
 		// Fix textures which got removed
 		for ( u32 i=0; i < MATERIAL_MAX_TEXTURES; ++i )
 		{
-			if ( material.TextureLayer[i].Texture && !TextureCache[i] )
+			if ( material.TextureLayers[i].Texture && !TextureCache[i] )
 			{
-				material.TextureLayer[i].Texture = 0;
+				material.TextureLayers[i].Texture = 0;
 			}
 		}
 	}

--- a/source/Irrlicht/COpenGLCoreTexture.h
+++ b/source/Irrlicht/COpenGLCoreTexture.h
@@ -31,7 +31,7 @@ public:
 	struct SStatesCache
 	{
 		SStatesCache() : WrapU(ETC_REPEAT), WrapV(ETC_REPEAT), WrapW(ETC_REPEAT),
-			LODBias(0), AnisotropicFilter(0), MinFilter(video::ETMINF_NEAREST),
+			LODBias(0), AnisotropicFilter(0), MinFilter(video::ETMINF_NEAREST_MIPMAP_NEAREST),
 			MagFilter(video::ETMAGF_NEAREST), MipMapStatus(false), IsCached(false)
 		{
 		}

--- a/source/Irrlicht/COpenGLCoreTexture.h
+++ b/source/Irrlicht/COpenGLCoreTexture.h
@@ -31,8 +31,8 @@ public:
 	struct SStatesCache
 	{
 		SStatesCache() : WrapU(ETC_REPEAT), WrapV(ETC_REPEAT), WrapW(ETC_REPEAT),
-			LODBias(0), AnisotropicFilter(0), BilinearFilter(false), TrilinearFilter(false),
-			MipMapStatus(false), IsCached(false)
+			LODBias(0), AnisotropicFilter(0), MinFilter(video::ETMINF_NEAREST),
+			MagFilter(video::ETMAGF_NEAREST), MipMapStatus(false), IsCached(false)
 		{
 		}
 
@@ -41,8 +41,8 @@ public:
 		u8 WrapW;
 		s8 LODBias;
 		u8 AnisotropicFilter;
-		bool BilinearFilter;
-		bool TrilinearFilter;
+		video::E_TEXTURE_MIN_FILTER MinFilter;
+		video::E_TEXTURE_MAG_FILTER MagFilter;
 		bool MipMapStatus;
 		bool IsCached;
 	};

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -2673,24 +2673,24 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 #ifdef GL_VERSION_2_1
 			if (Version >= 201)
 			{
-				if (!statesCache.IsCached || material.TextureLayer[i].LODBias != statesCache.LODBias)
+				if (!statesCache.IsCached || material.TextureLayers[i].LODBias != statesCache.LODBias)
 				{
-					if (material.TextureLayer[i].LODBias)
+					if (material.TextureLayers[i].LODBias)
 					{
-						const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+						const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 						glTexParameterf(tmpType, GL_TEXTURE_LOD_BIAS, tmp);
 					}
 					else
 						glTexParameterf(tmpType, GL_TEXTURE_LOD_BIAS, 0.f);
 
-					statesCache.LODBias = material.TextureLayer[i].LODBias;
+					statesCache.LODBias = material.TextureLayers[i].LODBias;
 				}
 			}
 			else if (FeatureAvailable[IRR_EXT_texture_lod_bias])
 			{
-				if (material.TextureLayer[i].LODBias)
+				if (material.TextureLayers[i].LODBias)
 				{
-					const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+					const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 					glTexEnvf(GL_TEXTURE_FILTER_CONTROL_EXT, GL_TEXTURE_LOD_BIAS_EXT, tmp);
 				}
 				else
@@ -2699,9 +2699,9 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 #elif defined(GL_EXT_texture_lod_bias)
 			if (FeatureAvailable[IRR_EXT_texture_lod_bias])
 			{
-				if (material.TextureLayer[i].LODBias)
+				if (material.TextureLayers[i].LODBias)
 				{
-					const float tmp = core::clamp(material.TextureLayer[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
+					const float tmp = core::clamp(material.TextureLayers[i].LODBias * 0.125f, -MaxTextureLODBias, MaxTextureLODBias);
 					glTexEnvf(GL_TEXTURE_FILTER_CONTROL_EXT, GL_TEXTURE_LOD_BIAS_EXT, tmp);
 				}
 				else
@@ -2709,9 +2709,9 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 			}
 #endif
 
-			if (!statesCache.IsCached || material.TextureLayer[i].MagFilter != statesCache.MagFilter)
+			if (!statesCache.IsCached || material.TextureLayers[i].MagFilter != statesCache.MagFilter)
 			{
-				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpType, GL_TEXTURE_MAG_FILTER,
 					magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
 
@@ -2720,10 +2720,10 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+				if (!statesCache.IsCached || material.TextureLayers[i].MinFilter != statesCache.MinFilter ||
 					!statesCache.MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
 						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
 						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
@@ -2735,10 +2735,10 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 			}
 			else
 			{
-				if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+				if (!statesCache.IsCached || material.TextureLayers[i].MinFilter != statesCache.MinFilter ||
 					statesCache.MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
 						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
@@ -2749,31 +2749,31 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 
 #ifdef GL_EXT_texture_filter_anisotropic
 			if (FeatureAvailable[IRR_EXT_texture_filter_anisotropic] &&
-				(!statesCache.IsCached || material.TextureLayer[i].AnisotropicFilter != statesCache.AnisotropicFilter))
+				(!statesCache.IsCached || material.TextureLayers[i].AnisotropicFilter != statesCache.AnisotropicFilter))
 			{
 				glTexParameteri(tmpType, GL_TEXTURE_MAX_ANISOTROPY_EXT,
-					material.TextureLayer[i].AnisotropicFilter > 1 ? core::min_(MaxAnisotropy, material.TextureLayer[i].AnisotropicFilter) : 1);
+					material.TextureLayers[i].AnisotropicFilter > 1 ? core::min_(MaxAnisotropy, material.TextureLayers[i].AnisotropicFilter) : 1);
 
-				statesCache.AnisotropicFilter = material.TextureLayer[i].AnisotropicFilter;
+				statesCache.AnisotropicFilter = material.TextureLayers[i].AnisotropicFilter;
 			}
 #endif
 
-			if (!statesCache.IsCached || material.TextureLayer[i].TextureWrapU != statesCache.WrapU)
+			if (!statesCache.IsCached || material.TextureLayers[i].TextureWrapU != statesCache.WrapU)
 			{
-				glTexParameteri(tmpType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayer[i].TextureWrapU));
-				statesCache.WrapU = material.TextureLayer[i].TextureWrapU;
+				glTexParameteri(tmpType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
+				statesCache.WrapU = material.TextureLayers[i].TextureWrapU;
 			}
 
-			if (!statesCache.IsCached || material.TextureLayer[i].TextureWrapV != statesCache.WrapV)
+			if (!statesCache.IsCached || material.TextureLayers[i].TextureWrapV != statesCache.WrapV)
 			{
-				glTexParameteri(tmpType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayer[i].TextureWrapV));
-				statesCache.WrapV = material.TextureLayer[i].TextureWrapV;
+				glTexParameteri(tmpType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
+				statesCache.WrapV = material.TextureLayers[i].TextureWrapV;
 			}
 
-			if (!statesCache.IsCached || material.TextureLayer[i].TextureWrapW != statesCache.WrapW)
+			if (!statesCache.IsCached || material.TextureLayers[i].TextureWrapW != statesCache.WrapW)
 			{
-				glTexParameteri(tmpType, GL_TEXTURE_WRAP_R, getTextureWrapMode(material.TextureLayer[i].TextureWrapW));
-				statesCache.WrapW = material.TextureLayer[i].TextureWrapW;
+				glTexParameteri(tmpType, GL_TEXTURE_WRAP_R, getTextureWrapMode(material.TextureLayers[i].TextureWrapW));
+				statesCache.WrapW = material.TextureLayers[i].TextureWrapW;
 			}
 
 			statesCache.IsCached = true;

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -3,6 +3,7 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #include "COpenGLDriver.h"
+#include <cassert>
 #include "CNullDriver.h"
 #include "IContextManager.h"
 
@@ -2713,7 +2714,8 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 			{
 				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpType, GL_TEXTURE_MAG_FILTER,
-					magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_NEAREST ? GL_NEAREST :
+					(assert(magFilter == ETMAGF_LINEAR), GL_LINEAR));
 
 				statesCache.MagFilter = magFilter;
 			}
@@ -2725,9 +2727,10 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
-						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
-						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
-						GL_NEAREST_MIPMAP_NEAREST);
+						minFilter == ETMINF_NEAREST_MIPMAP_NEAREST ? GL_NEAREST_MIPMAP_NEAREST :
+						minFilter == ETMINF_LINEAR_MIPMAP_NEAREST ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_NEAREST_MIPMAP_LINEAR ? GL_NEAREST_MIPMAP_LINEAR :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR_MIPMAP_LINEAR));
 
 					statesCache.MinFilter = minFilter;
 					statesCache.MipMapStatus = true;
@@ -2740,7 +2743,8 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
-						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_NEAREST_MIPMAP_NEAREST || minFilter == ETMINF_NEAREST_MIPMAP_LINEAR) ? GL_NEAREST :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_NEAREST || minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR));
 
 					statesCache.MinFilter = minFilter;
 					statesCache.MipMapStatus = false;

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -2709,41 +2709,40 @@ void COpenGLDriver::setTextureRenderStates(const SMaterial& material, bool reset
 			}
 #endif
 
-			if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-				material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter)
+			if (!statesCache.IsCached || material.TextureLayer[i].MagFilter != statesCache.MagFilter)
 			{
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
 				glTexParameteri(tmpType, GL_TEXTURE_MAG_FILTER,
-					(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_BILINEAR ? GL_LINEAR : GL_NEAREST);
 
-				statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-				statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+				statesCache.MagFilter = magFilter;
 			}
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter || !statesCache.MipMapStatus)
+				if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+					!statesCache.MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
-						material.TextureLayer[i].TrilinearFilter ? GL_LINEAR_MIPMAP_LINEAR :
-						material.TextureLayer[i].BilinearFilter ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
+						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
 						GL_NEAREST_MIPMAP_NEAREST);
 
-					statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					statesCache.MinFilter = minFilter;
 					statesCache.MipMapStatus = true;
 				}
 			}
 			else
 			{
-				if (!statesCache.IsCached || material.TextureLayer[i].BilinearFilter != statesCache.BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != statesCache.TrilinearFilter || statesCache.MipMapStatus)
+				if (!statesCache.IsCached || material.TextureLayer[i].MinFilter != statesCache.MinFilter ||
+					statesCache.MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpType, GL_TEXTURE_MIN_FILTER,
-						(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
-					statesCache.BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					statesCache.TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					statesCache.MinFilter = minFilter;
 					statesCache.MipMapStatus = false;
 				}
 			}

--- a/source/Irrlicht/CSkinnedMesh.cpp
+++ b/source/Irrlicht/CSkinnedMesh.cpp
@@ -690,14 +690,6 @@ void CSkinnedMesh::setBoundingBox( const core::aabbox3df& box)
 }
 
 
-//! sets a flag of all contained materials to a new value
-void CSkinnedMesh::setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue)
-{
-	for (u32 i=0; i<LocalBuffers.size(); ++i)
-		LocalBuffers[i]->Material.setFlag(flag,newvalue);
-}
-
-
 //! set the hardware mapping hint, for driver
 void CSkinnedMesh::setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint,
 		E_BUFFER_TYPE buffer)

--- a/source/Irrlicht/CSkinnedMesh.h
+++ b/source/Irrlicht/CSkinnedMesh.h
@@ -72,9 +72,6 @@ namespace scene
 		//! set user axis aligned bounding box
 		void setBoundingBox( const core::aabbox3df& box) override;
 
-		//! sets a flag of all contained materials to a new value
-		void setMaterialFlag(video::E_MATERIAL_FLAG flag, bool newvalue) override;
-
 		//! set the hardware mapping hint, for driver
 		void setHardwareMappingHint(E_HARDWARE_MAPPING newMappingHint, E_BUFFER_TYPE buffer=EBT_VERTEX_AND_INDEX) override;
 

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -402,7 +402,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 
 	bool COpenGL3DriverBase::setMaterialTexture(irr::u32 layerIdx, const irr::video::ITexture* texture)
 	{
-		Material.TextureLayer[layerIdx].Texture = const_cast<ITexture*>(texture); // function uses const-pointer for texture because all draw functions use const-pointers already
+		Material.TextureLayers[layerIdx].Texture = const_cast<ITexture*>(texture); // function uses const-pointer for texture because all draw functions use const-pointers already
 		return CacheHandler->getTextureCache().set(0, texture);
 	}
 
@@ -1456,9 +1456,9 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (resetAllRenderstates)
 				tmpTexture->getStatesCache().IsCached = false;
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
 			{
-				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
 					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
 
@@ -1467,10 +1467,10 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
 					!tmpTexture->getStatesCache().MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
 						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
@@ -1482,10 +1482,10 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			}
 			else
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
 					tmpTexture->getStatesCache().MipMapStatus)
 				{
-					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
@@ -1495,24 +1495,24 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			}
 
 			if (AnisotropicFilterSupported &&
-				(!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
+				(!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
 			{
 				glTexParameteri(tmpTextureType, GL.TEXTURE_MAX_ANISOTROPY,
-					material.TextureLayer[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayer[i].AnisotropicFilter) : 1);
+					material.TextureLayers[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayers[i].AnisotropicFilter) : 1);
 
-				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayer[i].AnisotropicFilter;
+				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayers[i].AnisotropicFilter;
 			}
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayer[i].TextureWrapU));
-				tmpTexture->getStatesCache().WrapU = material.TextureLayer[i].TextureWrapU;
+				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
+				tmpTexture->getStatesCache().WrapU = material.TextureLayers[i].TextureWrapU;
 			}
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].TextureWrapV != tmpTexture->getStatesCache().WrapV)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapV != tmpTexture->getStatesCache().WrapV)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayer[i].TextureWrapV));
-				tmpTexture->getStatesCache().WrapV = material.TextureLayer[i].TextureWrapV;
+				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
+				tmpTexture->getStatesCache().WrapV = material.TextureLayers[i].TextureWrapV;
 			}
 
 			tmpTexture->getStatesCache().IsCached = true;

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -1460,7 +1460,8 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			{
 				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_NEAREST ? GL_NEAREST :
+					(assert(magFilter == ETMAGF_LINEAR), GL_LINEAR));
 
 				tmpTexture->getStatesCache().MagFilter = magFilter;
 			}
@@ -1472,9 +1473,10 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
-						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
-						GL_NEAREST_MIPMAP_NEAREST);
+						minFilter == ETMINF_NEAREST_MIPMAP_NEAREST ? GL_NEAREST_MIPMAP_NEAREST :
+						minFilter == ETMINF_LINEAR_MIPMAP_NEAREST ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_NEAREST_MIPMAP_LINEAR ? GL_NEAREST_MIPMAP_LINEAR :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR_MIPMAP_LINEAR));
 
 					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = true;
@@ -1487,7 +1489,8 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_NEAREST_MIPMAP_NEAREST || minFilter == ETMINF_NEAREST_MIPMAP_LINEAR) ? GL_NEAREST :
+						(assert(minFilter == ETMINF_LINEAR_MIPMAP_NEAREST || minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR));
 
 					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = false;

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -1456,41 +1456,40 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (resetAllRenderstates)
 				tmpTexture->getStatesCache().IsCached = false;
 
-			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-				material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter)
+			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
 			{
+				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayer[i].MagFilter;
 				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
-					(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+					magFilter == ETMAGF_BILINEAR  ? GL_LINEAR : GL_NEAREST);
 
-				tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-				tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+				tmpTexture->getStatesCache().MagFilter = magFilter;
 			}
 
 			if (material.UseMipMaps && tmpTexture->hasMipMaps())
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter || !tmpTexture->getStatesCache().MipMapStatus)
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+					!tmpTexture->getStatesCache().MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						material.TextureLayer[i].TrilinearFilter ? GL_LINEAR_MIPMAP_LINEAR :
-						material.TextureLayer[i].BilinearFilter ? GL_LINEAR_MIPMAP_NEAREST :
+						minFilter == ETMINF_TRILINEAR ? GL_LINEAR_MIPMAP_LINEAR :
+						minFilter == ETMINF_BILINEAR ? GL_LINEAR_MIPMAP_NEAREST :
 						GL_NEAREST_MIPMAP_NEAREST);
 
-					tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = true;
 				}
 			}
 			else
 			{
-				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].BilinearFilter != tmpTexture->getStatesCache().BilinearFilter ||
-					material.TextureLayer[i].TrilinearFilter != tmpTexture->getStatesCache().TrilinearFilter || tmpTexture->getStatesCache().MipMapStatus)
+				if (!tmpTexture->getStatesCache().IsCached || material.TextureLayer[i].MinFilter != tmpTexture->getStatesCache().MinFilter ||
+					tmpTexture->getStatesCache().MipMapStatus)
 				{
+					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayer[i].MinFilter;
 					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
-						(material.TextureLayer[i].BilinearFilter || material.TextureLayer[i].TrilinearFilter) ? GL_LINEAR : GL_NEAREST);
+						(minFilter == ETMINF_TRILINEAR || minFilter == ETMINF_BILINEAR) ? GL_LINEAR : GL_NEAREST);
 
-					tmpTexture->getStatesCache().BilinearFilter = material.TextureLayer[i].BilinearFilter;
-					tmpTexture->getStatesCache().TrilinearFilter = material.TextureLayer[i].TrilinearFilter;
+					tmpTexture->getStatesCache().MinFilter = minFilter;
 					tmpTexture->getStatesCache().MipMapStatus = false;
 				}
 			}

--- a/source/Irrlicht/OpenGL/FixedPipelineRenderer.cpp
+++ b/source/Irrlicht/OpenGL/FixedPipelineRenderer.cpp
@@ -106,7 +106,7 @@ void COpenGL3MaterialSolidCB::OnSetMaterial(const SMaterial& material)
 	COpenGL3MaterialBaseCB::OnSetMaterial(material);
 
 	AlphaRef = material.MaterialTypeParam;
-	TextureUsage0 = (material.TextureLayer[0].Texture) ? 1 : 0;
+	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
 void COpenGL3MaterialSolidCB::OnSetConstants(IMaterialRendererServices* services, s32 userData)
@@ -163,7 +163,7 @@ void COpenGL3MaterialOneTextureBlendCB::OnSetMaterial(const SMaterial& material)
 		}
 	}
 
-	TextureUsage0 = (material.TextureLayer[0].Texture) ? 1 : 0;
+	TextureUsage0 = (material.TextureLayers[0].Texture) ? 1 : 0;
 }
 
 void COpenGL3MaterialOneTextureBlendCB::OnSetConstants(IMaterialRendererServices* services, s32 userData)

--- a/source/Irrlicht/OpenGL/Renderer2D.cpp
+++ b/source/Irrlicht/OpenGL/Renderer2D.cpp
@@ -69,7 +69,7 @@ void COpenGL3Renderer2D::OnSetMaterial(const video::SMaterial& material,
 
 	if ( WithTexture )
 	{
-		s32 TextureUsage = material.TextureLayer[0].Texture ? 1 : 0;
+		s32 TextureUsage = material.TextureLayers[0].Texture ? 1 : 0;
 		setPixelShaderConstant(TextureUsageID, &TextureUsage, 1);
 	}
 }


### PR DESCRIPTION
This is the Irrlicht side of minetest/minetest#13622.

This PR fixes minetest/minetest#13621. Because it exposes all OpenGL texture filtering options to Minetest, it also makes minetest/minetest#13108 trivial to fix.

### Part 1: Refactor parts of the material system

The first 6 commits of this PR are the "Refactor parts of the Irrlicht material system" part.

Before this PR:

- `SMaterialLayer` has two boolean fields, `BilinearFilter` and `TrilinearFilter`, which select both the min and the mag filter
- you set them via `SMaterial::setFlag`, which automatically sets them on all texture layers for you

After this PR:

- `SMaterialLayer` has two enum fields, `MinFilter` and `MagFilter`, which select the min and the mag filter
- ❌ setting them via `SMaterial::setFlag`? impossible because they are no booleans
- ❌ manually setting them on all texture layers? would cause code duplication
- ✅ you set them in a lambda passed to the new `SMaterial::forEachTexture` function

However, setting a per-texture material flag on all texture layers was the only real use of `SMaterial::setFlag`. All other uses could trivially be replaced by something like `material.<name of the flag> = <value>`, i.e. `setFlag` was a simple setter function. Therefore, I replaced all of its uses and removed it.

There also was `ISceneNode::setMaterialFlag`, which set a material flag on all materials of a scene node for you. Because I needed a replacement for that as well, I introduced `ISceneNode::forEachMaterial`.

One thing I like about the new API is that it makes it explicit at what layer you are configuring something right now. Look at this code using the old API:

```c++
// sets the type of all materials of this scene node
m_spritenode->setMaterialType(video::EMT_TRANSPARENT_ALPHA_CHANNEL);
// sets a flag on all materials of this scene node
m_spritenode->setMaterialFlag(video::EMF_LIGHTING, false);
// sets the first texture of all materials of this scene node
m_spritenode->setMaterialTexture(0,
		env->getGameDef()->tsrc()->getTextureForMesh("smoke_puff.png"));
// sets a flag on all textures of all materials of this scene node
m_spritenode->setMaterialFlag(video::EMF_BILINEAR_FILTER, false);
```

Without the comments, would you have guessed what each function call does? This is the equivalent code with the new API:

```c++
video::ITexture *smoke = env->getGameDef()->tsrc()->getTextureForMesh("smoke_puff.png");

m_spritenode->forEachMaterial([smoke] (video::SMaterial &mat) {
	mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
	mat.Lighting = false;
	mat.setTexture(0, smoke);
	mat.forEachTexture([] (video::SMaterialLayer &tex) {
		tex.BilinearFilter = false;
	});
});
```

The new API makes it obvious that you should actually be doing this:

```c++
video::ITexture *smoke = env->getGameDef()->tsrc()->getTextureForMesh("smoke_puff.png");

m_spritenode->forEachMaterial([smoke] (video::SMaterial &mat) {
	mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
	mat.Lighting = false;
	mat.setTexture(0, smoke);
	mat.TextureLayers[0].BilinearFilter = false;
});
```

(The two "new API" examples don't take the switch from `BilinearFilter` and `TrilinearFilter` to `MinFilter` and `MagFilter` into account.)

### Part 2: Set min filter to bilinear for 2D

The last commit of this PR is the "Set min filter to bilinear for 2D graphics" part.

This commit enables bilinear filtering for downscaling textures in Irrlicht's 2D renderer (which is used by Minetest's GUIs). Essentially, it just sets `GL_TEXTURE_MIN_FILTER` to `GL_LINEAR` for 2D rendering.

## To do

This PR is a Ready for Review.

## How to test

Use Minetest on all platforms and with all Irrlicht video drivers and verify that everything looks the same as before, with one exception: Images rendered with a lower resolution than their original resolution in GUIs look better. The difference is very visible with minetest/minetest#13606, for example.

## Additional context

Minetest cannot upscale GUI images with bilinear filtering because that would blur pixel art, but we can _downscale_ images with bilinear filtering. This makes downscaled images look much better. Compare these screenshots:

\[1\] before this PR, \[2\] after this PR

![screenshot before](https://github.com/minetest/irrlicht/assets/82708541/9ae2bf5b-bef2-4930-a50d-3d231cc4d1a0) ![screenshot after](https://github.com/minetest/irrlicht/assets/82708541/27f69dd3-431f-4bf8-9c98-9c2fa9f7523e)
