### PR TITLE
Include the unified driver by default

### DIFF
--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -141,7 +141,11 @@ endif()
 
 # OpenGL
 
-option(ENABLE_OPENGL3 "Enable OpenGL 3+" FALSE)
+if(USE_SDL2)
+	option(ENABLE_OPENGL3 "Enable OpenGL 3+" FALSE)
+else()
+	set(ENABLE_OPENGL3 FALSE)
+endif()
 
 if(ANDROID OR EMSCRIPTEN)
 	set(ENABLE_OPENGL FALSE)

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -142,7 +142,7 @@ endif()
 # OpenGL
 
 if(USE_SDL2)
-	option(ENABLE_OPENGL3 "Enable OpenGL 3+" FALSE)
+	option(ENABLE_OPENGL3 "Enable OpenGL 3+" TRUE)
 else()
 	set(ENABLE_OPENGL3 FALSE)
 endif()


### PR DESCRIPTION
As Mesebox defaults to `opengl` and not `opengl3` it should be safe.