### PR TITLE
CIrrDeviceLinux: Fix type for NET_WM_PID XChangeProperty

### DIFF
--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -332,7 +332,7 @@ void CIrrDeviceLinux::setupTopLevelXorgWindow()
 
 	Atom NET_WM_PID = XInternAtom(XDisplay, "_NET_WM_PID", false);
 
-	pid_t pid = getpid();
+	long pid = static_cast<long>(getpid());
 
 	XChangeProperty(XDisplay, XWindow, NET_WM_PID,
 			XA_CARDINAL, 32, PropModeReplace,


### PR DESCRIPTION
This uses format=32 which in X11's API means a C type of long (with restricted range when > 32 bits). pid_t is of unknown type, though on Linux and FreeBSD it's a 32-bit type, so does not have the same size as long on 64-bit architectures, and thus XChangeProperty reads outside its bounds. Fix this by casting to and passing a long.
