### PR TITLE
Deduplicate KP_5 from KP_HOME

### DIFF
--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -1485,7 +1485,7 @@ void CIrrDeviceLinux::createKeyMap()
 	KeyMap.push_back(SKeyMap(XK_Next, KEY_NEXT));
 	KeyMap.push_back(SKeyMap(XK_Page_Down, KEY_NEXT));
 	KeyMap.push_back(SKeyMap(XK_End, KEY_END));
-	KeyMap.push_back(SKeyMap(XK_Begin, KEY_HOME));
+	KeyMap.push_back(SKeyMap(XK_Begin, KEY_NUMPAD5));
 	KeyMap.push_back(SKeyMap(XK_Num_Lock, KEY_NUMLOCK));
 	KeyMap.push_back(SKeyMap(XK_KP_Space, KEY_SPACE));
 	KeyMap.push_back(SKeyMap(XK_KP_Tab, KEY_TAB));
@@ -1505,7 +1505,7 @@ void CIrrDeviceLinux::createKeyMap()
 	KeyMap.push_back(SKeyMap(XK_KP_Next, KEY_NEXT));
 	KeyMap.push_back(SKeyMap(XK_KP_Page_Down, KEY_NEXT));
 	KeyMap.push_back(SKeyMap(XK_KP_End, KEY_END));
-	KeyMap.push_back(SKeyMap(XK_KP_Begin, KEY_HOME));
+	KeyMap.push_back(SKeyMap(XK_KP_Begin, KEY_NUMPAD5));
 	KeyMap.push_back(SKeyMap(XK_KP_Insert, KEY_INSERT));
 	KeyMap.push_back(SKeyMap(XK_KP_Delete, KEY_DELETE));
 	KeyMap.push_back(SKeyMap(XK_KP_Equal, 0)); // ???


### PR DESCRIPTION
I had issues with setting the keybindings in minetest.

Both, the keypad 7 key (Home) and the keypad 5 key were mapped to `Home` (irrespective of the Num-lock status).

I remapped `…BEGIN` (which seems to be Num5) to `KEY_NUMPAD5`.

After that change I was able to properly differentiate the keybindings in minetest.

(Tested on Linux Mint 21.1, Gnome 42.9, Wayland)