### PR TITLE
Drop lots of methods and other things marked as deprecated

### DIFF
--- a/include/EPrimitiveTypes.h
+++ b/include/EPrimitiveTypes.h
@@ -36,20 +36,6 @@ namespace scene
 		//! Explicitly set all vertices for each triangle.
 		EPT_TRIANGLES,
 
-		//! After the first two vertices each further two vertices create a quad with the preceding two.
-		//! Not supported by Direct3D
-		EPT_QUAD_STRIP,
-
-		//! Every four vertices create a quad.
-		//! Not supported by Direct3D
-		//! Deprecated with newer OpenGL drivers
-		EPT_QUADS,
-
-		//! Just as LINE_LOOP, but filled.
-		//! Not supported by Direct3D
-		//! Deprecated with newer OpenGL drivers
-		EPT_POLYGON,
-
 		//! The single vertices are expanded to quad billboards on the GPU.
 		EPT_POINT_SPRITES
 	};

--- a/include/IBoneSceneNode.h
+++ b/include/IBoneSceneNode.h
@@ -59,10 +59,6 @@ namespace scene
 		IBoneSceneNode(ISceneNode* parent, ISceneManager* mgr, s32 id=-1) :
 			ISceneNode(parent, mgr, id),positionHint(-1),scaleHint(-1),rotationHint(-1) { }
 
-		//! Get the name of the bone
-		/** \deprecated Use getName instead. This method may be removed by Irrlicht 1.9 */
-		_IRR_DEPRECATED_ virtual const c8* getBoneName() const { return getName(); }
-
 		//! Get the index of the bone
 		virtual u32 getBoneIndex() const = 0;
 

--- a/include/IFileSystem.h
+++ b/include/IFileSystem.h
@@ -210,58 +210,6 @@ public:
 	\return A pointer to the specified loader, 0 if the index is incorrect. */
 	virtual IArchiveLoader* getArchiveLoader(u32 index) const = 0;
 
-	//! Adds a zip archive to the file system.
-	/** \deprecated This function is provided for compatibility
-	with older versions of Irrlicht and may be removed in Irrlicht 1.9,
-	you should use addFileArchive instead.
-	After calling this, the Irrlicht Engine will search and open files directly from this archive too.
-	This is useful for hiding data from the end user, speeding up file access and making it possible to
-	access for example Quake3 .pk3 files, which are no different than .zip files.
-	\param filename: Filename of the zip archive to add to the file system.
-	\param ignoreCase: If set to true, files in the archive can be accessed without
-	writing all letters in the right case.
-	\param ignorePaths: If set to true, files in the added archive can be accessed
-	without its complete path.
-	\return True if the archive was added successfully, false if not. */
-	_IRR_DEPRECATED_ virtual bool addZipFileArchive(const c8* filename, bool ignoreCase=true, bool ignorePaths=true)
-	{
-		return addFileArchive(filename, ignoreCase, ignorePaths, EFAT_ZIP);
-	}
-
-	//! Adds an unzipped archive (or basedirectory with subdirectories..) to the file system.
-	/** \deprecated This function is provided for compatibility
-	with older versions of Irrlicht and may be removed in Irrlicht 1.9,
-	you should use addFileArchive instead.
-	Useful for handling data which will be in a zip file
-	\param filename: Filename of the unzipped zip archive base directory to add to the file system.
-	\param ignoreCase: If set to true, files in the archive can be accessed without
-	writing all letters in the right case.
-	\param ignorePaths: If set to true, files in the added archive can be accessed
-	without its complete path.
-	\return True if the archive was added successful, false if not. */
-	_IRR_DEPRECATED_ virtual bool addFolderFileArchive(const c8* filename, bool ignoreCase=true, bool ignorePaths=true)
-	{
-		return addFileArchive(filename, ignoreCase, ignorePaths, EFAT_FOLDER);
-	}
-
-	//! Adds a pak archive to the file system.
-	/** \deprecated This function is provided for compatibility
-	with older versions of Irrlicht and may be removed in Irrlicht 1.9,
-	you should use addFileArchive instead.
-	After calling this, the Irrlicht Engine will search and open files directly from this archive too.
-	This is useful for hiding data from the end user, speeding up file access and making it possible to
-	access for example Quake2/KingPin/Hexen2 .pak files
-	\param filename: Filename of the pak archive to add to the file system.
-	\param ignoreCase: If set to true, files in the archive can be accessed without
-	writing all letters in the right case.
-	\param ignorePaths: If set to true, files in the added archive can be accessed
-	without its complete path.(should not use with Quake2 paks
-	\return True if the archive was added successful, false if not. */
-	_IRR_DEPRECATED_ virtual bool addPakFileArchive(const c8* filename, bool ignoreCase=true, bool ignorePaths=true)
-	{
-		return addFileArchive(filename, ignoreCase, ignorePaths, EFAT_PAK);
-	}
-
 	//! Get the current working directory.
 	/** \return Current working directory as a string. */
 	virtual const path& getWorkingDirectory() =0;

--- a/include/IGUITabControl.h
+++ b/include/IGUITabControl.h
@@ -41,12 +41,12 @@ namespace gui
 
 		//! Insert an existing tab
 		/** Note that it will also add the tab as a child of this TabControl.
-		\param idx Index at which tab will be inserted. Later tabs will be moved. 
-		           Previous active tab will stay active unless this is the first 
+		\param idx Index at which tab will be inserted. Later tabs will be moved.
+		           Previous active tab will stay active unless this is the first
 				   element to be inserted in which case it becomes active.
 		\param tab New tab to insert.
 		\param serializationMode Internally used for serialization. You should not need this.
-		       When true it reserves space for the index, doesn't move but replaces tabs 
+		       When true it reserves space for the index, doesn't move but replaces tabs
 			   and it doesn't change the active tab.
 		\return Index of added tab (should be same as the one passed) or -1 for failure*/
 		virtual s32 insertTab(s32 idx, IGUITab* tab, bool serializationMode=false) = 0;
@@ -67,8 +67,8 @@ namespace gui
 		virtual IGUITab* getTab(s32 idx) const = 0;
 
 		//! For given element find if it's a tab and return it's zero-based index (or -1 for not found)
-		/** \param tab Tab for which we are looking (usually you will look for an IGUITab* type as only  
-		              those can be tabs, but we allow looking for any kind of IGUIElement* as there are some 
+		/** \param tab Tab for which we are looking (usually you will look for an IGUITab* type as only
+		              those can be tabs, but we allow looking for any kind of IGUIElement* as there are some
 					  use-cases for that even if it just returns 0. For example this way you can check for
 					  all children of this gui-element if they are tabs or some non-tab children.*/
 		virtual s32 getTabIndex(const IGUIElement *tab) const = 0;
@@ -128,15 +128,6 @@ namespace gui
 		//! constructor
 		IGUITab(IGUIEnvironment* environment, IGUIElement* parent, s32 id, core::rect<s32> rectangle)
 			: IGUIElement(EGUIET_TAB, environment, parent, id, rectangle) {}
-
-		//! Returns zero based index of tab if in tabcontrol.
-		/** \deprecated Deprecated in 1.9, use IGUITabControl::getTabIndex instead*/
-		_IRR_DEPRECATED_ virtual s32 getNumber() const
-		{
-			if (Parent && Parent->getType() == EGUIET_TAB_CONTROL)
-				return static_cast<IGUITabControl*>(Parent)->getTabIndex(this);
-			return -1;
-		}
 
 		//! sets if the tab should draw its background
 		virtual void setDrawBackground(bool draw=true) = 0;

--- a/include/IImage.h
+++ b/include/IImage.h
@@ -183,24 +183,6 @@ public:
 		return Data;
 	}
 
-	//! Lock function. Use this to get a pointer to the image data.
-	/** Use getData instead.
-	\return Pointer to the image data. What type of data is pointed to
-	depends on the color format of the image. For example if the color
-	format is ECF_A8R8G8B8, it is of u32. Be sure to call unlock() after
-	you don't need the pointer any more. */
-	_IRR_DEPRECATED_ void* lock()
-	{
-		return getData();
-	}
-
-	//! Unlock function.
-	/** Should be called after the pointer received by lock() is not
-	needed anymore. */
-	_IRR_DEPRECATED_ void unlock()
-	{
-	}
-
 	//! Get the mipmap size for this image for a certain mipmap level
 	/** level 0 will be full image size. Every further level is half the size.
 		Doesn't care if the image actually has mipmaps, just which size would be needed. */
@@ -366,19 +348,6 @@ public:
 
 	//! fills the surface with given color
 	virtual void fill(const SColor &color) =0;
-
-	//! Inform whether the image is compressed
-	_IRR_DEPRECATED_ bool isCompressed() const
-	{
-		return IImage::isCompressedFormat(Format);
-	}
-
-	//! Check whether the image has MipMaps
-	/** \return True if image has MipMaps, else false. */
-	_IRR_DEPRECATED_ bool hasMipMaps() const
-	{
-		return (getMipMapsData() != 0);
-	}
 
 	//! get the amount of Bits per Pixel of the given color format
 	static u32 getBitsPerPixelFromFormat(const ECOLOR_FORMAT format)

--- a/include/IMaterialRendererServices.h
+++ b/include/IMaterialRendererServices.h
@@ -115,30 +115,6 @@ public:
 	\param constantAmount Amount of registers to be set. One register consists of 4 floats. */
 	virtual void setPixelShaderConstant(const f32* data, s32 startRegister, s32 constantAmount=1) = 0;
 
-	//! \deprecated. This method may be removed by Irrlicht 2.0
-	_IRR_DEPRECATED_ bool setVertexShaderConstant(const c8* name, const f32* floats, int count)
-	{
-		return setVertexShaderConstant(getVertexShaderConstantID(name), floats, count);
-	}
-
-	//! \deprecated. This method may be removed by Irrlicht 2.0
-	_IRR_DEPRECATED_ bool setVertexShaderConstant(const c8* name, const s32* ints, int count)
-	{
-		return setVertexShaderConstant(getVertexShaderConstantID(name), ints, count);
-	}
-
-	//! \deprecated. This method may be removed by Irrlicht 2.0
-	_IRR_DEPRECATED_ bool setPixelShaderConstant(const c8* name, const f32* floats, int count)
-	{
-		return setPixelShaderConstant(getPixelShaderConstantID(name), floats, count);
-	}
-
-	//! \deprecated. This method may be removed by Irrlicht 2.0
-	_IRR_DEPRECATED_ bool setPixelShaderConstant(const c8* name, const s32* ints, int count)
-	{
-		return setPixelShaderConstant(getPixelShaderConstantID(name), ints, count);
-	}
-
 	//! Get pointer to the IVideoDriver interface
 	/** \return Pointer to the IVideoDriver interface */
 	virtual IVideoDriver* getVideoDriver() = 0;

--- a/include/IMeshBuffer.h
+++ b/include/IMeshBuffer.h
@@ -172,9 +172,6 @@ namespace scene
                 case scene::EPT_TRIANGLE_STRIP: return (indexCount-2);
                 case scene::EPT_TRIANGLE_FAN:   return (indexCount-2);
                 case scene::EPT_TRIANGLES:      return indexCount/3;
-                case scene::EPT_QUAD_STRIP:     return (indexCount-2)/2;
-                case scene::EPT_QUADS:          return indexCount/4;
-                case scene::EPT_POLYGON:        return indexCount; // (not really primitives, that would be 1, works like line_strip)
                 case scene::EPT_POINT_SPRITES:  return indexCount;
 			}
 			return 0;

--- a/include/IMeshCache.h
+++ b/include/IMeshCache.h
@@ -78,46 +78,6 @@ namespace scene
 		number. */
 		virtual IAnimatedMesh* getMeshByIndex(u32 index) = 0;
 
-		//! Returns a mesh based on its name (often a filename).
-		/** \deprecated Use getMeshByName() instead. This method may be removed by
-		Irrlicht 1.9 */
-		_IRR_DEPRECATED_ IAnimatedMesh* getMeshByFilename(const io::path& filename)
-		{
-			return getMeshByName(filename);
-		}
-
-		//! Get the name of a loaded mesh, based on its index. (Name is often identical to the filename).
-		/** \deprecated Use getMeshName() instead. This method may be removed by
-		Irrlicht 1.9 */
-		_IRR_DEPRECATED_ const io::path& getMeshFilename(u32 index) const
-		{
-			return getMeshName(index).getInternalName();
-		}
-
-		//! Get the name of a loaded mesh, if there is any. (Name is often identical to the filename).
-		/** \deprecated Use getMeshName() instead. This method may be removed by
-		Irrlicht 1.9 */
-		_IRR_DEPRECATED_ const io::path& getMeshFilename(const IMesh* const mesh) const
-		{
-			return getMeshName(mesh).getInternalName();
-		}
-
-		//! Renames a loaded mesh.
-		/** \deprecated Use renameMesh() instead. This method may be removed by
-		Irrlicht 1.9 */
-		_IRR_DEPRECATED_ bool setMeshFilename(u32 index, const io::path& filename)
-		{
-			return renameMesh(index, filename);
-		}
-
-		//! Renames a loaded mesh.
-		/** \deprecated Use renameMesh() instead. This method may be removed by
-		Irrlicht 1.9 */
-		_IRR_DEPRECATED_ bool setMeshFilename(const IMesh* const mesh, const io::path& filename)
-		{
-			return renameMesh(mesh, filename);
-		}
-
 		//! Returns a mesh based on its name.
 		/** \param name Name of the mesh. Usually a filename.
 		\return Pointer to the mesh or 0 if there is none with this number. */

--- a/include/IOSOperator.h
+++ b/include/IOSOperator.h
@@ -18,13 +18,6 @@ public:
 	//! Get the current operation system version as string.
 	virtual const core::stringc& getOperatingSystemVersion() const = 0;
 
-	//! Get the current operation system version as string.
-	/** \deprecated Use getOperatingSystemVersion instead. This method will be removed in Irrlicht 1.9. */
-	_IRR_DEPRECATED_ const wchar_t* getOperationSystemVersion() const
-	{
-		return core::stringw(getOperatingSystemVersion()).c_str();
-	}
-
 	//! Copies text to the clipboard
 	//! \param text: text in utf-8
 	virtual void copyToClipboard(const c8* text) const = 0;

--- a/include/IVideoDriver.h
+++ b/include/IVideoDriver.h
@@ -302,24 +302,6 @@ namespace video
 		getTexture() with this name will return this texture.
 		The name can _not_ be empty.
 		\param image Image the texture is created from.
-		\param mipmapData Optional pointer to a mipmaps data.
-		If this parameter is not given, the mipmaps are derived from image.
-		\return Pointer to the newly created texture. This pointer
-		should not be dropped. See IReferenceCounted::drop() for more
-		information. */
-		_IRR_DEPRECATED_ ITexture* addTexture(const io::path& name, IImage* image, void* mipmapData)
-		{
-			if (image)
-				image->setMipMapsData(mipmapData, false);
-
-			return addTexture(name, image);
-		}
-
-		//! Creates a texture from an IImage.
-		/** \param name A name for the texture. Later calls of
-		getTexture() with this name will return this texture.
-		The name can _not_ be empty.
-		\param image Image the texture is created from.
 		\return Pointer to the newly created texture. This pointer
 		should not be dropped. See IReferenceCounted::drop() for more
 		information. */
@@ -458,15 +440,9 @@ namespace video
 		color values may not be exactly the same in the engine and for
 		example in picture edit programs. To avoid this problem, you
 		could use the makeColorKeyTexture method, which takes the
-		position of a pixel instead a color value.
-		\param zeroTexels (deprecated) If set to true, then any texels that match
-		the color key will have their color, as well as their alpha, set to zero
-		(i.e. black). This behavior matches the legacy (buggy) behavior prior
-		to release 1.5 and is provided for backwards compatibility only.
-		This parameter may be removed by Irrlicht 1.9. */
+		position of a pixel instead a color value. */
 		virtual void makeColorKeyTexture(video::ITexture* texture,
-						video::SColor color,
-						bool zeroTexels = false) const =0;
+						video::SColor color) const =0;
 
 		//! Sets a boolean alpha channel on the texture based on the color at a position.
 		/** This makes the texture fully transparent at the texels where
@@ -475,15 +451,9 @@ namespace video
 		\param texture Texture whose alpha channel is modified.
 		\param colorKeyPixelPos Position of a pixel with the color key
 		color. Every texel with this color will become fully transparent as
-		described above.
-		\param zeroTexels (deprecated) If set to true, then any texels that match
-		the color key will have their color, as well as their alpha, set to zero
-		(i.e. black). This behavior matches the legacy (buggy) behavior prior
-		to release 1.5 and is provided for backwards compatibility only.
-		This parameter may be removed by Irrlicht 1.9. */
+		described above. */
 		virtual void makeColorKeyTexture(video::ITexture* texture,
-				core::position2d<s32> colorKeyPixelPos,
-				bool zeroTexels = false) const =0;
+				core::position2d<s32> colorKeyPixelPos) const =0;
 
 		//! Set a render target.
 		/** This will only work if the driver supports the
@@ -1031,27 +1001,6 @@ namespace video
 		See IReferenceCounted::drop() for more information. */
 		virtual IImage* createImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size) =0;
 
-		//! Creates a software image by converting it to given format from another image.
-		/** \deprecated Create an empty image and use copyTo(). This method may be removed by Irrlicht 1.9.
-		\param format Desired color format of the image.
-		\param imageToCopy Image to copy to the new image.
-		\return The created image.
-		If you no longer need the image, you should call IImage::drop().
-		See IReferenceCounted::drop() for more information. */
-		_IRR_DEPRECATED_ virtual IImage* createImage(ECOLOR_FORMAT format, IImage *imageToCopy) =0;
-
-		//! Creates a software image from a part of another image.
-		/** \deprecated Create an empty image and use copyTo(). This method may be removed by Irrlicht 1.9.
-		\param imageToCopy Image to copy to the new image in part.
-		\param pos Position of rectangle to copy.
-		\param size Extents of rectangle to copy.
-		\return The created image.
-		If you no longer need the image, you should call IImage::drop().
-		See IReferenceCounted::drop() for more information. */
-		_IRR_DEPRECATED_ virtual IImage* createImage(IImage* imageToCopy,
-				const core::position2d<s32>& pos,
-				const core::dimension2d<u32>& size) =0;
-
 		//! Creates a software image from a part of a texture.
 		/**
 		\param texture Texture to copy to the new image in part.
@@ -1154,23 +1103,6 @@ namespace video
 
 		//! Clear the color, depth and/or stencil buffers.
 		virtual void clearBuffers(u16 flag, SColor color = SColor(255,0,0,0), f32 depth = 1.f, u8 stencil = 0) = 0;
-
-		//! Clear the color, depth and/or stencil buffers.
-		_IRR_DEPRECATED_ void clearBuffers(bool backBuffer, bool depthBuffer, bool stencilBuffer, SColor color)
-		{
-			u16 flag = 0;
-
-			if (backBuffer)
-				flag |= ECBF_COLOR;
-
-			if (depthBuffer)
-				flag |= ECBF_DEPTH;
-
-			if (stencilBuffer)
-				flag |= ECBF_STENCIL;
-
-			clearBuffers(flag, color);
-		}
 
 		//! Clears the ZBuffer.
 		/** Note that you usually need not to call this method, as it

--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -228,19 +228,6 @@ namespace video
 		ECM_DIFFUSE_AND_AMBIENT
 	};
 
-	//! DEPRECATED. Will be removed after Irrlicht 1.9.
-	/** Flags for the definition of the polygon offset feature. These flags define whether the offset should be into the screen, or towards the eye. */
-	enum E_POLYGON_OFFSET
-	{
-		//! Push pixel towards the far plane, away from the eye
-		/** This is typically used for rendering inner areas. */
-		EPO_BACK=0,
-		//! Pull pixels towards the camera.
-		/** This is typically used for polygons which should appear on top
-		of other elements, such as decals. */
-		EPO_FRONT=1
-	};
-
 	//! Names for polygon offset direction
 	const c8* const PolygonOffsetDirectionNames[] =
 	{
@@ -289,17 +276,17 @@ namespace video
 	{
 	public:
 		//! Default constructor. Creates a solid, lit material with white colors
-		SMaterial()
-		: MaterialType(EMT_SOLID), AmbientColor(255,255,255,255), DiffuseColor(255,255,255,255),
-			EmissiveColor(0,0,0,0), SpecularColor(255,255,255,255),
-			Shininess(0.0f), MaterialTypeParam(0.0f), Thickness(1.0f),
-			ZBuffer(ECFN_LESSEQUAL), AntiAliasing(EAAM_SIMPLE), ColorMask(ECP_ALL),
-			ColorMaterial(ECM_DIFFUSE), BlendOperation(EBO_NONE), BlendFactor(0.0f),
-			PolygonOffsetFactor(0), PolygonOffsetDirection(EPO_FRONT),
-			PolygonOffsetDepthBias(0.f), PolygonOffsetSlopeScale(0.f),
-			Wireframe(false), PointCloud(false), GouraudShading(true),
-			Lighting(true), ZWriteEnable(EZW_AUTO), BackfaceCulling(true), FrontfaceCulling(false),
-			FogEnable(false), NormalizeNormals(false), UseMipMaps(true)
+		SMaterial() :
+				MaterialType(EMT_SOLID), AmbientColor(255, 255, 255, 255),
+				DiffuseColor(255, 255, 255, 255), EmissiveColor(0, 0, 0, 0),
+				SpecularColor(255, 255, 255, 255), Shininess(0.0f),
+				MaterialTypeParam(0.0f), Thickness(1.0f), ZBuffer(ECFN_LESSEQUAL),
+				AntiAliasing(EAAM_SIMPLE), ColorMask(ECP_ALL), ColorMaterial(ECM_DIFFUSE),
+				BlendOperation(EBO_NONE), BlendFactor(0.0f), PolygonOffsetDepthBias(0.f),
+				PolygonOffsetSlopeScale(0.f), Wireframe(false), PointCloud(false),
+				GouraudShading(true), Lighting(true), ZWriteEnable(EZW_AUTO),
+				BackfaceCulling(true), FrontfaceCulling(false), FogEnable(false),
+				NormalizeNormals(false), UseMipMaps(true)
 		{ }
 
 		//! Texture layer array.
@@ -385,27 +372,15 @@ namespace video
 
 		//! Store the blend factors
 		/** textureBlendFunc/textureBlendFuncSeparate functions should be used to write
-		properly blending factors to this parameter. 
-		Due to historical reasons this parameter is not used for material type 
+		properly blending factors to this parameter.
+		Due to historical reasons this parameter is not used for material type
 		EMT_ONETEXTURE_BLEND which uses MaterialTypeParam instead for the blend factor.
 		It's generally used only for materials without any blending otherwise (like EMT_SOLID).
-		It's main use is to allow having shader materials which can enable/disable 
-		blending after they have been created. 
+		It's main use is to allow having shader materials which can enable/disable
+		blending after they have been created.
 		When you set this you usually also have to set BlendOperation to a value != EBO_NONE
 		(setting it to EBO_ADD is probably the most common one value). */
 		f32 BlendFactor;
-
-		//! DEPRECATED. Will be removed after Irrlicht 1.9. Please use PolygonOffsetDepthBias instead.
-		/** Factor specifying how far the polygon offset should be made.
-		Specifying 0 disables the polygon offset. The direction is specified separately.
-		The factor can be from 0 to 7.
-		Note: This probably never worked on Direct3D9 (was coded for D3D8 which had different value ranges)	*/
-		u8 PolygonOffsetFactor:3;
-
-		//! DEPRECATED. Will be removed after Irrlicht 1.9.
-		/** Flag defining the direction the polygon offset is applied to.
-		Can be to front or to back, specified by values from E_POLYGON_OFFSET. 	*/
-		E_POLYGON_OFFSET PolygonOffsetDirection:1;
 
 		//! A constant z-buffer offset for a polygon/line/point
 		/** The range of the value is driver specific.
@@ -438,7 +413,7 @@ namespace video
 		bool Lighting:1;
 
 		//! Is the zbuffer writable or is it read-only. Default: EZW_AUTO.
-		/** If this parameter is not EZW_OFF, you probably also want to set ZBuffer 
+		/** If this parameter is not EZW_OFF, you probably also want to set ZBuffer
 		to values other than ECFN_DISABLED */
 		E_ZWRITE ZWriteEnable:2;
 
@@ -546,8 +521,6 @@ namespace video
 				ColorMaterial != b.ColorMaterial ||
 				BlendOperation != b.BlendOperation ||
 				BlendFactor != b.BlendFactor ||
-				PolygonOffsetFactor != b.PolygonOffsetFactor ||
-				PolygonOffsetDirection != b.PolygonOffsetDirection ||
 				PolygonOffsetDepthBias != b.PolygonOffsetDepthBias ||
 				PolygonOffsetSlopeScale != b.PolygonOffsetSlopeScale ||
 				UseMipMaps != b.UseMipMaps

--- a/include/SOverrideMaterial.h
+++ b/include/SOverrideMaterial.h
@@ -35,10 +35,10 @@ namespace video
 		u16 EnablePasses;
 
 		//! Global enable flag, overwritten by the SceneManager in each pass
-		/** NOTE: This is generally _not_ set by users of the engine, but the 
-		Scenemanager uses the EnablePass array and sets Enabled to true if the 
+		/** NOTE: This is generally _not_ set by users of the engine, but the
+		Scenemanager uses the EnablePass array and sets Enabled to true if the
 		Override material is enabled in the current pass.
-		As user you generally _only_ set EnablePasses. 
+		As user you generally _only_ set EnablePasses.
 		The exception is when rendering without SceneManager but using draw calls in the VideoDriver. */
 		bool Enabled;
 
@@ -47,7 +47,7 @@ namespace video
 			SMaterialTypeReplacement(s32 original, u32 replacement) : Original(original), Replacement(replacement) {}
 			SMaterialTypeReplacement(u32 replacement) : Original(-1), Replacement(replacement) {}
 
-			//! SMaterial.MaterialType to replace. 
+			//! SMaterial.MaterialType to replace.
 			//! -1 for all types or a specific value to only replace that one (which is either one of E_MATERIAL_TYPE or a shader material id)
 			s32 Original;
 
@@ -151,8 +151,6 @@ namespace video
 						case EMP_BLEND_OPERATION: material.BlendOperation = Material.BlendOperation; break;
 						case EMP_BLEND_FACTOR: material.BlendFactor = Material.BlendFactor; break;
 						case EMP_POLYGON_OFFSET:
-							material.PolygonOffsetDirection = Material.PolygonOffsetDirection;
-							material.PolygonOffsetFactor = Material.PolygonOffsetFactor;
 							material.PolygonOffsetDepthBias = Material.PolygonOffsetDepthBias;
 							material.PolygonOffsetSlopeScale = Material.PolygonOffsetSlopeScale;
 							break;

--- a/include/matrix4.h
+++ b/include/matrix4.h
@@ -151,7 +151,7 @@ namespace core
 			CMatrix4<T> operator*(const CMatrix4<T>& other) const;
 
 			//! Multiply by another matrix.
-			/** Like calling: (*this) = (*this) * other 
+			/** Like calling: (*this) = (*this) * other
 			*/
 			CMatrix4<T>& operator*=(const CMatrix4<T>& other);
 
@@ -190,10 +190,10 @@ namespace core
 
 			//! Get the rotation, as set by setRotation() when you already know the scale used to create the matrix
 			/** NOTE: The scale needs to be the correct one used to create this matrix.
-				You can _not_ use the result of getScale(), but have to save your scale 
+				You can _not_ use the result of getScale(), but have to save your scale
 				variable in another place (like ISceneNode does).
 			NOTE: No scale value can be 0 or the result is undefined.
-			NOTE: It does not necessarily return the *same* Euler angles as those set by setRotationDegrees(), 
+			NOTE: It does not necessarily return the *same* Euler angles as those set by setRotationDegrees(),
 				but the rotation will be equivalent,  i.e. will have the same result when used to rotate a vector or node.
 			NOTE: It will (usually) give wrong results when further transformations have been added in the matrix (like shear).
 			WARNING: There have been troubles with this function over the years and we may still have missed some corner cases.
@@ -203,9 +203,9 @@ namespace core
 
 			//! Returns the rotation, as set by setRotation().
 			/** NOTE: You will have the same end-rotation as used in setRotation, but it might not use the same axis values.
-				NOTE: This only works correct if no other matrix operations have been done on the inner 3x3 matrix besides 
+				NOTE: This only works correct if no other matrix operations have been done on the inner 3x3 matrix besides
 					setting rotation (so no scale/shear). Thought it (probably) works as long as scale doesn't flip handedness.
-				NOTE: It does not necessarily return the *same* Euler angles as those set by setRotationDegrees(), 
+				NOTE: It does not necessarily return the *same* Euler angles as those set by setRotationDegrees(),
 				but the rotation will be equivalent,  i.e. will have the same result when used to rotate a vector or node.
 			*/
 			core::vector3d<T> getRotationDegrees() const;
@@ -278,13 +278,6 @@ namespace core
 			void transformPlane( const core::plane3d<f32> &in, core::plane3d<f32> &out) const;
 
 			//! Transforms a axis aligned bounding box
-			/** The result box of this operation may not be accurate at all. For
-			correct results, use transformBoxEx() */
-			void transformBox(core::aabbox3d<f32>& box) const;
-
-			//! Transforms a axis aligned bounding box
-			/** The result box of this operation should be accurate, but this operation
-			is slower than transformBox(). */
 			void transformBoxEx(core::aabbox3d<f32>& box) const;
 
 			//! Multiplies this matrix by a 1x4 matrix
@@ -906,8 +899,8 @@ namespace core
 
 
 	//! Returns a rotation which (mostly) works in combination with the given scale
-	/** 
-	This code was originally written by by Chev (assuming no scaling back then, 
+	/**
+	This code was originally written by by Chev (assuming no scaling back then,
 	we can be blamed for all problems added by regarding scale)
 	*/
 	template <class T>
@@ -953,17 +946,17 @@ namespace core
 	template <class T>
 	inline core::vector3d<T> CMatrix4<T>::getRotationDegrees() const
 	{
-		// Note: Using getScale() here make it look like it could do matrix decomposition. 
-		// It can't! It works (or should work) as long as rotation doesn't flip the handedness 
-		// aka scale swapping 1 or 3 axes. (I think we could catch that as well by comparing 
+		// Note: Using getScale() here make it look like it could do matrix decomposition.
+		// It can't! It works (or should work) as long as rotation doesn't flip the handedness
+		// aka scale swapping 1 or 3 axes. (I think we could catch that as well by comparing
 		// crossproduct of first 2 axes to direction of third axis, but TODO)
-		// And maybe it should also offer the solution for the simple calculation 
+		// And maybe it should also offer the solution for the simple calculation
 		// without regarding scaling as Irrlicht did before 1.7
 		core::vector3d<T> scale(getScale());
 
 		// We assume the matrix uses rotations instead of negative scaling 2 axes.
-		// Otherwise it fails even for some simple cases, like rotating around 
-		// 2 axes by 180° which getScale thinks is a negative scaling.
+		// Otherwise it fails even for some simple cases, like rotating around
+		// 2 axes by 180Â° which getScale thinks is a negative scaling.
 		if (scale.Y<0 && scale.Z<0)
 		{
 			scale.Y =-scale.Y;
@@ -1276,22 +1269,6 @@ namespace core
 	{
 		out = in;
 		transformPlane( out );
-	}
-
-	//! Transforms the edge-points of a bounding box
-	//! Deprecated as it's usually not what people need (regards only 2 corners, but other corners might be outside the box after transformation)
-	//! Use transformBoxEx instead.
-	template <class T>
-	_IRR_DEPRECATED_ inline void CMatrix4<T>::transformBox(core::aabbox3d<f32>& box) const
-	{
-#if defined ( USE_MATRIX_TEST )
-		if (isIdentity())
-			return;
-#endif
-
-		transformVect(box.MinEdge);
-		transformVect(box.MaxEdge);
-		box.repair();
 	}
 
 	//! Transforms a axis aligned bounding box more accurately than transformBox()

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -869,8 +869,7 @@ const wchar_t* CNullDriver::getName() const
 
 //! Creates a boolean alpha channel of the texture based of an color key.
 void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
-									video::SColor color,
-									bool zeroTexels) const
+									video::SColor color) const
 {
 	if (!texture)
 		return;
@@ -905,12 +904,7 @@ void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
 			// If the color matches the reference color, ignoring alphas,
 			// set the alpha to zero.
 			if(((*p) & 0x7fff) == refZeroAlpha)
-			{
-				if(zeroTexels)
-					(*p) = 0;
-				else
-					(*p) = refZeroAlpha;
-			}
+				(*p) = refZeroAlpha;
 
 			++p;
 		}
@@ -939,12 +933,7 @@ void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
 			// If the color matches the reference color, ignoring alphas,
 			// set the alpha to zero.
 			if(((*p) & 0x00ffffff) == refZeroAlpha)
-			{
-				if(zeroTexels)
-					(*p) = 0;
-				else
 					(*p) = refZeroAlpha;
-			}
 
 			++p;
 		}
@@ -958,8 +947,7 @@ void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
 
 //! Creates an boolean alpha channel of the texture based of an color key position.
 void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
-					core::position2d<s32> colorKeyPixelPos,
-					bool zeroTexels) const
+					core::position2d<s32> colorKeyPixelPos) const
 {
 	if (!texture)
 		return;
@@ -1004,7 +992,7 @@ void CNullDriver::makeColorKeyTexture(video::ITexture* texture,
 	}
 
 	texture->unlock();
-	makeColorKeyTexture(texture, colorKey, zeroTexels);
+	makeColorKeyTexture(texture, colorKey);
 }
 
 
@@ -1239,27 +1227,6 @@ IImage* CNullDriver::createImageFromData(ECOLOR_FORMAT format,
 IImage* CNullDriver::createImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size)
 {
 	return new CImage(format, size);
-}
-
-
-//! Creates a software image from another image.
-IImage* CNullDriver::createImage(ECOLOR_FORMAT format, IImage *imageToCopy)
-{
-	os::Printer::log("Deprecated method, please create an empty image instead and use copyTo().", ELL_WARNING);
-
-	CImage* tmp = new CImage(format, imageToCopy->getDimension());
-	imageToCopy->copyTo(tmp);
-	return tmp;
-}
-
-
-//! Creates a software image from part of another image.
-IImage* CNullDriver::createImage(IImage* imageToCopy, const core::position2d<s32>& pos, const core::dimension2d<u32>& size)
-{
-	os::Printer::log("Deprecated method, please create an empty image instead and use copyTo().", ELL_WARNING);
-	CImage* tmp = new CImage(imageToCopy->getColorFormat(), imageToCopy->getDimension());
-	imageToCopy->copyTo(tmp, core::position2di(0,0), core::recti(pos,size));
-	return tmp;
 }
 
 

--- a/source/Irrlicht/CNullDriver.h
+++ b/source/Irrlicht/CNullDriver.h
@@ -296,11 +296,11 @@ namespace video
 				const io::path& name, const ECOLOR_FORMAT format) override;
 
 		//! Creates an 1bit alpha channel of the texture based of an color key.
-		void makeColorKeyTexture(video::ITexture* texture, video::SColor color, bool zeroTexels) const override;
+		void makeColorKeyTexture(video::ITexture* texture, video::SColor color) const override;
 
 		//! Creates an 1bit alpha channel of the texture based of an color key position.
-		virtual void makeColorKeyTexture(video::ITexture* texture, core::position2d<s32> colorKeyPixelPos,
-			bool zeroTexels) const override;
+		virtual void makeColorKeyTexture(video::ITexture* texture,
+				core::position2d<s32> colorKeyPixelPos) const override;
 
 		//! Returns the maximum amount of primitives (mostly vertices) which
 		//! the device is able to render with one drawIndexedTriangleList
@@ -327,14 +327,6 @@ namespace video
 
 		//! Creates an empty software image.
 		IImage* createImage(ECOLOR_FORMAT format, const core::dimension2d<u32>& size) override;
-
-		//! Creates a software image from another image.
-		IImage* createImage(ECOLOR_FORMAT format, IImage *imageToCopy) override;
-
-		//! Creates a software image from part of another image.
-		virtual IImage* createImage(IImage* imageToCopy,
-				const core::position2d<s32>& pos,
-				const core::dimension2d<u32>& size) override;
 
 		//! Creates a software image from part of a texture.
 		virtual IImage* createImage(ITexture* texture,

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -2523,8 +2523,6 @@ void COpenGLDriver::setBasicRenderStates(const SMaterial& material, const SMater
 
 	// Polygon Offset
 	if (queryFeature(EVDF_POLYGON_OFFSET) && (resetAllRenderStates ||
-		lastmaterial.PolygonOffsetDirection != material.PolygonOffsetDirection ||
-		lastmaterial.PolygonOffsetFactor != material.PolygonOffsetFactor ||
 		lastmaterial.PolygonOffsetSlopeScale != material.PolygonOffsetSlopeScale ||
 		lastmaterial.PolygonOffsetDepthBias != material.PolygonOffsetDepthBias ))
 	{
@@ -2534,15 +2532,6 @@ void COpenGLDriver::setBasicRenderStates(const SMaterial& material, const SMater
 			glEnable(material.Wireframe?GL_POLYGON_OFFSET_LINE:material.PointCloud?GL_POLYGON_OFFSET_POINT:GL_POLYGON_OFFSET_FILL);
 
 			glPolygonOffset(material.PolygonOffsetSlopeScale, material.PolygonOffsetDepthBias);
-		}
-		else if (material.PolygonOffsetFactor)
-		{
-			glEnable(material.Wireframe?GL_POLYGON_OFFSET_LINE:material.PointCloud?GL_POLYGON_OFFSET_POINT:GL_POLYGON_OFFSET_FILL);
-
-			if (material.PolygonOffsetDirection==EPO_BACK)
-				glPolygonOffset(1.0f, (GLfloat)material.PolygonOffsetFactor);
-			else
-				glPolygonOffset(-1.0f, (GLfloat)-material.PolygonOffsetFactor);
 		}
 		else
 		{

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -1034,15 +1034,6 @@ void COpenGLDriver::renderArray(const void* indexList, u32 primitiveCount,
 		case scene::EPT_TRIANGLES:
 			glDrawElements(GL_TRIANGLES, primitiveCount*3, indexSize, indexList);
 			break;
-		case scene::EPT_QUAD_STRIP:
-			glDrawElements(GL_QUAD_STRIP, primitiveCount*2+2, indexSize, indexList);
-			break;
-		case scene::EPT_QUADS:
-			glDrawElements(GL_QUADS, primitiveCount*4, indexSize, indexList);
-			break;
-		case scene::EPT_POLYGON:
-			glDrawElements(GL_POLYGON, primitiveCount, indexSize, indexList);
-			break;
 	}
 }
 
@@ -3893,12 +3884,6 @@ GLenum COpenGLDriver::primitiveTypeToGL(scene::E_PRIMITIVE_TYPE type) const
 			return GL_TRIANGLE_FAN;
 		case scene::EPT_TRIANGLES:
 			return GL_TRIANGLES;
-		case scene::EPT_QUAD_STRIP:
-			return GL_QUAD_STRIP;
-		case scene::EPT_QUADS:
-			return GL_QUADS;
-		case scene::EPT_POLYGON:
-			return GL_POLYGON;
 		case scene::EPT_POINT_SPRITES:
 #ifdef GL_ARB_point_sprite
 			return GL_POINT_SPRITE_ARB;


### PR DESCRIPTION
I removed everything I could marked as deprecated in the IrrlichtMT code base that was not used by Minetest. The only things I could not remove were the position2d file (deprecated, but used all over internally in the Irrlicht code), and the EGDS_MESSAGE_BOX_WIDTH and EGDS_MESSAGE_BOX_HEIGHT enum values in the IGUISkin file, used by gui/guiSkin.cpp in the Minetest repo.