### PR TITLE
[NOSQUASH] Remove the unnecessary sort in CNullDriver::addTexture

### DIFF
--- a/include/IVideoDriver.h
+++ b/include/IVideoDriver.h
@@ -265,23 +265,9 @@ namespace video
 		IReferenceCounted::drop() for more information. */
 		virtual ITexture* getTexture(io::IReadFile* file) =0;
 
-		//! Returns a texture by index
-		/** \param index: Index of the texture, must be smaller than
-		getTextureCount() Please note that this index might change when
-		adding or removing textures
-		\return Pointer to the texture, or 0 if the texture was not
-		set or index is out of bounds. This pointer should not be
-		dropped. See IReferenceCounted::drop() for more information. */
-		virtual ITexture* getTextureByIndex(u32 index) =0;
-
 		//! Returns amount of textures currently loaded
 		/** \return Amount of textures currently loaded */
 		virtual u32 getTextureCount() const = 0;
-
-		//! Renames a texture
-		/** \param texture Pointer to the texture to rename.
-		\param newName New name for the texture. This should be a unique name. */
-		virtual void renameTexture(ITexture* texture, const io::path& newName) = 0;
 
 		//! Creates an empty texture of specified size.
 		/** \param size: Size of the texture.

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -580,10 +580,7 @@ void CNullDriver::addTexture(video::ITexture* texture)
 
 		// the new texture is now at the end of the texture list. when searching for
 		// the next new texture, the texture array will be sorted and the index of this texture
-		// will be changed. to let the order be more consistent to the user, sort
-		// the textures now already although this isn't necessary:
-
-		Textures.sort();
+		// will be changed.
 	}
 }
 

--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -305,35 +305,12 @@ void CNullDriver::removeAllTextures()
 }
 
 
-//! Returns a texture by index
-ITexture* CNullDriver::getTextureByIndex(u32 i)
-{
-	if ( i < Textures.size() )
-		return Textures[i].Surface;
-
-	return 0;
-}
-
-
 //! Returns amount of textures currently loaded
 u32 CNullDriver::getTextureCount() const
 {
 	return Textures.size();
 }
 
-
-//! Renames a texture
-void CNullDriver::renameTexture(ITexture* texture, const io::path& newName)
-{
-	// we can do a const_cast here safely, the name of the ITexture interface
-	// is just readonly to prevent the user changing the texture name without invoking
-	// this method, because the textures will need resorting afterwards
-
-	io::SNamedPath& name = const_cast<io::SNamedPath&>(texture->getName());
-	name.setPath(newName);
-
-	Textures.sort();
-}
 
 ITexture* CNullDriver::addTexture(const core::dimension2d<u32>& size, const io::path& name, ECOLOR_FORMAT format)
 {

--- a/source/Irrlicht/CNullDriver.h
+++ b/source/Irrlicht/CNullDriver.h
@@ -79,14 +79,8 @@ namespace video
 		//! loads a Texture
 		ITexture* getTexture(io::IReadFile* file) override;
 
-		//! Returns a texture by index
-		ITexture* getTextureByIndex(u32 index) override;
-
 		//! Returns amount of textures currently loaded
 		u32 getTextureCount() const override;
-
-		//! Renames a texture
-		void renameTexture(ITexture* texture, const io::path& newName) override;
 
 		ITexture* addTexture(const core::dimension2d<u32>& size, const io::path& name, ECOLOR_FORMAT format = ECF_A8R8G8B8) override;
 


### PR DESCRIPTION
TL;DR: A performance fix for faster client startup.

I've done some little profiling on client connect. Here's a flame graph showing Game::startup of a session where it took about 40 seconds to connect to a server:

![graph_long_before](https://github.com/minetest/irrlicht/assets/7613443/6bdd79c0-fb71-4a6d-99b4-9fda6920cb1b)

The `std::__introsort_loop` is the sort of CNullDriver::Textures that we do for each texture. This sorting is unnecessary.

CNullDriver::Textures holds an irr::core::array that is possibly sorted by texture name. Textures are accessed via binary search (see irrArray.h), which always sorts anyway. The comment that was already there also explains this.
CNullDriver::Textures is also not used by any child class, FYI.

Benchmarks (of Client::afterContentReceived, and Game::startup in parenthesis):
(I haven't run these often. Values are rounded.)

lightweight scenario (singleplayer mtg + mesecons):
before: 1.1 s (2.0 s)
after: 0.9 (1.8)

heavy scenario (some server):
before: 35.9 s (44.4 s)
after: 5.0 s (12.7 s)