### PR TITLE
ComboBox API additions for minetest#13814

### DIFF
--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -263,6 +263,10 @@ namespace irr
 			//! A checkbox has changed its check state.
 			EGET_CHECKBOX_CHANGED,
 
+			//! A listbox would like to open.
+			/** You can prevent the listbox from opening by absorbing the event. */
+			EGET_LISTBOX_OPENED,
+
 			//! A new item in a listbox was selected.
 			/** NOTE: You also get this event currently when the same item was clicked again after more than 500 ms. */
 			EGET_LISTBOX_CHANGED,

--- a/include/IGUIComboBox.h
+++ b/include/IGUIComboBox.h
@@ -52,6 +52,10 @@ namespace gui
 		//! Sets the selected item. Set this to -1 if no item should be selected
 		virtual void setSelected(s32 idx) = 0;
 
+		//! Sets the selected item and emits a change event.
+		/** Set this to -1 if no item should be selected */
+		virtual void setAndSendSelected(s32 idx) = 0;
+
 		//! Sets text justification of the text area
 		/** \param horizontal: EGUIA_UPPERLEFT for left justified (default),
 		EGUIA_LOWERRIGHT for right justified, or EGUIA_CENTER for centered text.

--- a/source/Irrlicht/CGUIComboBox.cpp
+++ b/source/Irrlicht/CGUIComboBox.cpp
@@ -22,9 +22,9 @@ namespace gui
 CGUIComboBox::CGUIComboBox(IGUIEnvironment* environment, IGUIElement* parent,
 	s32 id, core::rect<s32> rectangle)
 	: IGUIComboBox(environment, parent, id, rectangle),
-	ListButton(0), SelectedText(0), ListBox(0), LastFocus(0),
+	ListButton(nullptr), SelectedText(nullptr), ListBox(nullptr), LastFocus(nullptr),
 	Selected(-1), HAlign(EGUIA_UPPERLEFT), VAlign(EGUIA_CENTER), MaxSelectionRows(5), HasFocus(false),
-	ActiveFont(0)
+	ActiveFont(nullptr)
 {
 	#ifdef _DEBUG
 	setDebugName("CGUIComboBox");
@@ -217,7 +217,7 @@ bool CGUIComboBox::OnEvent(const SEvent& event)
 					openCloseMenu();
 				}
 
-				ListButton->setPressed(ListBox == 0);
+				ListButton->setPressed(ListBox == nullptr);
 
 				return true;
 			}
@@ -370,7 +370,7 @@ void CGUIComboBox::sendSelectionChangedEvent()
 
 		event.EventType = EET_GUI_EVENT;
 		event.GUIEvent.Caller = this;
-		event.GUIEvent.Element = 0;
+		event.GUIEvent.Element = nullptr;
 		event.GUIEvent.EventType = EGET_COMBO_BOX_CHANGED;
 		Parent->OnEvent(event);
 	}
@@ -456,7 +456,7 @@ void CGUIComboBox::openCloseMenu()
 		// close list box
 		Environment->setFocus(this);
 		ListBox->remove();
-		ListBox = 0;
+		ListBox = nullptr;
 	}
 	else
 	{
@@ -464,7 +464,7 @@ void CGUIComboBox::openCloseMenu()
 			SEvent event;
 			event.EventType = EET_GUI_EVENT;
 			event.GUIEvent.Caller = this;
-			event.GUIEvent.Element = 0;
+			event.GUIEvent.Element = nullptr;
 			event.GUIEvent.EventType = EGET_LISTBOX_OPENED;
 
 			// Allow to prevent the listbox from opening.

--- a/source/Irrlicht/CGUIComboBox.cpp
+++ b/source/Irrlicht/CGUIComboBox.cpp
@@ -185,6 +185,15 @@ void CGUIComboBox::setSelected(s32 idx)
 }
 
 
+//! Sets the selected item and emits a change event.
+/** Set this to -1 if no item should be selected */
+void CGUIComboBox::setAndSendSelected(s32 idx)
+{
+	setSelected(idx);
+	sendSelectionChangedEvent();
+}
+
+
 //! called if an event happened.
 bool CGUIComboBox::OnEvent(const SEvent& event)
 {
@@ -451,8 +460,19 @@ void CGUIComboBox::openCloseMenu()
 	}
 	else
 	{
-		if (Parent)
+		if (Parent) {
+			SEvent event;
+			event.EventType = EET_GUI_EVENT;
+			event.GUIEvent.Caller = this;
+			event.GUIEvent.Element = 0;
+			event.GUIEvent.EventType = EGET_LISTBOX_OPENED;
+
+			// Allow to prevent the listbox from opening.
+			if (Parent->OnEvent(event))
+				return;
+
 			Parent->bringToFront(this);
+		}
 
 		IGUISkin* skin = Environment->getSkin();
 		u32 h = Items.size();

--- a/source/Irrlicht/CGUIComboBox.h
+++ b/source/Irrlicht/CGUIComboBox.h
@@ -55,6 +55,10 @@ namespace gui
 		//! sets the selected item. Set this to -1 if no item should be selected
 		void setSelected(s32 idx) override;
 
+		//! Sets the selected item and emits a change event.
+		/** Set this to -1 if no item should be selected */
+		void setAndSendSelected(s32 idx) override;
+
 		//! sets the text alignment of the text part
 		void setTextAlignment(EGUI_ALIGNMENT horizontal, EGUI_ALIGNMENT vertical) override;
 


### PR DESCRIPTION
This PR makes improvements to the combobox API for minetest/minetest#13814.

- Allow reliably detecting when the user opens a combobox.
- Allow preventing comboboxes from opening.
- Allow sending a combobox change event.