### PR TITLE
Revert #225 to make Windows+SDL builds use the SDL device again

### DIFF
--- a/source/Irrlicht/CEGLManager.cpp
+++ b/source/Irrlicht/CEGLManager.cpp
@@ -4,6 +4,8 @@
 
 #include "CEGLManager.h"
 
+#ifdef _IRR_COMPILE_WITH_EGL_MANAGER_
+
 #include "irrString.h"
 #include "irrArray.h"
 #include "os.h"
@@ -42,7 +44,7 @@ bool CEGLManager::initialize(const SIrrlichtCreationParameters& params, const SE
         return true;
 
 	// Window is depend on platform.
-#if defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_)
 	EglWindow = (NativeWindowType)Data.OpenGLWin32.HWnd;
 	Data.OpenGLWin32.HDc = GetDC((HWND)EglWindow);
 	EglDisplay = eglGetDisplay((NativeDisplayType)Data.OpenGLWin32.HDc);
@@ -97,7 +99,7 @@ void CEGLManager::terminate()
 		EglDisplay = EGL_NO_DISPLAY;
 	}
 
-#if defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_)
 	if (Data.OpenGLWin32.HDc)
     {
 		ReleaseDC((HWND)EglWindow, (HDC)Data.OpenGLWin32.HDc);
@@ -662,3 +664,4 @@ bool CEGLManager::testEGLError()
 }
 }
 
+#endif

--- a/source/Irrlicht/CEGLManager.h
+++ b/source/Irrlicht/CEGLManager.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#ifdef _IRR_COMPILE_WITH_EGL_MANAGER_
+
 #include <EGL/egl.h>
 
 #include "SIrrCreationParameters.h"
@@ -109,3 +111,4 @@ namespace video
 	};
 }
 }
+#endif

--- a/source/Irrlicht/CIrrDeviceWin32.cpp
+++ b/source/Irrlicht/CIrrDeviceWin32.cpp
@@ -3,6 +3,7 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
 
 #if defined (__STRICT_ANSI__)
     #error Compiling with __STRICT_ANSI__ not supported. g++ does set this when compiling with -std=c++11 or -std=c++0x. Use instead -std=gnu++11 or -std=gnu++0x. Or use -U__STRICT_ANSI__ to disable strict ansi.
@@ -1594,3 +1595,4 @@ core::dimension2di CIrrDeviceWin32::CCursorControl::getSupportedIconSize() const
 
 } // end namespace
 
+#endif // _IRR_COMPILE_WITH_WINDOWS_DEVICE_

--- a/source/Irrlicht/CIrrDeviceWin32.h
+++ b/source/Irrlicht/CIrrDeviceWin32.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
+
 #include "CIrrDeviceStub.h"
 #include "IrrlichtDevice.h"
 
@@ -423,3 +425,5 @@ namespace irr
 	};
 
 } // end namespace irr
+
+#endif // _IRR_COMPILE_WITH_WINDOWS_DEVICE_

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -78,10 +78,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
 	set(SOLARIS TRUE)
 endif()
 
-# EGL
-
-set(ENABLE_EGL OFF)
-
 # Device
 
 if(WIN32)
@@ -96,11 +92,8 @@ elseif(ANDROID)
 		message(FATAL_ERROR "SDL2 device is not (yet) supported on Android")
 	endif()
 	set(DEVICE "ANDROID")
-	# EGL is required for Android
-	set(ENABLE_EGL ON)
 elseif(EMSCRIPTEN)
-	add_definitions(-D_IRR_EMSCRIPTEN_PLATFORM_)
-	set(ENABLE_EGL ON)
+	add_definitions(-D_IRR_EMSCRIPTEN_PLATFORM_ -D_IRR_COMPILE_WITH_EGL_MANAGER_)
 	set(LINUX_PLATFORM TRUE)
 	set(DEVICE "SDL")
 elseif(SOLARIS)
@@ -189,7 +182,7 @@ endif()
 if(ENABLE_OPENGL)
 	add_definitions(-D_IRR_COMPILE_WITH_OPENGL_)
 	if(DEVICE STREQUAL "WINDOWS")
-		add_definitions(-D_IRR_OPENGL_USE_EXTPOINTER_)
+		add_definitions(-D_IRR_COMPILE_WITH_WGL_MANAGER_ -D_IRR_OPENGL_USE_EXTPOINTER_)
 	elseif(DEVICE STREQUAL "X11")
 		add_definitions(-D_IRR_COMPILE_WITH_GLX_MANAGER_ -D_IRR_OPENGL_USE_EXTPOINTER_)
 	elseif(DEVICE STREQUAL "OSX")
@@ -213,22 +206,18 @@ if(ENABLE_GLES1)
 	endif()
 	add_definitions(-D_IRR_COMPILE_WITH_OGLES1_)
 	if(DEVICE MATCHES "^(WINDOWS|X11|ANDROID)$")
-		add_definitions(-D_IRR_OGLES1_USE_EXTPOINTER_)
+		add_definitions(-D_IRR_COMPILE_WITH_EGL_MANAGER_ -D_IRR_OGLES1_USE_EXTPOINTER_)
 	endif()
-	# We need EGL for GLES1
-	set(ENABLE_EGL ON)
 endif()
 
 if(ENABLE_GLES2)
 	add_definitions(-D_IRR_COMPILE_WITH_OGLES2_)
 	if(DEVICE MATCHES "^(WINDOWS|X11|ANDROID)$" OR EMSCRIPTEN)
-		add_definitions(-D_IRR_OGLES2_USE_EXTPOINTER_)
+		add_definitions(-D_IRR_COMPILE_WITH_EGL_MANAGER_ -D_IRR_OGLES2_USE_EXTPOINTER_)
 	elseif(DEVICE STREQUAL "SDL")
 		set(USE_SDLGL ON)
 		set(USE_SDLGLES2 ON)
 	endif()
-	# We need EGL for GLES2
-	set(ENABLE_EGL ON)
 endif()
 
 if(ENABLE_WEBGL1)
@@ -256,7 +245,6 @@ elseif (ENABLE_GLES2)
 else()
 	message(STATUS "OpenGL ES 2: OFF")
 endif()
-message(STATUS "EGL: ${ENABLE_EGL}")
 message(STATUS "WebGL: ${ENABLE_WEBGL1}")
 
 # Required libs
@@ -368,20 +356,11 @@ add_library(IRROBJ OBJECT
 set(IRRDRVROBJ
 	CNullDriver.cpp
 	CGLXManager.cpp
+	CWGLManager.cpp
+	CEGLManager.cpp
 	CSDLManager.cpp
 	mt_opengl_loader.cpp
 )
-
-if(WIN32)
-	set(IRRDRVROBJ ${IRRDRVROBJ}
-		CIrrDeviceWin32.cpp
-	)
-	if(ENABLE_OPENGL)
-		set(IRRDRVROBJ ${IRRDRVROBJ}
-			CWGLManager.cpp
-		)
-	endif()
-endif()
 
 if(ENABLE_OPENGL)
 	set(IRRDRVROBJ
@@ -399,14 +378,6 @@ if(ENABLE_GLES1)
 		${IRRDRVROBJ}
 		COGLESDriver.cpp
 		COGLESExtensionHandler.cpp
-	)
-endif()
-
-
-if(ENABLE_EGL)
-	set(IRRDRVROBJ
-		${IRRDRVROBJ}
-		CEGLManager.cpp
 	)
 endif()
 
@@ -473,6 +444,7 @@ add_library(IRROTHEROBJ OBJECT
 	CIrrDeviceSDL.cpp
 	CIrrDeviceLinux.cpp
 	CIrrDeviceStub.cpp
+	CIrrDeviceWin32.cpp
 	CLogger.cpp
 	COSOperator.cpp
 	Irrlicht.cpp

--- a/source/Irrlicht/COGLESExtensionHandler.cpp
+++ b/source/Irrlicht/COGLESExtensionHandler.cpp
@@ -13,7 +13,7 @@
 #include "fast_atof.h"
 
 #if defined(_IRR_OGLES1_USE_EXTPOINTER_)
-#if defined(_IRR_COMPILE_WITH_ANDROID_DEVICE_) || defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_COMPILE_WITH_ANDROID_DEVICE_) || defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_)
 #include <EGL/egl.h>
 #else
 #include <GLES/egl.h>

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -48,7 +48,7 @@ bool COpenGLDriver::initDriver()
 
 	genericDriverInit();
 
-#if defined(_IRR_WINDOWS_API_) || defined(_IRR_COMPILE_WITH_X11_DEVICE_)
+#if defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_) || defined(_IRR_COMPILE_WITH_X11_DEVICE_)
 	extGlSwapInterval(Params.Vsync ? 1 : 0);
 #endif
 

--- a/source/Irrlicht/COpenGLExtensionHandler.h
+++ b/source/Irrlicht/COpenGLExtensionHandler.h
@@ -3391,7 +3391,7 @@ inline void COpenGLExtensionHandler::extGlGenerateTextureMipmap(GLuint texture, 
 inline void COpenGLExtensionHandler::extGlSwapInterval(int interval)
 {
 	// we have wglext, so try to use that
-#if defined(_IRR_WINDOWS_API_)
+#if defined(_IRR_WINDOWS_API_) && defined(_IRR_COMPILE_WITH_WINDOWS_DEVICE_)
 #ifdef WGL_EXT_swap_control
 	if (pWglSwapIntervalEXT)
 		pWglSwapIntervalEXT(interval);

--- a/source/Irrlicht/CWGLManager.cpp
+++ b/source/Irrlicht/CWGLManager.cpp
@@ -4,6 +4,8 @@
 
 #include "CWGLManager.h"
 
+#ifdef _IRR_COMPILE_WITH_WGL_MANAGER_
+
 #include "os.h"
 
 #include <GL/gl.h>
@@ -505,3 +507,5 @@ bool CWGLManager::swapBuffers()
 
 }
 }
+
+#endif

--- a/source/Irrlicht/CWGLManager.h
+++ b/source/Irrlicht/CWGLManager.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#ifdef _IRR_COMPILE_WITH_WGL_MANAGER_
+
 #include "SIrrCreationParameters.h"
 #include "SExposedVideoData.h"
 #include "IContextManager.h"
@@ -70,3 +72,5 @@ namespace video
 	};
 }
 }
+
+#endif

--- a/source/Irrlicht/Irrlicht.cpp
+++ b/source/Irrlicht/Irrlicht.cpp
@@ -13,7 +13,7 @@ static const char* const copyright = "Irrlicht Engine (c) 2002-2017 Nikolaus Geb
 #endif
 
 #include "irrlicht.h"
-#ifdef _IRR_WINDOWS_API_
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
 #include "CIrrDeviceWin32.h"
 #endif
 
@@ -60,7 +60,7 @@ namespace irr
 
 		IrrlichtDevice* dev = 0;
 
-#ifdef _IRR_WINDOWS_API_
+#ifdef _IRR_COMPILE_WITH_WINDOWS_DEVICE_
 		if (params.DeviceType == EIDT_WIN32 || (!dev && params.DeviceType == EIDT_BEST))
 			dev = new CIrrDeviceWin32(params);
 #endif


### PR DESCRIPTION
Fixes #246. (Doesn't have an effect on #239.)

This PR reverts #225 to make Windows+SDL builds use the SDL device again. Currently, they contain both the Windows device and the SDL device, but they always use the Windows device.

This PR is only intended as a temporary fix until #225 is redone correctly.

## How to test

Compile Minetest with `-DUSE_SDL2=TRUE` on Windows. Verify that the "About" tab shows "Irrlicht device: SDL".