### PR TITLE
Fix character encoding conversion issues

### DIFF
--- a/examples/AutomatedTest/test_string.cpp
+++ b/examples/AutomatedTest/test_string.cpp
@@ -168,22 +168,31 @@ static void test_methods()
 
 static void test_conv()
 {
-	// assumes Unicode and UTF-8 locale
-	setlocale(LC_CTYPE, "");
+	// should be locale-independent
 
 	stringw out;
-	multibyteToWString(out, "†††");
+	utf8ToWString(out, "†††");
 	UASSERTEQ(out.size(), 3);
 	for (int i = 0; i < 3; i++)
 		UASSERTEQ(static_cast<u16>(out[i]), 0x2020);
+
 	stringc out2;
-	wStringToMultibyte(out2, L"†††");
+	wStringToUTF8(out2, L"†††");
 	UASSERTEQ(out2.size(), 9);
 	for (int i = 0; i < 3; i++) {
 		UASSERTEQ(static_cast<u8>(out2[3*i]), 0xe2);
 		UASSERTEQ(static_cast<u8>(out2[3*i+1]), 0x80);
 		UASSERTEQ(static_cast<u8>(out2[3*i+2]), 0xa0);
 	}
+
+	// assumes Unicode and UTF-8 locale
+	setlocale(LC_CTYPE, "");
+
+	stringw out3;
+	multibyteToWString(out3, "†††");
+	UASSERTEQ(out3.size(), 3);
+	for (int i = 0; i < 3; i++)
+		UASSERTEQ(static_cast<u16>(out3[i]), 0x2020);
 }
 
 void test_irr_string()

--- a/examples/AutomatedTest/test_string.cpp
+++ b/examples/AutomatedTest/test_string.cpp
@@ -168,7 +168,7 @@ static void test_methods()
 
 static void test_conv()
 {
-	// should be locale-independent
+	// locale-independent
 
 	stringw out;
 	utf8ToWString(out, "†††");
@@ -185,8 +185,8 @@ static void test_conv()
 		UASSERTEQ(static_cast<u8>(out2[3*i+2]), 0xa0);
 	}
 
-	// assumes Unicode and UTF-8 locale
-	setlocale(LC_CTYPE, "");
+	// locale-dependent
+	setlocale(LC_CTYPE, "C.UTF-8");
 
 	stringw out3;
 	multibyteToWString(out3, "†††");

--- a/examples/AutomatedTest/test_string.cpp
+++ b/examples/AutomatedTest/test_string.cpp
@@ -186,7 +186,8 @@ static void test_conv()
 	}
 
 	// locale-dependent
-	setlocale(LC_CTYPE, "C.UTF-8");
+	if (!setlocale(LC_CTYPE, "C.UTF-8"))
+		setlocale(LC_CTYPE, "UTF-8"); // macOS
 
 	stringw out3;
 	multibyteToWString(out3, "†††");

--- a/include/IOSOperator.h
+++ b/include/IOSOperator.h
@@ -11,11 +11,11 @@
 namespace irr
 {
 
-//! The Operating system operator provides operation system specific methods and information.
+//! The OSOperator provides OS-specific methods and information.
 class IOSOperator : public virtual IReferenceCounted
 {
 public:
-	//! Get the current operation system version as string.
+	//! Get the current OS version as string.
 	virtual const core::stringc& getOperatingSystemVersion() const = 0;
 
 	//! Copies text to the clipboard

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -299,7 +299,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
 				core::stringc s;
-				wStringToMultibyte(s, Text.subString(realmbgn, realmend - realmbgn));
+				wStringToUTF8(s, Text.subString(realmbgn, realmend - realmbgn));
 				Operator->copyToClipboard(s.c_str());
 			}
 			break;
@@ -312,7 +312,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 
 				// copy
 				core::stringc sc;
-				wStringToMultibyte(sc, Text.subString(realmbgn, realmend - realmbgn));
+				wStringToUTF8(sc, Text.subString(realmbgn, realmend - realmbgn));
 				Operator->copyToClipboard(sc.c_str());
 
 				if (isEnabled())
@@ -345,7 +345,7 @@ bool CGUIEditBox::processKey(const SEvent& event)
 				if (p)
 				{
 					irr::core::stringw widep;
-					core::multibyteToWString(widep, p);
+					core::utf8ToWString(widep, p);
 
 					if (MarkBegin == MarkEnd)
 					{
@@ -1157,7 +1157,7 @@ bool CGUIEditBox::processMouse(const SEvent& event)
 			const c8 *inserted_text_utf8 = Operator->getTextFromPrimarySelection();
 			if (!inserted_text_utf8)
 				return inserted_text;
-			core::multibyteToWString(inserted_text, inserted_text_utf8);
+			core::utf8ToWString(inserted_text, inserted_text_utf8);
 			return inserted_text;
 		}());
 
@@ -1659,7 +1659,7 @@ void CGUIEditBox::setTextMarkers(s32 begin, s32 end)
 			const s32 realmend = MarkBegin < MarkEnd ? MarkEnd : MarkBegin;
 
 			core::stringc s;
-			wStringToMultibyte(s, Text.subString(realmbgn, realmend - realmbgn));
+			wStringToUTF8(s, Text.subString(realmbgn, realmend - realmbgn));
 			Operator->copyToPrimarySelection(s.c_str());
 		}
 

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -673,7 +673,7 @@ bool CIrrDeviceSDL::run()
 			{
 				irrevent.EventType = irr::EET_STRING_INPUT_EVENT;
 				irrevent.StringInput.Str = new core::stringw();
-				irr::core::multibyteToWString(*irrevent.StringInput.Str, SDL_event.text.text);
+				irr::core::utf8ToWString(*irrevent.StringInput.Str, SDL_event.text.text);
 				postEventFromUser(irrevent);
 				delete irrevent.StringInput.Str;
 				irrevent.StringInput.Str = NULL;
@@ -928,7 +928,7 @@ void CIrrDeviceSDL::sleep(u32 timeMs, bool pauseTimer)
 void CIrrDeviceSDL::setWindowCaption(const wchar_t* text)
 {
 	core::stringc textc;
-	core::wStringToMultibyte(textc, text);
+	core::wStringToUTF8(textc, text);
 	SDL_SetWindowTitle(Window, textc.c_str());
 }
 

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 # OpenGL
 
 if(USE_SDL2)
-	option(ENABLE_OPENGL3 "Enable OpenGL 3+" TRUE)
+	option(ENABLE_OPENGL3 "Enable OpenGL 3+" FALSE)
 else()
 	set(ENABLE_OPENGL3 FALSE)
 endif()

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -50,6 +50,8 @@ elseif(MSVC)
 	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
 		add_compile_options(/arch:SSE)
 	endif()
+
+	add_compile_options(/D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 endif()
 
 # Sanity-check version

--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -94,7 +94,7 @@ void COSOperator::copyToClipboard(const c8 *text) const
 	EmptyClipboard();
 
 	core::stringw tempbuffer;
-	core::multibyteToWString(tempbuffer, text);
+	core::utf8ToWString(tempbuffer, text);
 	const u32 size = (tempbuffer.size() + 1) * sizeof(wchar_t);
 
 	HGLOBAL clipbuffer;
@@ -164,7 +164,7 @@ const c8* COSOperator::getTextFromClipboard() const
 	HANDLE hData = GetClipboardData( CF_UNICODETEXT );
 	buffer = (wchar_t*) GlobalLock( hData );
 
-	core::wStringToMultibyte(ClipboardBuf, buffer);
+	core::wStringToUTF8(ClipboardBuf, buffer);
 
 	GlobalUnlock( hData );
 	CloseClipboard();

--- a/source/Irrlicht/COSOperator.h
+++ b/source/Irrlicht/COSOperator.h
@@ -11,7 +11,7 @@ namespace irr
 
 class CIrrDeviceLinux;
 
-//! The Operating system operator provides operation system specific methods and information.
+//! The OSOperator provides OS-specific methods and information.
 class COSOperator : public IOSOperator
 {
 public:
@@ -27,25 +27,31 @@ public:
 	COSOperator(const COSOperator &) = delete;
 	COSOperator &operator=(const COSOperator &) = delete;
 
-	//! returns the current operation system version as string.
+	//! Get the current OS version as string.
 	const core::stringc& getOperatingSystemVersion() const override;
 
-	//! copies text to the clipboard
+	//! Copies text to the clipboard
+	//! \param text: text in utf-8
 	void copyToClipboard(const c8 *text) const override;
 
-	//! copies text to the primary selection
+	//! Copies text to the primary selection
+	//! This is a no-op on some platforms.
+	//! \param text: text in utf-8
 	void copyToPrimarySelection(const c8 *text) const override;
 
-	//! gets text from the clipboard
+	//! Get text from the clipboard
+	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 	const c8* getTextFromClipboard() const override;
 
-	//! gets text from the primary selection
+	//! Get text from the primary selection
+	//! This is a no-op on some platforms.
+	//! \return Returns 0 if no string is in there, otherwise an utf-8 string.
 	const c8* getTextFromPrimarySelection() const override;
 
-	//! gets the total and available system RAM in kB
-	//! \param Total: will contain the total system memory
-	//! \param Avail: will contain the available memory
-	//! \return Returns true if successful, false if not
+	//! Get the total and available system RAM
+	/** \param totalBytes: will contain the total system memory in Kilobytes (1024 B)
+	\param availableBytes: will contain the available memory in Kilobytes (1024 B)
+	\return True if successful, false if not */
 	bool getSystemMemory(u32* Total, u32* Avail) const override;
 
 private:


### PR DESCRIPTION
Continuation of #221. Fixes #216 and fixes minetest/minetest#13646.

The Irrlicht string conversion functions are not broken, they are just the wrong kind of conversion functions: Irrlicht uses `wide <-> multibyte` conversion functions in places where it should actually use `wide <-> UTF-8` conversion functions. This usually works because the locale-defined multibyte encoding is UTF-8 in many environments, but sometimes, it doesn't.

This PR introduces new `wide <-> UTF-8` conversion functions, `utf8ToWString` and `wStringToUTF8`, and uses them where appropriate. `wStringToMultibyte` is not used anymore and has been removed, `multibyteToWString` has been kept because it is still used in one place.

EDIT: btw, "AutomatedTest" doesn't even compile on Windows.

## To do

This PR is Ready for Review. Before merging, 69622fe641017a10eaf05d0f36186fea424d80ec should be reverted.

## How to test

Compile Minetest on Windows with and without SDL. Set a weird combination of language settings. Verify that Unicode text is displayed/copied/whatever-ed correctly.