### PR TITLE
Fix Windows/SDL builds

### DIFF
--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -192,19 +192,19 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			QuadsIndices.push_back(4 * k + 2);
 			QuadsIndices.push_back(4 * k + 3);
 		}
-		glGenBuffers(1, &QuadIndexBuffer);
-		glBindBuffer(GL_ARRAY_BUFFER, QuadIndexBuffer);
-		glBufferData(GL_ARRAY_BUFFER, sizeof(QuadsIndices[0]) * QuadsIndices.size(), QuadsIndices.data(), GL_STATIC_DRAW);
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		GL.GenBuffers(1, &QuadIndexBuffer);
+		GL.BindBuffer(GL_ARRAY_BUFFER, QuadIndexBuffer);
+		GL.BufferData(GL_ARRAY_BUFFER, sizeof(QuadsIndices[0]) * QuadsIndices.size(), QuadsIndices.data(), GL_STATIC_DRAW);
+		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 		QuadIndexCount = QuadsIndices.size();
 	}
 
 	void COpenGL3DriverBase::initVersion() {
-		Name = glGetString(GL_VERSION);
+		Name = GL.GetString(GL_VERSION);
 		printVersion();
 
 		// print renderer information
-		VendorName = glGetString(GL_VENDOR);
+		VendorName = GL.GetString(GL_VENDOR);
 		os::Printer::log(VendorName.c_str(), ELL_INFORMATION);
 
 		Version = getVersionFromOpenGL();
@@ -242,7 +242,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		DriverAttributes->setAttribute("Version", 100 * Version.Major + Version.Minor);
 		DriverAttributes->setAttribute("AntiAlias", AntiAlias);
 
-		glPixelStorei(GL_PACK_ALIGNMENT, 1);
+		GL.PixelStorei(GL_PACK_ALIGNMENT, 1);
 
 		UserClipPlane.reallocate(0);
 
@@ -250,10 +250,10 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			setTransform(static_cast<E_TRANSFORMATION_STATE>(i), core::IdentityMatrix);
 
 		setAmbientLight(SColorf(0.0f, 0.0f, 0.0f, 0.0f));
-		glClearDepthf(1.0f);
+		GL.ClearDepthf(1.0f);
 
-		glHint(GL_GENERATE_MIPMAP_HINT, GL_NICEST);
-		glFrontFace(GL_CW);
+		GL.Hint(GL_GENERATE_MIPMAP_HINT, GL_NICEST);
+		GL.FrontFace(GL_CW);
 
 		// create material renderers
 		createMaterialRenderers();
@@ -418,7 +418,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 	{
 		CNullDriver::endScene();
 
-		glFlush();
+		GL.Flush();
 
 		if (ContextManager)
 			return ContextManager->swapBuffers();
@@ -460,7 +460,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		bool newBuffer = false;
 		if (!HWBuffer->vbo_verticesID)
 		{
-			glGenBuffers(1, &HWBuffer->vbo_verticesID);
+			GL.GenBuffers(1, &HWBuffer->vbo_verticesID);
 			if (!HWBuffer->vbo_verticesID) return false;
 			newBuffer = true;
 		}
@@ -469,22 +469,22 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			newBuffer = true;
 		}
 
-		glBindBuffer(GL_ARRAY_BUFFER, HWBuffer->vbo_verticesID);
+		GL.BindBuffer(GL_ARRAY_BUFFER, HWBuffer->vbo_verticesID);
 
 		// copy data to graphics card
 		if (!newBuffer)
-			glBufferSubData(GL_ARRAY_BUFFER, 0, bufferSize, buffer);
+			GL.BufferSubData(GL_ARRAY_BUFFER, 0, bufferSize, buffer);
 		else
 		{
 			HWBuffer->vbo_verticesSize = bufferSize;
 
 			if (HWBuffer->Mapped_Vertex == scene::EHM_STATIC)
-				glBufferData(GL_ARRAY_BUFFER, bufferSize, buffer, GL_STATIC_DRAW);
+				GL.BufferData(GL_ARRAY_BUFFER, bufferSize, buffer, GL_STATIC_DRAW);
 			else
-				glBufferData(GL_ARRAY_BUFFER, bufferSize, buffer, GL_DYNAMIC_DRAW);
+				GL.BufferData(GL_ARRAY_BUFFER, bufferSize, buffer, GL_DYNAMIC_DRAW);
 		}
 
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 
 		return (!testGLError(__LINE__));
 	}
@@ -523,7 +523,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		bool newBuffer = false;
 		if (!HWBuffer->vbo_indicesID)
 		{
-			glGenBuffers(1, &HWBuffer->vbo_indicesID);
+			GL.GenBuffers(1, &HWBuffer->vbo_indicesID);
 			if (!HWBuffer->vbo_indicesID) return false;
 			newBuffer = true;
 		}
@@ -532,22 +532,22 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			newBuffer = true;
 		}
 
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, HWBuffer->vbo_indicesID);
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, HWBuffer->vbo_indicesID);
 
 		// copy data to graphics card
 		if (!newBuffer)
-			glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, indexCount * indexSize, indices);
+			GL.BufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, indexCount * indexSize, indices);
 		else
 		{
 			HWBuffer->vbo_indicesSize = indexCount * indexSize;
 
 			if (HWBuffer->Mapped_Index == scene::EHM_STATIC)
-				glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexCount * indexSize, indices, GL_STATIC_DRAW);
+				GL.BufferData(GL_ELEMENT_ARRAY_BUFFER, indexCount * indexSize, indices, GL_STATIC_DRAW);
 			else
-				glBufferData(GL_ELEMENT_ARRAY_BUFFER, indexCount * indexSize, indices, GL_DYNAMIC_DRAW);
+				GL.BufferData(GL_ELEMENT_ARRAY_BUFFER, indexCount * indexSize, indices, GL_DYNAMIC_DRAW);
 		}
 
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
 		return (!testGLError(__LINE__));
 	}
@@ -627,12 +627,12 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		SHWBufferLink_opengl *HWBuffer = static_cast<SHWBufferLink_opengl*>(_HWBuffer);
 		if (HWBuffer->vbo_verticesID)
 		{
-			glDeleteBuffers(1, &HWBuffer->vbo_verticesID);
+			GL.DeleteBuffers(1, &HWBuffer->vbo_verticesID);
 			HWBuffer->vbo_verticesID = 0;
 		}
 		if (HWBuffer->vbo_indicesID)
 		{
-			glDeleteBuffers(1, &HWBuffer->vbo_indicesID);
+			GL.DeleteBuffers(1, &HWBuffer->vbo_indicesID);
 			HWBuffer->vbo_indicesID = 0;
 		}
 
@@ -656,13 +656,13 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 
 		if (HWBuffer->Mapped_Vertex != scene::EHM_NEVER)
 		{
-			glBindBuffer(GL_ARRAY_BUFFER, HWBuffer->vbo_verticesID);
+			GL.BindBuffer(GL_ARRAY_BUFFER, HWBuffer->vbo_verticesID);
 			vertices = 0;
 		}
 
 		if (HWBuffer->Mapped_Index != scene::EHM_NEVER)
 		{
-			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, HWBuffer->vbo_indicesID);
+			GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, HWBuffer->vbo_indicesID);
 			indexList = 0;
 		}
 
@@ -673,10 +673,10 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 				mb->getIndexType());
 
 		if (HWBuffer->Mapped_Vertex != scene::EHM_NEVER)
-			glBindBuffer(GL_ARRAY_BUFFER, 0);
+			GL.BindBuffer(GL_ARRAY_BUFFER, 0);
 
 		if (HWBuffer->Mapped_Index != scene::EHM_NEVER)
-			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+			GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 	}
 
 
@@ -741,25 +741,25 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		{
 			case scene::EPT_POINTS:
 			case scene::EPT_POINT_SPRITES:
-				glDrawArrays(GL_POINTS, 0, primitiveCount);
+				GL.DrawArrays(GL_POINTS, 0, primitiveCount);
 				break;
 			case scene::EPT_LINE_STRIP:
-				glDrawElements(GL_LINE_STRIP, primitiveCount + 1, indexSize, indexList);
+				GL.DrawElements(GL_LINE_STRIP, primitiveCount + 1, indexSize, indexList);
 				break;
 			case scene::EPT_LINE_LOOP:
-				glDrawElements(GL_LINE_LOOP, primitiveCount, indexSize, indexList);
+				GL.DrawElements(GL_LINE_LOOP, primitiveCount, indexSize, indexList);
 				break;
 			case scene::EPT_LINES:
-				glDrawElements(GL_LINES, primitiveCount*2, indexSize, indexList);
+				GL.DrawElements(GL_LINES, primitiveCount*2, indexSize, indexList);
 				break;
 			case scene::EPT_TRIANGLE_STRIP:
-				glDrawElements(GL_TRIANGLE_STRIP, primitiveCount + 2, indexSize, indexList);
+				GL.DrawElements(GL_TRIANGLE_STRIP, primitiveCount + 2, indexSize, indexList);
 				break;
 			case scene::EPT_TRIANGLE_FAN:
-				glDrawElements(GL_TRIANGLE_FAN, primitiveCount + 2, indexSize, indexList);
+				GL.DrawElements(GL_TRIANGLE_FAN, primitiveCount + 2, indexSize, indexList);
 				break;
 			case scene::EPT_TRIANGLES:
-				glDrawElements((LastMaterial.Wireframe) ? GL_LINES : (LastMaterial.PointCloud) ? GL_POINTS : GL_TRIANGLES, primitiveCount*3, indexSize, indexList);
+				GL.DrawElements((LastMaterial.Wireframe) ? GL_LINES : (LastMaterial.PointCloud) ? GL_POINTS : GL_TRIANGLES, primitiveCount*3, indexSize, indexList);
 				break;
 			default:
 				break;
@@ -827,8 +827,8 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (!clipRect->isValid())
 				return;
 
-			glEnable(GL_SCISSOR_TEST);
-			glScissor(clipRect->UpperLeftCorner.X, renderTargetSize.Height - clipRect->LowerRightCorner.Y,
+			GL.Enable(GL_SCISSOR_TEST);
+			GL.Scissor(clipRect->UpperLeftCorner.X, renderTargetSize.Height - clipRect->LowerRightCorner.Y,
 				clipRect->getWidth(), clipRect->getHeight());
 		}
 
@@ -846,7 +846,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		drawQuad(vt2DImage, vertices);
 
 		if (clipRect)
-			glDisable(GL_SCISSOR_TEST);
+			GL.Disable(GL_SCISSOR_TEST);
 
 		testGLError(__LINE__);
 	}
@@ -906,8 +906,8 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (!clipRect->isValid())
 				return;
 
-			glEnable(GL_SCISSOR_TEST);
-			glScissor(clipRect->UpperLeftCorner.X, renderTargetSize.Height - clipRect->LowerRightCorner.Y,
+			GL.Enable(GL_SCISSOR_TEST);
+			GL.Scissor(clipRect->UpperLeftCorner.X, renderTargetSize.Height - clipRect->LowerRightCorner.Y,
 					clipRect->getWidth(), clipRect->getHeight());
 		}
 
@@ -952,12 +952,12 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 					tcoords.UpperLeftCorner.X, tcoords.LowerRightCorner.Y));
 		}
 
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, QuadIndexBuffer);
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, QuadIndexBuffer);
 		drawElements(GL_TRIANGLES, vt2DImage, vtx.const_pointer(), vtx.size(), 0, 6 * drawCount);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+		GL.BindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
 		if (clipRect)
-			glDisable(GL_SCISSOR_TEST);
+			GL.Disable(GL_SCISSOR_TEST);
 	}
 
 
@@ -1093,25 +1093,25 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 	void COpenGL3DriverBase::drawArrays(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount)
 	{
 		beginDraw(vertexType, reinterpret_cast<uintptr_t>(vertices));
-		glDrawArrays(primitiveType, 0, vertexCount);
+		GL.DrawArrays(primitiveType, 0, vertexCount);
 		endDraw(vertexType);
 	}
 
 	void COpenGL3DriverBase::drawElements(GLenum primitiveType, const VertexType &vertexType, const void *vertices, int vertexCount, const u16 *indices, int indexCount)
 	{
 		beginDraw(vertexType, reinterpret_cast<uintptr_t>(vertices));
-		glDrawRangeElements(primitiveType, 0, vertexCount - 1, indexCount, GL_UNSIGNED_SHORT, indices);
+		GL.DrawRangeElements(primitiveType, 0, vertexCount - 1, indexCount, GL_UNSIGNED_SHORT, indices);
 		endDraw(vertexType);
 	}
 
 	void COpenGL3DriverBase::beginDraw(const VertexType &vertexType, uintptr_t verticesBase)
 	{
 		for (auto attr: vertexType) {
-			glEnableVertexAttribArray(attr.Index);
+			GL.EnableVertexAttribArray(attr.Index);
 			switch (attr.mode) {
-			case VertexAttribute::Mode::Regular: glVertexAttribPointer(attr.Index, attr.ComponentCount, attr.ComponentType, GL_FALSE, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
-			case VertexAttribute::Mode::Normalized: glVertexAttribPointer(attr.Index, attr.ComponentCount, attr.ComponentType, GL_TRUE, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
-			case VertexAttribute::Mode::Integral: glVertexAttribIPointer(attr.Index, attr.ComponentCount, attr.ComponentType, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
+			case VertexAttribute::Mode::Regular: GL.VertexAttribPointer(attr.Index, attr.ComponentCount, attr.ComponentType, GL_FALSE, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
+			case VertexAttribute::Mode::Normalized: GL.VertexAttribPointer(attr.Index, attr.ComponentCount, attr.ComponentType, GL_TRUE, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
+			case VertexAttribute::Mode::Integral: GL.VertexAttribIPointer(attr.Index, attr.ComponentCount, attr.ComponentType, vertexType.VertexSize, reinterpret_cast<void *>(verticesBase + attr.Offset)); break;
 			}
 		}
 	}
@@ -1119,7 +1119,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 	void COpenGL3DriverBase::endDraw(const VertexType &vertexType)
 	{
 		for (auto attr: vertexType)
-			glDisableVertexAttribArray(attr.Index);
+			GL.DisableVertexAttribArray(attr.Index);
 	}
 
 	ITexture* COpenGL3DriverBase::createDeviceDependentTexture(const io::path& name, IImage* image)
@@ -1156,7 +1156,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 	bool COpenGL3DriverBase::testGLError(int code)
 	{
 #ifdef _DEBUG
-		GLenum g = glGetError();
+		GLenum g = GL.GetError();
 		switch (g)
 		{
 			case GL_NO_ERROR:
@@ -1418,15 +1418,15 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		// TODO: Polygon Offset. Not sure if it was left out deliberately or if it won't work with this driver.
 
 		if (resetAllRenderStates || lastmaterial.Thickness != material.Thickness)
-			glLineWidth(core::clamp(static_cast<GLfloat>(material.Thickness), DimAliasedLine[0], DimAliasedLine[1]));
+			GL.LineWidth(core::clamp(static_cast<GLfloat>(material.Thickness), DimAliasedLine[0], DimAliasedLine[1]));
 
 		// Anti aliasing
 		if (resetAllRenderStates || lastmaterial.AntiAliasing != material.AntiAliasing)
 		{
 			if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+				GL.Enable(GL_SAMPLE_ALPHA_TO_COVERAGE);
 			else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+				GL.Disable(GL_SAMPLE_ALPHA_TO_COVERAGE);
 		}
 
 		// Texture parameters
@@ -1455,7 +1455,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].MagFilter != tmpTexture->getStatesCache().MagFilter)
 			{
 				E_TEXTURE_MAG_FILTER magFilter = material.TextureLayers[i].MagFilter;
-				glTexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
+				GL.TexParameteri(tmpTextureType, GL_TEXTURE_MAG_FILTER,
 					magFilter == ETMAGF_NEAREST ? GL_NEAREST :
 					(assert(magFilter == ETMAGF_LINEAR), GL_LINEAR));
 
@@ -1468,7 +1468,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 					!tmpTexture->getStatesCache().MipMapStatus)
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
-					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
+					GL.TexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						minFilter == ETMINF_NEAREST_MIPMAP_NEAREST ? GL_NEAREST_MIPMAP_NEAREST :
 						minFilter == ETMINF_LINEAR_MIPMAP_NEAREST ? GL_LINEAR_MIPMAP_NEAREST :
 						minFilter == ETMINF_NEAREST_MIPMAP_LINEAR ? GL_NEAREST_MIPMAP_LINEAR :
@@ -1484,7 +1484,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 					tmpTexture->getStatesCache().MipMapStatus)
 				{
 					E_TEXTURE_MIN_FILTER minFilter = material.TextureLayers[i].MinFilter;
-					glTexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
+					GL.TexParameteri(tmpTextureType, GL_TEXTURE_MIN_FILTER,
 						(minFilter == ETMINF_NEAREST_MIPMAP_NEAREST || minFilter == ETMINF_NEAREST_MIPMAP_LINEAR) ? GL_NEAREST :
 						(assert(minFilter == ETMINF_LINEAR_MIPMAP_NEAREST || minFilter == ETMINF_LINEAR_MIPMAP_LINEAR), GL_LINEAR));
 
@@ -1496,7 +1496,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			if (AnisotropicFilterSupported &&
 				(!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].AnisotropicFilter != tmpTexture->getStatesCache().AnisotropicFilter))
 			{
-				glTexParameteri(tmpTextureType, GL.TEXTURE_MAX_ANISOTROPY,
+				GL.TexParameteri(tmpTextureType, GL.TEXTURE_MAX_ANISOTROPY,
 					material.TextureLayers[i].AnisotropicFilter>1 ? core::min_(MaxAnisotropy, material.TextureLayers[i].AnisotropicFilter) : 1);
 
 				tmpTexture->getStatesCache().AnisotropicFilter = material.TextureLayers[i].AnisotropicFilter;
@@ -1504,13 +1504,13 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 
 			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapU != tmpTexture->getStatesCache().WrapU)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
+				GL.TexParameteri(tmpTextureType, GL_TEXTURE_WRAP_S, getTextureWrapMode(material.TextureLayers[i].TextureWrapU));
 				tmpTexture->getStatesCache().WrapU = material.TextureLayers[i].TextureWrapU;
 			}
 
 			if (!tmpTexture->getStatesCache().IsCached || material.TextureLayers[i].TextureWrapV != tmpTexture->getStatesCache().WrapV)
 			{
-				glTexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
+				GL.TexParameteri(tmpTextureType, GL_TEXTURE_WRAP_T, getTextureWrapMode(material.TextureLayers[i].TextureWrapV));
 				tmpTexture->getStatesCache().WrapV = material.TextureLayers[i].TextureWrapV;
 			}
 
@@ -1902,7 +1902,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			CacheHandler->setColorMask(ECP_ALL);
 
 			const f32 inv = 1.0f / 255.0f;
-			glClearColor(color.getRed() * inv, color.getGreen() * inv,
+			GL.ClearColor(color.getRed() * inv, color.getGreen() * inv,
 				color.getBlue() * inv, color.getAlpha() * inv);
 
 			mask |= GL_COLOR_BUFFER_BIT;
@@ -1911,18 +1911,18 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		if (flag & ECBF_DEPTH)
 		{
 			CacheHandler->setDepthMask(true);
-			glClearDepthf(depth);
+			GL.ClearDepthf(depth);
 			mask |= GL_DEPTH_BUFFER_BIT;
 		}
 
 		if (flag & ECBF_STENCIL)
 		{
-			glClearStencil(stencil);
+			GL.ClearStencil(stencil);
 			mask |= GL_STENCIL_BUFFER_BIT;
 		}
 
 		if (mask)
-			glClear(mask);
+			GL.Clear(mask);
 
 		CacheHandler->setColorMask(colorMask);
 		CacheHandler->setDepthMask(depthMask);
@@ -1941,8 +1941,8 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 		GLint internalformat = GL_RGBA;
 		GLint type = GL_UNSIGNED_BYTE;
 		{
-//			glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &internalformat);
-//			glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &type);
+//			GL.GetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &internalformat);
+//			GL.GetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &type);
 			// there's a format we don't support ATM
 			if (GL_UNSIGNED_SHORT_4_4_4_4 == type)
 			{
@@ -1977,7 +1977,7 @@ COpenGL3DriverBase::~COpenGL3DriverBase()
 			return 0;
 		}
 
-		glReadPixels(0, 0, ScreenSize.Width, ScreenSize.Height, internalformat, type, pixels);
+		GL.ReadPixels(0, 0, ScreenSize.Width, ScreenSize.Height, internalformat, type, pixels);
 		testGLError(__LINE__);
 
 		// opengl images are horizontally flipped, so we have to fix that here.

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -46,20 +46,20 @@ namespace video
 
 	struct VertexType {
 		int VertexSize;
-		std::initializer_list<VertexAttribute> Attributes;  // Extends lifetime when used properly!
+		std::vector<VertexAttribute> Attributes;
 	};
 
 	static const VertexAttribute *begin(const VertexType &type)
 	{
-		return type.Attributes.begin();
+		return type.Attributes.data();
 	}
 
 	static const VertexAttribute *end(const VertexType &type)
 	{
-		return type.Attributes.end();
+		return type.Attributes.data() + type.Attributes.size();
 	}
 
-	static constexpr VertexType vtStandard = {
+	static const VertexType vtStandard = {
 		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Normal)},
@@ -71,7 +71,7 @@ namespace video
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
-	static constexpr VertexType vt2TCoords = {
+	static const VertexType vt2TCoords = {
 		sizeof(S3DVertex2TCoords), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Normal)},
@@ -81,7 +81,7 @@ namespace video
 		},
 	};
 
-	static constexpr VertexType vtTangents = {
+	static const VertexType vtTangents = {
 		sizeof(S3DVertexTangents), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Normal)},
@@ -104,7 +104,7 @@ namespace video
 		}
 	}
 
-	static constexpr VertexType vt2DImage = {
+	static const VertexType vt2DImage = {
 		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
@@ -112,7 +112,7 @@ namespace video
 		},
 	};
 
-	static constexpr VertexType vtPrimitive = {
+	static const VertexType vtPrimitive = {
 		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},

--- a/source/Irrlicht/OpenGL/Driver.cpp
+++ b/source/Irrlicht/OpenGL/Driver.cpp
@@ -46,25 +46,21 @@ namespace video
 
 	struct VertexType {
 		int VertexSize;
-		int AttributeCount;
-		VertexAttribute Attributes[];
-
-		VertexType(const VertexType &) = delete;
-		VertexType &operator= (const VertexType &) = delete;
+		std::initializer_list<VertexAttribute> Attributes;  // Extends lifetime when used properly!
 	};
 
 	static const VertexAttribute *begin(const VertexType &type)
 	{
-		return type.Attributes;
+		return type.Attributes.begin();
 	}
 
 	static const VertexAttribute *end(const VertexType &type)
 	{
-		return type.Attributes + type.AttributeCount;
+		return type.Attributes.end();
 	}
 
 	static constexpr VertexType vtStandard = {
-		sizeof(S3DVertex), 4, {
+		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Normal)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
@@ -76,7 +72,7 @@ namespace video
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 	static constexpr VertexType vt2TCoords = {
-		sizeof(S3DVertex2TCoords), 5, {
+		sizeof(S3DVertex2TCoords), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex2TCoords, Normal)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex2TCoords, Color)},
@@ -86,7 +82,7 @@ namespace video
 	};
 
 	static constexpr VertexType vtTangents = {
-		sizeof(S3DVertexTangents), 6, {
+		sizeof(S3DVertexTangents), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Pos)},
 			{EVA_NORMAL, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertexTangents, Normal)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertexTangents, Color)},
@@ -109,7 +105,7 @@ namespace video
 	}
 
 	static constexpr VertexType vt2DImage = {
-		sizeof(S3DVertex), 3, {
+		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
 			{EVA_TCOORD0, 2, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, TCoords)},
@@ -117,7 +113,7 @@ namespace video
 	};
 
 	static constexpr VertexType vtPrimitive = {
-		sizeof(S3DVertex), 2, {
+		sizeof(S3DVertex), {
 			{EVA_POSITION, 3, GL_FLOAT, VertexAttribute::Mode::Regular, offsetof(S3DVertex, Pos)},
 			{EVA_COLOR, 4, GL_UNSIGNED_BYTE, VertexAttribute::Mode::Normalized, offsetof(S3DVertex, Color)},
 		},

--- a/source/Irrlicht/OpenGL/ExtensionHandler.cpp
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.cpp
@@ -17,7 +17,7 @@ namespace video
 {
 	void COpenGL3ExtensionHandler::initExtensionsOld()
 	{
-		auto extensions_string = reinterpret_cast<const char *>(glGetString(GL_EXTENSIONS));
+		auto extensions_string = reinterpret_cast<const char *>(GL.GetString(GL_EXTENSIONS));
 		const char *pos = extensions_string;
 		while (const char *next = strchr(pos, ' ')) {
 			addExtension(std::string{pos, next});

--- a/source/Irrlicht/OpenGL/ExtensionHandler.cpp
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.cpp
@@ -39,7 +39,7 @@ namespace video
 		Extensions.emplace(std::move(name));
 	}
 
-	bool COpenGL3ExtensionHandler::queryExtension(const std::string &name) const{
+	bool COpenGL3ExtensionHandler::queryExtension(const std::string &name) const noexcept {
 		return Extensions.find(name) != Extensions.end();
 	}
 

--- a/source/Irrlicht/OpenGL/ExtensionHandler.h
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.h
@@ -11,9 +11,9 @@
 #include "EDriverFeatures.h"
 #include "irrTypes.h"
 #include "os.h"
-#include <mt_opengl.h>
 
 #include "Common.h"
+#include <mt_opengl.h> // must be after Common.h
 
 #include "COGLESCoreExtensionHandler.h"
 

--- a/source/Irrlicht/OpenGL/ExtensionHandler.h
+++ b/source/Irrlicht/OpenGL/ExtensionHandler.h
@@ -79,13 +79,13 @@ namespace video
 
 		static GLint GetInteger(GLenum key) {
 			GLint val = 0;
-			glGetIntegerv(key, &val);
+			GL.GetIntegerv(key, &val);
 			return val;
 		};
 
 		inline void irrGlActiveTexture(GLenum texture)
 		{
-			glActiveTexture(texture);
+			GL.ActiveTexture(texture);
 		}
 
 		inline void irrGlCompressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border,
@@ -102,37 +102,37 @@ namespace video
 
 		inline void irrGlUseProgram(GLuint prog)
 		{
-			glUseProgram(prog);
+			GL.UseProgram(prog);
 		}
 
 		inline void irrGlBindFramebuffer(GLenum target, GLuint framebuffer)
 		{
-			glBindFramebuffer(target, framebuffer);
+			GL.BindFramebuffer(target, framebuffer);
 		}
 
 		inline void irrGlDeleteFramebuffers(GLsizei n, const GLuint *framebuffers)
 		{
-			glDeleteFramebuffers(n, framebuffers);
+			GL.DeleteFramebuffers(n, framebuffers);
 		}
 
 		inline void irrGlGenFramebuffers(GLsizei n, GLuint *framebuffers)
 		{
-			glGenFramebuffers(n, framebuffers);
+			GL.GenFramebuffers(n, framebuffers);
 		}
 
 		inline GLenum irrGlCheckFramebufferStatus(GLenum target)
 		{
-			return glCheckFramebufferStatus(target);
+			return GL.CheckFramebufferStatus(target);
 		}
 
 		inline void irrGlFramebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level)
 		{
-			glFramebufferTexture2D(target, attachment, textarget, texture, level);
+			GL.FramebufferTexture2D(target, attachment, textarget, texture, level);
 		}
 
 		inline void irrGlGenerateMipmap(GLenum target)
 		{
-			glGenerateMipmap(target);
+			GL.GenerateMipmap(target);
 		}
 
 		inline void irrGlDrawBuffer(GLenum mode)
@@ -147,12 +147,12 @@ namespace video
 
 		inline void irrGlBlendFuncSeparate(GLenum sfactorRGB, GLenum dfactorRGB, GLenum sfactorAlpha, GLenum dfactorAlpha)
 		{
-			glBlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
+			GL.BlendFuncSeparate(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
 		}
 
 		inline void irrGlBlendEquation(GLenum mode)
 		{
-			glBlendEquation(mode);
+			GL.BlendEquation(mode);
 		}
 
 		bool AnisotropicFilterSupported = false;

--- a/source/Irrlicht/OpenGL/MaterialRenderer.cpp
+++ b/source/Irrlicht/OpenGL/MaterialRenderer.cpp
@@ -86,12 +86,12 @@ COpenGL3MaterialRenderer::~COpenGL3MaterialRenderer()
 	{
 		GLuint shaders[8];
 		GLint count;
-		glGetAttachedShaders(Program, 8, &count, shaders);
+		GL.GetAttachedShaders(Program, 8, &count, shaders);
 
 		count=core::min_(count,8);
 		for (GLint i=0; i<count; ++i)
-			glDeleteShader(shaders[i]);
-		glDeleteProgram(Program);
+			GL.DeleteShader(shaders[i]);
+		GL.DeleteProgram(Program);
 		Program = 0;
 	}
 
@@ -110,7 +110,7 @@ void COpenGL3MaterialRenderer::init(s32& outMaterialTypeNr,
 {
 	outMaterialTypeNr = -1;
 
-	Program = glCreateProgram();
+	Program = GL.CreateProgram();
 
 	if (!Program)
 		return;
@@ -124,7 +124,7 @@ void COpenGL3MaterialRenderer::init(s32& outMaterialTypeNr,
 			return;
 
 	for ( size_t i = 0; i < EVA_COUNT; ++i )
-			glBindAttribLocation( Program, i, sBuiltInVertexAttributeNames[i]);
+			GL.BindAttribLocation( Program, i, sBuiltInVertexAttributeNames[i]);
 
 	if (!linkProgram())
 		return;
@@ -198,13 +198,13 @@ bool COpenGL3MaterialRenderer::createShader(GLenum shaderType, const char* shade
 {
 	if (Program)
 	{
-		GLuint shaderHandle = glCreateShader(shaderType);
-		glShaderSource(shaderHandle, 1, &shader, NULL);
-		glCompileShader(shaderHandle);
+		GLuint shaderHandle = GL.CreateShader(shaderType);
+		GL.ShaderSource(shaderHandle, 1, &shader, NULL);
+		GL.CompileShader(shaderHandle);
 
 		GLint status = 0;
 
-		glGetShaderiv(shaderHandle, GL_COMPILE_STATUS, &status);
+		GL.GetShaderiv(shaderHandle, GL_COMPILE_STATUS, &status);
 
 		if (status != GL_TRUE)
 		{
@@ -213,13 +213,13 @@ bool COpenGL3MaterialRenderer::createShader(GLenum shaderType, const char* shade
 			GLint maxLength=0;
 			GLint length;
 
-			glGetShaderiv(shaderHandle, GL_INFO_LOG_LENGTH,
+			GL.GetShaderiv(shaderHandle, GL_INFO_LOG_LENGTH,
 					&maxLength);
 
 			if (maxLength)
 			{
 				GLchar *infoLog = new GLchar[maxLength];
-				glGetShaderInfoLog(shaderHandle, maxLength, &length, infoLog);
+				GL.GetShaderInfoLog(shaderHandle, maxLength, &length, infoLog);
 				os::Printer::log(reinterpret_cast<const c8*>(infoLog), ELL_ERROR);
 				delete [] infoLog;
 			}
@@ -227,7 +227,7 @@ bool COpenGL3MaterialRenderer::createShader(GLenum shaderType, const char* shade
 			return false;
 		}
 
-		glAttachShader(Program, shaderHandle);
+		GL.AttachShader(Program, shaderHandle);
 	}
 
 	return true;
@@ -238,11 +238,11 @@ bool COpenGL3MaterialRenderer::linkProgram()
 {
 	if (Program)
 	{
-		glLinkProgram(Program);
+		GL.LinkProgram(Program);
 
 		GLint status = 0;
 
-		glGetProgramiv(Program, GL_LINK_STATUS, &status);
+		GL.GetProgramiv(Program, GL_LINK_STATUS, &status);
 
 		if (!status)
 		{
@@ -251,12 +251,12 @@ bool COpenGL3MaterialRenderer::linkProgram()
 			GLint maxLength=0;
 			GLsizei length;
 
-			glGetProgramiv(Program, GL_INFO_LOG_LENGTH, &maxLength);
+			GL.GetProgramiv(Program, GL_INFO_LOG_LENGTH, &maxLength);
 
 			if (maxLength)
 			{
 				GLchar *infoLog = new GLchar[maxLength];
-				glGetProgramInfoLog(Program, maxLength, &length, infoLog);
+				GL.GetProgramInfoLog(Program, maxLength, &length, infoLog);
 				os::Printer::log(reinterpret_cast<const c8*>(infoLog), ELL_ERROR);
 				delete [] infoLog;
 			}
@@ -266,14 +266,14 @@ bool COpenGL3MaterialRenderer::linkProgram()
 
 		GLint num = 0;
 
-		glGetProgramiv(Program, GL_ACTIVE_UNIFORMS, &num);
+		GL.GetProgramiv(Program, GL_ACTIVE_UNIFORMS, &num);
 
 		if (num == 0)
 			return true;
 
 		GLint maxlen = 0;
 
-		glGetProgramiv(Program, GL_ACTIVE_UNIFORM_MAX_LENGTH, &maxlen);
+		GL.GetProgramiv(Program, GL_ACTIVE_UNIFORM_MAX_LENGTH, &maxlen);
 
 		if (maxlen == 0)
 		{
@@ -294,7 +294,7 @@ bool COpenGL3MaterialRenderer::linkProgram()
 			memset(buf, 0, maxlen);
 
 			GLint size;
-			glGetActiveUniform(Program, i, maxlen, 0, &size, &ui.type, reinterpret_cast<GLchar*>(buf));
+			GL.GetActiveUniform(Program, i, maxlen, 0, &size, &ui.type, reinterpret_cast<GLchar*>(buf));
 
             core::stringc name = "";
 
@@ -308,7 +308,7 @@ bool COpenGL3MaterialRenderer::linkProgram()
 			}
 
 			ui.name = name;
-			ui.location = glGetUniformLocation(Program, buf);
+			ui.location = GL.GetUniformLocation(Program, buf);
 
 			UniformInfo.push_back(ui);
 		}
@@ -378,25 +378,25 @@ bool COpenGL3MaterialRenderer::setPixelShaderConstant(s32 index, const f32* floa
 	switch (UniformInfo[index].type)
 	{
 		case GL_FLOAT:
-			glUniform1fv(UniformInfo[index].location, count, floats);
+			GL.Uniform1fv(UniformInfo[index].location, count, floats);
 			break;
 		case GL_FLOAT_VEC2:
-			glUniform2fv(UniformInfo[index].location, count/2, floats);
+			GL.Uniform2fv(UniformInfo[index].location, count/2, floats);
 			break;
 		case GL_FLOAT_VEC3:
-			glUniform3fv(UniformInfo[index].location, count/3, floats);
+			GL.Uniform3fv(UniformInfo[index].location, count/3, floats);
 			break;
 		case GL_FLOAT_VEC4:
-			glUniform4fv(UniformInfo[index].location, count/4, floats);
+			GL.Uniform4fv(UniformInfo[index].location, count/4, floats);
 			break;
 		case GL_FLOAT_MAT2:
-			glUniformMatrix2fv(UniformInfo[index].location, count/4, false, floats);
+			GL.UniformMatrix2fv(UniformInfo[index].location, count/4, false, floats);
 			break;
 		case GL_FLOAT_MAT3:
-			glUniformMatrix3fv(UniformInfo[index].location, count/9, false, floats);
+			GL.UniformMatrix3fv(UniformInfo[index].location, count/9, false, floats);
 			break;
 		case GL_FLOAT_MAT4:
-			glUniformMatrix4fv(UniformInfo[index].location, count/16, false, floats);
+			GL.UniformMatrix4fv(UniformInfo[index].location, count/16, false, floats);
 			break;
 		case GL_SAMPLER_2D:
 		case GL_SAMPLER_CUBE:
@@ -404,7 +404,7 @@ bool COpenGL3MaterialRenderer::setPixelShaderConstant(s32 index, const f32* floa
 				if(floats)
 				{
 					const GLint id = (GLint)(*floats);
-					glUniform1iv(UniformInfo[index].location, 1, &id);
+					GL.Uniform1iv(UniformInfo[index].location, 1, &id);
 				}
 				else
 					status = false;
@@ -429,23 +429,23 @@ bool COpenGL3MaterialRenderer::setPixelShaderConstant(s32 index, const s32* ints
 	{
 		case GL_INT:
 		case GL_BOOL:
-			glUniform1iv(UniformInfo[index].location, count, ints);
+			GL.Uniform1iv(UniformInfo[index].location, count, ints);
 			break;
 		case GL_INT_VEC2:
 		case GL_BOOL_VEC2:
-			glUniform2iv(UniformInfo[index].location, count/2, ints);
+			GL.Uniform2iv(UniformInfo[index].location, count/2, ints);
 			break;
 		case GL_INT_VEC3:
 		case GL_BOOL_VEC3:
-			glUniform3iv(UniformInfo[index].location, count/3, ints);
+			GL.Uniform3iv(UniformInfo[index].location, count/3, ints);
 			break;
 		case GL_INT_VEC4:
 		case GL_BOOL_VEC4:
-			glUniform4iv(UniformInfo[index].location, count/4, ints);
+			GL.Uniform4iv(UniformInfo[index].location, count/4, ints);
 			break;
 		case GL_SAMPLER_2D:
 		case GL_SAMPLER_CUBE:
-			glUniform1iv(UniformInfo[index].location, 1, ints);
+			GL.Uniform1iv(UniformInfo[index].location, 1, ints);
 			break;
 		default:
 			status = false;

--- a/source/Irrlicht/OpenGL3/Driver.cpp
+++ b/source/Irrlicht/OpenGL3/Driver.cpp
@@ -15,9 +15,9 @@ namespace video {
 
 	OpenGLVersion COpenGL3Driver::getVersionFromOpenGL() const {
 		GLint major, minor, profile;
-		glGetIntegerv(GL_MAJOR_VERSION, &major);
-		glGetIntegerv(GL_MINOR_VERSION, &minor);
-		glGetIntegerv(GL_CONTEXT_PROFILE_MASK, &profile);
+		GL.GetIntegerv(GL_MAJOR_VERSION, &major);
+		GL.GetIntegerv(GL_MINOR_VERSION, &minor);
+		GL.GetIntegerv(GL_CONTEXT_PROFILE_MASK, &profile);
 		// The spec is clear a context can’t be both core and compatibility at the same time.
 		// However, the returned value is a mask. Ask Khronos why. -- numzero
 		if (profile & GL_CONTEXT_COMPATIBILITY_PROFILE_BIT)
@@ -66,8 +66,8 @@ namespace video {
 			MaxAnisotropy = GetInteger(GL.MAX_TEXTURE_MAX_ANISOTROPY);
 		MaxIndices = GetInteger(GL_MAX_ELEMENTS_INDICES);
 		MaxTextureSize = GetInteger(GL_MAX_TEXTURE_SIZE);
-		glGetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);
-		glGetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, DimAliasedLine);
+		GL.GetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);
+		GL.GetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, DimAliasedLine);
 		DimAliasedPoint[0] = 1.0f;
 		DimAliasedPoint[1] = 1.0f;
 	}

--- a/source/Irrlicht/OpenGLES2/Driver.cpp
+++ b/source/Irrlicht/OpenGLES2/Driver.cpp
@@ -14,7 +14,7 @@ namespace video {
 	}
 
 	OpenGLVersion COpenGLES2Driver::getVersionFromOpenGL() const {
-		auto version_string = reinterpret_cast<const char *>(glGetString(GL_VERSION));
+		auto version_string = reinterpret_cast<const char *>(GL.GetString(GL_VERSION));
 		int major, minor;
 		if (sscanf(version_string, "OpenGL ES %d.%d", &major, &minor) != 2) {
 			os::Printer::log("Failed to parse OpenGL ES version string", version_string, ELL_ERROR);
@@ -123,9 +123,9 @@ namespace video {
 			MaxIndices = GetInteger(GL_MAX_ELEMENTS_INDICES);
 		MaxTextureSize = GetInteger(GL_MAX_TEXTURE_SIZE);
 		if (TextureLODBiasSupported)
-			glGetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);
-		glGetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, DimAliasedLine); // NOTE: this is not in the OpenGL ES 2.0 spec...
-		glGetFloatv(GL_ALIASED_POINT_SIZE_RANGE, DimAliasedPoint);
+			GL.GetFloatv(GL_MAX_TEXTURE_LOD_BIAS, &MaxTextureLODBias);
+		GL.GetFloatv(GL_ALIASED_LINE_WIDTH_RANGE, DimAliasedLine); // NOTE: this is not in the OpenGL ES 2.0 spec...
+		GL.GetFloatv(GL_ALIASED_POINT_SIZE_RANGE, DimAliasedPoint);
 	}
 
 	IVideoDriver* createOGLES2Driver(const SIrrlichtCreationParameters& params, io::IFileSystem* io, IContextManager* contextManager)


### PR DESCRIPTION
This PR replaces all direct calls to the OpenGL library from the unified driver with calls via OpenGLProcedures. There are also a few fixes required for it to compile.

This is inspired by #232 but is much simpler. Also not all calls are replaced, those in e.g. COpenGLCoreTexture (shared with other drivers) remain. That shouldn’t be a problem as these drivers do that too and work (it might be the cause of some obscure bugs though).

I can’t test whether this Windows/SDL build actually works but given that it didn’t even compile, it is definitely better than before ;)