### PR TITLE
Revert "Remove the now unused SMaterialLayer::setFiltersMinetest method"

### DIFF
--- a/include/SMaterialLayer.h
+++ b/include/SMaterialLayer.h
@@ -232,6 +232,16 @@ namespace video
 		if the value is positive. */
 		s8 LODBias;
 
+		//! Sets the MinFilter, MagFilter and AnisotropicFilter properties according
+		//! to the three relevant boolean values found in the Minetest settings.
+		/** The value of `trilinear` takes precedence over the value of `bilinear`. */
+		void setFiltersMinetest(bool bilinear, bool trilinear, bool anisotropic) {
+			MinFilter = trilinear ? ETMINF_LINEAR_MIPMAP_LINEAR :
+					(bilinear ? ETMINF_LINEAR_MIPMAP_NEAREST : ETMINF_NEAREST_MIPMAP_NEAREST);
+			MagFilter = (trilinear || bilinear) ? ETMAGF_LINEAR : ETMAGF_NEAREST;
+			AnisotropicFilter = anisotropic ? 0xFF : 0;
+		}
+
 	private:
 		friend class SMaterial;
 


### PR DESCRIPTION
This reverts commit 1d4672bd92fb20c63806ef4bf0179a1aeecff16b.

The “now unused” code is needed again, as the Minetest PR that obsoleted it <https://github.com/minetest/minetest/pull/13683> had to be reverted due to causing several regressions in Minetest's texture filtering.