### PR TITLE
Android: Make ALooper_pollAll call always non-blocking

### DIFF
--- a/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
@@ -106,7 +106,7 @@ bool CIrrDeviceAndroid::run()
 	s32 Events = 0;
 	android_poll_source* Source = 0;
 
-	while ((id = ALooper_pollAll(((Focused && !Paused) || !Initialized) ? 0 : -1, 0, &Events, (void**)&Source)) >= 0)
+	while ((id = ALooper_pollAll(0, 0, &Events, (void**)&Source)) >= 0)
 	{
 		if(Source)
 			Source->process(Android, Source);


### PR DESCRIPTION
This PR tries to fix minetest/minetest#10842. See there for further discussion.

**Implementation details**

Original:

```cpp
((Focused && !Paused) || !Initialized) ? 0 : -1
```

Since we want Minetest to still run when the text box shows up (`Focused` is `false`) and when Minetest is minimised (`Paused` is `true`), we remove both variables from the formula.

```cpp
!Initialized ? 0 : -1
```

Because of this:

https://github.com/minetest/irrlicht/blob/85081d6fe0c422cf47f74714ee25562715528aa2/source/Irrlicht/Android/CIrrDeviceAndroid.cpp#L100-L101

we can remove `Initialized` from the formula.

```cpp
0
```