### PR TITLE
Initialize X11 thread safety

### DIFF
--- a/source/Irrlicht/CIrrDeviceLinux.cpp
+++ b/source/Irrlicht/CIrrDeviceLinux.cpp
@@ -147,6 +147,11 @@ CIrrDeviceLinux::CIrrDeviceLinux(const SIrrlichtCreationParameters& param)
 	// create keymap
 	createKeyMap();
 
+	// initialize X11 thread safety
+	// libX11 1.8+ has this on by default
+	// without it, multi-threaded GL drivers may crash
+	XInitThreads();
+
 	// create window
 	if (CreationParams.DriverType != video::EDT_NULL)
 	{


### PR DESCRIPTION
This fixes a crash in libx11 on Linux when resizing the window:

```
[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
minetest: ../../src/xcb_io.c:278: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed.
Aborted (core dumped)
```
Latest libx11 does not crash. Bisection found that it stopped crashing after [afcdb6fb0045](https://gitlab.freedesktop.org/xorg/lib/libx11/-/commit/afcdb6fb0045c6186aa83d9298f327a7ec1b2cb9) which enables thread-safety by default.

The issue appears to be that libX11 requires thread-safety to interact with multi-threaded mesa/nvidia/amd GL drivers.