### PR TITLE
Fix 10 MSVC narrowing cast warnings from irrString and irrArray

### DIFF
--- a/include/irrArray.h
+++ b/include/irrArray.h
@@ -241,7 +241,7 @@ public:
 	/** \return Size of elements in the array which are actually occupied. */
 	u32 size() const
 	{
-		return m_data.size();
+		return static_cast<u32>(m_data.size());
 	}
 
 
@@ -317,7 +317,7 @@ public:
 		// *it = first element in [first, last) that is >= element, or last if not found.
 		if (*it < element || element < *it)
 			return -1;
-		return it - m_data.begin();
+		return static_cast<u32>(it - m_data.begin());
 	}
 
 
@@ -335,8 +335,8 @@ public:
 		auto iters = std::equal_range(m_data.begin(), m_data.end(), element);
 		if (iters.first == iters.second)
 			return -1;
-		last = (iters.second - m_data.begin()) - 1;
-		return iters.first - m_data.begin();
+		last = static_cast<s32>((iters.second - m_data.begin()) - 1);
+		return static_cast<s32>(iters.first - m_data.begin());
 	}
 
 
@@ -351,7 +351,7 @@ public:
 		auto it = std::find(m_data.begin(), m_data.end(), element);
 		if (it == m_data.end())
 			return -1;
-		return it - m_data.begin();
+		return static_cast<u32>(it - m_data.begin());
 	}
 
 

--- a/include/irrString.h
+++ b/include/irrString.h
@@ -266,7 +266,7 @@ public:
 	the trailing NUL. */
 	u32 size() const
 	{
-		return str.size();
+		return static_cast<u32>(str.size());
 	}
 
 	//! Informs if the string is empty or not.
@@ -834,7 +834,7 @@ public:
 		if (!delimiter)
 			return 0;
 
-		const u32 oldSize=ret.size();
+		const u32 oldSize=static_cast<u32>(ret.size());
 
 		u32 tokenStartIdx = 0;
 		for (u32 i=0; i<size()+1; ++i)
@@ -862,7 +862,7 @@ public:
 		else if (!ignoreEmptyTokens)
 			ret.push_back(string<T>());
 
-		return ret.size()-oldSize;
+		return static_cast<u32>(ret.size()-oldSize);
 	}
 
 	// This function should not be used and is only kept for "CGUIFileOpenDialog::pathToStringW".
@@ -888,10 +888,10 @@ private:
 		return len;
 	}
 	static inline u32 calclen(const char* p) {
-		return strlen(p);
+		return static_cast<u32>(strlen(p));
 	}
 	static inline u32 calclen(const wchar_t* p) {
-		return wcslen(p);
+		return static_cast<u32>(wcslen(p));
 	}
 
 	//! strcmp wrapper


### PR DESCRIPTION
It seems these data structures sizes are intended to be limited to what fits in a u32 by the current implementation, so I've resolved the warnings by casting the sizes of the underlying STL types.

I saw these warnings in a Visual Studio 17 2022 Debug build with current master.