### PR TITLE
SDL: Implement touchscreen support

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -318,6 +318,8 @@ namespace irr
 
 		core::array<SKeyMap> KeyMap;
 		SDL_SysWMinfo Info;
+
+		s32 CurrentTouchCount;
 	};
 
 } // end namespace irr


### PR DESCRIPTION
This PR adds touchscreen support to the SDL device. It is a prerequisite for migrating the Android build to SDL.

Requires minetest/minetest#14117 and minetest/minetest#14118 to work correctly.

## To do

This PR is a Ready for Review.

Compared to `CIrrDeviceLinux` on the same device, I experience two problems:

1. `SDL_FINGERDOWN` events are delayed, they only arrive after a short delay or at the latest together with the corresponding `SDL_FINGERUP` event

3. ~~There are still emulated mouse events even though I disabled them~~ will be fixed by minetest/minetest#14118

Since issue no. 1 only happens on my Linux system, I have no idea how to fix it and it is not a dealbreaker, I declare this PR ready anyway.

## How to test

Buy a Linux/Windows/macOS device with a touchscreen.

Compile Minetest with `USE_SDL2=TRUE` and `ENABLE_TOUCH=TRUE`. Verify that everything works like on Android.