### PR TITLE
Use KHRONOS_APIENTRY to fix Win32 crash

### DIFF
--- a/include/mt_opengl.h
+++ b/include/mt_opengl.h
@@ -11,7 +11,7 @@
 #include <KHR/khrplatform.h>
 
 #ifndef APIENTRY
-	#define APIENTRY
+	#define APIENTRY KHRONOS_APIENTRY
 #endif
 #ifndef APIENTRYP
 	#define APIENTRYP APIENTRY *

--- a/scripts/BindingGenerator.lua
+++ b/scripts/BindingGenerator.lua
@@ -355,7 +355,7 @@ f:write[[
 #include <KHR/khrplatform.h>
 
 #ifndef APIENTRY
-	#define APIENTRY
+	#define APIENTRY KHRONOS_APIENTRY
 #endif
 #ifndef APIENTRYP
 	#define APIENTRYP APIENTRY *


### PR DESCRIPTION
Proposed solution to Windows 32-bit build crash.

The crash is caused by a calling convention mismatch. The default calling convention is cdecl, but the OpenGL functions returned by getProcAddress() are stdcall. This causes stack corruption unless function pointers are annotated with __stdcall.

For reference, this is how SDL3 determines the calling convention:

https://github.com/libsdl-org/SDL/blob/72b7acfe8ac26498dac57d751e1b3485d30a62e3/include/SDL3/SDL_opengl.h#L92-L103

This is how KHRONOS_APIENTRY is determined:

https://github.com/minetest/irrlicht/blob/9b52d6fb0db1e491b1d2787ef33c5c74aebb3558/source/Irrlicht/KHR/khrplatform.h#L122-L127