### PR TITLE
[no squash] Make equals method symmetric

### DIFF
--- a/include/vector2d.h
+++ b/include/vector2d.h
@@ -75,36 +75,37 @@ public:
 		return *(&X+index);
 	}
 
-	//! sort in order X, Y. Equality with rounding tolerance.
+	//! sort in order X, Y.
 	bool operator<=(const vector2d<T>&other) const
 	{
-		return (X<other.X || core::equals(X, other.X)) ||
-				(core::equals(X, other.X) && (Y<other.Y || core::equals(Y, other.Y)));
+		return !(*this > other);
 	}
 
-	//! sort in order X, Y. Equality with rounding tolerance.
+	//! sort in order X, Y.
 	bool operator>=(const vector2d<T>&other) const
 	{
-		return (X>other.X || core::equals(X, other.X)) ||
-				(core::equals(X, other.X) && (Y>other.Y || core::equals(Y, other.Y)));
+		return !(*this < other);
 	}
 
-	//! sort in order X, Y. Difference must be above rounding tolerance.
+	//! sort in order X, Y.
 	bool operator<(const vector2d<T>&other) const
 	{
-		return (X<other.X && !core::equals(X, other.X)) ||
-				(core::equals(X, other.X) && Y<other.Y && !core::equals(Y, other.Y));
+		return X < other.X || (X == other.X && Y < other.Y);
 	}
 
-	//! sort in order X, Y. Difference must be above rounding tolerance.
+	//! sort in order X, Y.
 	bool operator>(const vector2d<T>&other) const
 	{
-		return (X>other.X && !core::equals(X, other.X)) ||
-				(core::equals(X, other.X) && Y>other.Y && !core::equals(Y, other.Y));
+		return X > other.X || (X == other.X && Y > other.Y);
 	}
 
-	bool operator==(const vector2d<T>& other) const { return equals(other); }
-	bool operator!=(const vector2d<T>& other) const { return !equals(other); }
+	bool operator==(const vector2d<T>& other) const {
+		return X == other.X && Y == other.Y;
+	}
+
+	bool operator!=(const vector2d<T>& other) const {
+		return !(*this == other);
+	}
 
 	// functions
 

--- a/include/vector2d.h
+++ b/include/vector2d.h
@@ -111,11 +111,10 @@ public:
 	//! Checks if this vector equals the other one.
 	/** Takes floating point rounding errors into account.
 	\param other Vector to compare with.
-	\param tolerance Epsilon value for both - comparing X and Y.
 	\return True if the two vector are (almost) equal, else false. */
-	bool equals(const vector2d<T>& other, const T tolerance = (T)ROUNDING_ERROR_f32 ) const
+	bool equals(const vector2d<T>& other) const
 	{
-		return core::equals(X, other.X, tolerance) && core::equals(Y, other.Y, tolerance);
+		return core::equals(X, other.X) && core::equals(Y, other.Y);
 	}
 
 	vector2d<T>& set(T nx, T ny) {X=nx; Y=ny; return *this; }

--- a/include/vector3d.h
+++ b/include/vector3d.h
@@ -114,11 +114,9 @@ namespace core
 		// functions
 
 		//! returns if this vector equals the other one, taking floating point rounding errors into account
-		bool equals(const vector3d<T>& other, const T tolerance = (T)ROUNDING_ERROR_f32 ) const
+		bool equals(const vector3d<T>& other) const
 		{
-			return core::equals(X, other.X, tolerance) &&
-				core::equals(Y, other.Y, tolerance) &&
-				core::equals(Z, other.Z, tolerance);
+			return core::equals(X, other.X) && core::equals(Y, other.Y) && core::equals(Z, other.Z);
 		}
 
 		vector3d<T>& set(const T nx, const T ny, const T nz) {X=nx; Y=ny; Z=nz; return *this;}

--- a/include/vector3d.h
+++ b/include/vector3d.h
@@ -68,52 +68,48 @@ namespace core
 			return *(&X+index);
 		}
 
-		//! sort in order X, Y, Z. Equality with rounding tolerance.
+		//! sort in order X, Y, Z.
 		bool operator<=(const vector3d<T>&other) const
 		{
-			return (X<other.X || core::equals(X, other.X)) ||
-					(core::equals(X, other.X) && (Y<other.Y || core::equals(Y, other.Y))) ||
-					(core::equals(X, other.X) && core::equals(Y, other.Y) && (Z<other.Z || core::equals(Z, other.Z)));
+			return !(*this > other);
 		}
 
-		//! sort in order X, Y, Z. Equality with rounding tolerance.
+		//! sort in order X, Y, Z.
 		bool operator>=(const vector3d<T>&other) const
 		{
-			return (X>other.X || core::equals(X, other.X)) ||
-					(core::equals(X, other.X) && (Y>other.Y || core::equals(Y, other.Y))) ||
-					(core::equals(X, other.X) && core::equals(Y, other.Y) && (Z>other.Z || core::equals(Z, other.Z)));
+			return !(*this < other);
 		}
 
-		//! sort in order X, Y, Z. Difference must be above rounding tolerance.
+		//! sort in order X, Y, Z.
 		bool operator<(const vector3d<T>&other) const
 		{
-			return (X<other.X && !core::equals(X, other.X)) ||
-					(core::equals(X, other.X) && Y<other.Y && !core::equals(Y, other.Y)) ||
-					(core::equals(X, other.X) && core::equals(Y, other.Y) && Z<other.Z && !core::equals(Z, other.Z));
+			return X < other.X || (X == other.X && Y < other.Y) ||
+					(X == other.X && Y == other.Y && Z < other.Z);
 		}
 
-		//! sort in order X, Y, Z. Difference must be above rounding tolerance.
+		//! sort in order X, Y, Z.
 		bool operator>(const vector3d<T>&other) const
 		{
-			return (X>other.X && !core::equals(X, other.X)) ||
-					(core::equals(X, other.X) && Y>other.Y && !core::equals(Y, other.Y)) ||
-					(core::equals(X, other.X) && core::equals(Y, other.Y) && Z>other.Z && !core::equals(Z, other.Z));
+			return X > other.X || (X == other.X && Y > other.Y) ||
+					(X == other.X && Y == other.Y && Z > other.Z);
 		}
 
-		//! use weak float compare
 		bool operator==(const vector3d<T>& other) const
 		{
-			return this->equals(other);
+			return X == other.X && Y == other.Y && Z == other.Z;
 		}
 
 		bool operator!=(const vector3d<T>& other) const
 		{
-			return !this->equals(other);
+			return !(*this == other);
 		}
 
 		// functions
 
-		//! returns if this vector equals the other one, taking floating point rounding errors into account
+		//! Checks if this vector equals the other one.
+		/** Takes floating point rounding errors into account.
+		\param other Vector to compare with.
+		\return True if the two vector are (almost) equal, else false. */
 		bool equals(const vector3d<T>& other) const
 		{
 			return core::equals(X, other.X) && core::equals(Y, other.Y) && core::equals(Z, other.Z);


### PR DESCRIPTION
Fix minetest/minetest#14132
See https://github.com/minetest/minetest/issues/14132#issuecomment-1865302265
This fix is better as it also removes some nonsense.