### PR TITLE
Keep RTTI for Minetest IPO/LTO

### DIFF
--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -29,7 +29,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
 	set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 	set(CMAKE_CXX_FLAGS_DEBUG "-g")
 
-	add_compile_options(-Wall -pipe -fno-exceptions -fno-rtti)
+	add_compile_options(-Wall -pipe -fno-exceptions)
 
 	# Enable SSE for floating point math on 32-bit x86 by default
 	# reasoning see minetest issue #11810 and https://gcc.gnu.org/wiki/FloatingPointMath


### PR DESCRIPTION
Minetest using RTTI, so we cannot apply the flag here if we want to start using IPO/LTO.

If we keep `-fno-rtti` here, compiler loses part of informations and cannot do efficient optimizations.

The benefit of not using RTTI on Irrlicht disappears with when Minetest and Irrlicht gets IPO/LTO linked together.