### PR TITLE
Add IrrlichtDevice::isWindowVisible for Android

### DIFF
--- a/include/IrrlichtDevice.h
+++ b/include/IrrlichtDevice.h
@@ -177,6 +177,10 @@ namespace irr
 		/** \return True if window is fullscreen. */
 		virtual bool isFullscreen() const = 0;
 
+		//! Checks if the application is truly paused.
+		//! Currently, this can only happen on Android.
+		virtual bool isAppPaused() const { return false; };
+
 		//! Get the current color format of the window
 		/** \return Color format of the window. */
 		virtual video::ECOLOR_FORMAT getColorFormat() const = 0;

--- a/include/IrrlichtDevice.h
+++ b/include/IrrlichtDevice.h
@@ -177,9 +177,9 @@ namespace irr
 		/** \return True if window is fullscreen. */
 		virtual bool isFullscreen() const = 0;
 
-		//! Checks if the application is truly paused.
-		//! Currently, this can only happen on Android.
-		virtual bool isAppPaused() const { return false; };
+		//! Checks if the window could possibly be visible.
+		//! Currently, this only returns false when the app is paused on Android.
+		virtual bool isWindowVisible() const { return true; };
 
 		//! Get the current color format of the window
 		/** \return Color format of the window. */

--- a/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
@@ -193,6 +193,11 @@ bool CIrrDeviceAndroid::isWindowMinimized() const
 	return !Focused;
 }
 
+bool CIrrDeviceAndroid::isAppPaused() const
+{
+	return Paused;
+}
+
 void CIrrDeviceAndroid::closeDevice()
 {
 	ANativeActivity_finish(Android->activity);

--- a/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.cpp
@@ -193,9 +193,9 @@ bool CIrrDeviceAndroid::isWindowMinimized() const
 	return !Focused;
 }
 
-bool CIrrDeviceAndroid::isAppPaused() const
+bool CIrrDeviceAndroid::isWindowVisible() const
 {
-	return Paused;
+	return !Paused;
 }
 
 void CIrrDeviceAndroid::closeDevice()

--- a/source/Irrlicht/Android/CIrrDeviceAndroid.h
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.h
@@ -36,6 +36,8 @@ namespace irr
 
 		virtual bool isWindowMinimized() const;
 
+		virtual bool isAppPaused() const;
+
 		virtual void closeDevice();
 
 		virtual void setResizable(bool resize = false);

--- a/source/Irrlicht/Android/CIrrDeviceAndroid.h
+++ b/source/Irrlicht/Android/CIrrDeviceAndroid.h
@@ -36,7 +36,7 @@ namespace irr
 
 		virtual bool isWindowMinimized() const;
 
-		virtual bool isAppPaused() const;
+		virtual bool isWindowVisible() const;
 
 		virtual void closeDevice();
 


### PR DESCRIPTION
This PR adds a method called `isWindowVisible` to `IrrlichtDevice`. It returns false on Android if the app is paused and true in all other cases and on all other platforms.

This is necessary because `isWindowActive` and similar methods not only return false on Android when the app is paused, but also when it is merely "unfocused" (e.g. a text input dialog is open).