### PR TITLE
Update minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 # >=3.9 enables IPO; >=3.11 prefers GLVND
 if(${CMAKE_VERSION} VERSION_LESS 3.11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.12) 
 
 set(IRRLICHTMT_REVISION 13)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12) 
+cmake_minimum_required(VERSION 3.12)
 
 set(IRRLICHTMT_REVISION 13)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-# >=3.9 enables IPO; >=3.11 prefers GLVND
-if(${CMAKE_VERSION} VERSION_LESS 3.11)
-	cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-	cmake_policy(VERSION 3.11)
-endif()
-
 set(IRRLICHTMT_REVISION 13)
 
 project(Irrlicht


### PR DESCRIPTION
Cmake in engine currently very old.

Give it a few birthdays so we can use newer features.

We are missing the ability to add link libraries to object library targets. We'd like this for the glTF development.