### PR TITLE
Windows: Return early if the clipboard data is not in Unicode text forrmat

### DIFF
--- a/source/Irrlicht/COSOperator.cpp
+++ b/source/Irrlicht/COSOperator.cpp
@@ -159,10 +159,11 @@ const c8* COSOperator::getTextFromClipboard() const
 	if (!OpenClipboard(NULL))
 		return 0;
 
-	wchar_t * buffer = 0;
-
 	HANDLE hData = GetClipboardData( CF_UNICODETEXT );
-	buffer = (wchar_t*) GlobalLock( hData );
+	if (hData == NULL) // Probably not in Unicode text format
+		return 0;
+
+	wchar_t * buffer = (wchar_t*) GlobalLock( hData );
 
 	core::wStringToUTF8(ClipboardBuf, buffer);
 


### PR DESCRIPTION
This PR tries to fix minetest/minetest#14150. See there for further discussion.

[Documentation for `GetClipboardData()`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getclipboarddata)