### PR TITLE
Fix mip map size calculation for non-square textures

### DIFF
--- a/source/Irrlicht/COpenGLCoreTexture.h
+++ b/source/Irrlicht/COpenGLCoreTexture.h
@@ -561,6 +561,10 @@ protected:
 
 		u32 width = Size.Width >> level;
 		u32 height = Size.Height >> level;
+		if (width < 1)
+			width = 1;
+		if (height < 1)
+			height = 1;
 
 		GLenum tmpTextureType = TextureType;
 


### PR DESCRIPTION
# Problem description

The size of a mip map is `max{floor(width / 2 ^ level), 1} x max{floor(height / 2 ^ level), 1}`, where `width x height` is the size of the full-resolution image, `level` is the integer mip map level and the smallest mip map has `1 x 1` resolution. If `regenerateMipMapLevels` is called with custom mip map data, the mip map sizes are calculated in this function and separately in `uploadTexture`. `uploadTexture` calculates a size by `floor(width / 2 ^ level) x floor(height / 2 ^ level)`.

# Proposed changes

To support non-square textures, after this change, `uploadTexture` sets the mip map width or height to `1` if it is `0`.

# How to test

* Compile Minetest with the changes in [my mipmap_custom_simple_fill branch](https://github.com/HybridDog/minetest/tree/mipmap_custom_simple_fill)
* Use a texture pack to override the `default_desert_sand.png` texture with this 2x16 pixel texture: ![default_desert_sand](https://github.com/minetest/irrlicht/assets/3192173/5c85420a-9262-4cd6-bf64-dc658e609464)
* In the Minetest settings, set the `mip_map` setting to `sharp`
* Play Minetest and look at different nodes, especially at default's Desert Sand

Before the changes: Desert Sand nodes are black and in the inventory it's white. 
![before](https://github.com/minetest/irrlicht/assets/3192173/afade92c-474e-4dfa-a0a8-faea6a91dadc)

After the changes: Desert Sand looks like the other nodes, i.e. the full resolution and inventory image show the texture and only the mip maps are cyan, which is supposed to happen with the code in my mipmap_custom_simple_fill branch.
![after](https://github.com/minetest/irrlicht/assets/3192173/346dcc63-db0a-4857-b5ff-994f89ce9e8a)

