### PR TITLE
Optimize scene node child removal to constant time

### DIFF
--- a/include/ISceneNode.h
+++ b/include/ISceneNode.h
@@ -277,8 +277,9 @@ namespace scene
 				child->grab();
 				child->remove(); // remove from old parent
 				Children.push_back(child);
-				child->Iterator = Children.end();
-				(*child->Iterator)--;
+				// Note: This iterator is not invalidated until we erase it.
+				child->ThisIterator = Children.end();
+				--(*child->ThisIterator);
 				child->Parent = this;
 			}
 		}
@@ -294,8 +295,9 @@ namespace scene
 			if (child->Parent != this)
 				return false;
 
-			auto it = child->Iterator.value();
-			child->Iterator = std::nullopt;
+			// The iterator must be set since the parent is not null.
+			auto it = *child->ThisIterator;
+			child->ThisIterator = std::nullopt;
 			child->Parent = nullptr;
 			child->drop();
 			Children.erase(it);
@@ -311,7 +313,7 @@ namespace scene
 		{
 			for (auto &child : Children) {
 				child->Parent = nullptr;
-				child->Iterator = std::nullopt;
+				child->ThisIterator = std::nullopt;
 				child->drop();
 			}
 			Children.clear();
@@ -617,10 +619,11 @@ namespace scene
 		//! Pointer to the parent
 		ISceneNode* Parent;
 
-		std::optional<ISceneNodeList::iterator> Iterator;
-
 		//! List of all children of this node
 		std::list<ISceneNode*> Children;
+
+		//! Iterator pointing to this node in the parent's child list.
+		std::optional<ISceneNodeList::iterator> ThisIterator;
 
 		//! Pointer to the scene manager
 		ISceneManager* SceneManager;

--- a/include/ISceneNode.h
+++ b/include/ISceneNode.h
@@ -296,6 +296,7 @@ namespace scene
 				return false;
 
 			// The iterator must be set since the parent is not null.
+			_IRR_DEBUG_BREAK_IF(!child->ThisIterator.has_value());
 			auto it = *child->ThisIterator;
 			child->ThisIterator = std::nullopt;
 			child->Parent = nullptr;

--- a/include/ISceneNode.h
+++ b/include/ISceneNode.h
@@ -276,10 +276,8 @@ namespace scene
 
 				child->grab();
 				child->remove(); // remove from old parent
-				Children.push_back(child);
 				// Note: This iterator is not invalidated until we erase it.
-				child->ThisIterator = Children.end();
-				--(*child->ThisIterator);
+				child->ThisIterator = Children.insert(Children.end(), child);
 				child->Parent = this;
 			}
 		}
@@ -617,14 +615,14 @@ namespace scene
 		//! Relative scale of the scene node.
 		core::vector3df RelativeScale;
 
-		//! Pointer to the parent
-		ISceneNode* Parent;
-
 		//! List of all children of this node
 		std::list<ISceneNode*> Children;
 
 		//! Iterator pointing to this node in the parent's child list.
 		std::optional<ISceneNodeList::iterator> ThisIterator;
+
+		//! Pointer to the parent
+		ISceneNode* Parent;
 
 		//! Pointer to the scene manager
 		ISceneManager* SceneManager;


### PR DESCRIPTION
An attempt at fixing #274, briefly tested with Shadow Forest, but not profiled.

This relies on two invariants in `removeChild`:

* If a node is a child of another node, its parent property is set appropriately. (And if a node isn't a child of another node, it's parent property **must** be different from that other node.)
* If a node is a child of another node, the iterator points to the correct list node.

You can experimentally verify that these seem to hold by replacing the body of `removeChild` with the less efficient:

```cpp
ISceneNodeList::iterator it = Children.begin();
for (; it != Children.end(); ++it)
	if ((*it) == child)
	{
		assert(child->Parent == this);
		assert(it == child->Iterator);
		child->Iterator = std::nullopt;
		child->Parent = 0;
		child->drop();
		Children.erase(it);
		return true;
	}

assert(child->Parent != this);
return false;
```

The `assert`s should not be tripped.