### PR TITLE
Undefine SDL2 DirectFB video driver

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -17,6 +17,10 @@
 #endif
 
 #include <SDL.h>
+// DirectFB is removed in SDL3, thou distribution as Alpine currently ships SDL2
+// with enabled DirectFB, but requiring another fix at a top of SDL2.
+// We don't need DirectFB in Irrlicht/Minetest, so simply disable it here to prevent issues.
+#undef SDL_VIDEO_DRIVER_DIRECTFB
 #include <SDL_syswm.h>
 
 #include <memory>


### PR DESCRIPTION
1. we don't need it
2. it's dropped in SDL 3
3. it breaks compilation on Alpine and postmarketOS with SDL2 enabled (and the bug never going to get fixed on SDL2 side)