### PR TITLE
CMake: Move generator conditional expressions

### DIFF
--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -513,6 +513,7 @@ target_include_directories(IrrlichtMt
 		${link_includes}
 )
 
+# this needs to be here and not in a variable (like link_includes) due to issues with the generator expressions
 target_link_libraries(IrrlichtMt PRIVATE
 	${ZLIB_LIBRARY}
 	${JPEG_LIBRARY}

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -314,26 +314,6 @@ set(link_includes
 	"$<$<BOOL:${USE_X11}>:${X11_INCLUDE_DIR}>"
 )
 
-set(link_libs
-	"${ZLIB_LIBRARY}"
-	"${JPEG_LIBRARY}"
-	"${PNG_LIBRARY}"
-	"$<$<BOOL:${USE_SDL2}>:${SDL2_LIBRARIES}>"
-
-	"$<$<BOOL:${OPENGL_DIRECT_LINK}>:${OPENGL_LIBRARIES}>"
-	"$<$<BOOL:${OPENGLES_DIRECT_LINK}>:${OPENGLES_LIBRARY}>"
-	"$<$<BOOL:${OPENGLES2_DIRECT_LINK}>:${OPENGLES2_LIBRARIES}>"
-	${EGL_LIBRARY}
-
-	"$<$<PLATFORM_ID:Android>:-landroid -llog>"
-	${COCOA_LIB}
-	${IOKIT_LIB}
-	"$<$<PLATFORM_ID:Windows>:gdi32>"
-	"$<$<PLATFORM_ID:Windows>:winmm>"
-	"$<$<BOOL:${USE_X11}>:${X11_X11_LIB}>"
-	"$<$<BOOL:${USE_X11}>:${X11_Xi_LIB}>"
-)
-
 # Source files
 
 set(IRRMESHLOADER
@@ -533,7 +513,25 @@ target_include_directories(IrrlichtMt
 		${link_includes}
 )
 
-target_link_libraries(IrrlichtMt PRIVATE ${link_libs})
+target_link_libraries(IrrlichtMt PRIVATE
+	"${ZLIB_LIBRARY}"
+	"${JPEG_LIBRARY}"
+	"${PNG_LIBRARY}"
+	"$<$<BOOL:${USE_SDL2}>:${SDL2_LIBRARIES}>"
+
+	"$<$<BOOL:${OPENGL_DIRECT_LINK}>:${OPENGL_LIBRARIES}>"
+	"$<$<BOOL:${OPENGLES_DIRECT_LINK}>:${OPENGLES_LIBRARY}>"
+	"$<$<BOOL:${OPENGLES2_DIRECT_LINK}>:${OPENGLES2_LIBRARIES}>"
+	${EGL_LIBRARY}
+
+	"$<$<PLATFORM_ID:Android>:-landroid -llog>"
+	${COCOA_LIB}
+	${IOKIT_LIB}
+	"$<$<PLATFORM_ID:Windows>:gdi32>"
+	"$<$<PLATFORM_ID:Windows>:winmm>"
+	"$<$<BOOL:${USE_X11}>:${X11_X11_LIB}>"
+	"$<$<BOOL:${USE_X11}>:${X11_Xi_LIB}>"
+)
 
 if(WIN32)
 	target_compile_definitions(IrrlichtMt INTERFACE _IRR_WINDOWS_API_) # used in _IRR_DEBUG_BREAK_IF definition in a public header

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -513,7 +513,8 @@ target_include_directories(IrrlichtMt
 		${link_includes}
 )
 
-# this needs to be here and not in a variable (like link_includes) due to issues with the generator expressions
+# this needs to be here and not in a variable (like link_includes) due to issues
+# with the generator expressions on at least CMake 3.22, but not 3.28 or later
 target_link_libraries(IrrlichtMt PRIVATE
 	${ZLIB_LIBRARY}
 	${JPEG_LIBRARY}

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -514,9 +514,9 @@ target_include_directories(IrrlichtMt
 )
 
 target_link_libraries(IrrlichtMt PRIVATE
-	"${ZLIB_LIBRARY}"
-	"${JPEG_LIBRARY}"
-	"${PNG_LIBRARY}"
+	${ZLIB_LIBRARY}
+	${JPEG_LIBRARY}
+	${PNG_LIBRARY}
 	"$<$<BOOL:${USE_SDL2}>:${SDL2_LIBRARIES}>"
 
 	"$<$<BOOL:${OPENGL_DIRECT_LINK}>:${OPENGL_LIBRARIES}>"


### PR DESCRIPTION
OPENGL_LIBRARIES may contain multiple paths, separated by semicolons. In CMake 3.22.1 this results in an improper list of libraries. The workaround is to instead clear library paths that are not supposed to be linked.

`make` output right after commit 88ca26c41856144752ca60e77804933d6157e90a: (notice the stray `>` after libGLU.so)
```
make[2]: *** No rule to make target '/usr/lib/x86_64-linux-gnu/libGLU.so>', needed by 'lib/Linux/libIrrlichtMt.so.1.9.0.13'.  Stop.
make[1]: *** [CMakeFiles/Makefile2:289: source/Irrlicht/CMakeFiles/IrrlichtMt.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Investigating the variables reveals that there seems to be an issue with termination handling of semicolon-separated lists:
```
message("${OPENGL_LIBRARIES}")
--> /usr/lib/x86_64-linux-gnu/libGL.so;/usr/lib/x86_64-linux-gnu/libGLU.so
```

This change works on my side but if there's any saner solution, please let me know.