### PR TITLE
[SDL] Improve handling of IMEs

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -219,17 +219,29 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	gui::IGUIElement *elem = GUIEnvironment->getFocus();
 	if (elem && elem->acceptsIME())
 	{
-		core::rect<s32> pos = elem->getAbsolutePosition();
-		SDL_Rect rect;
-		rect.x = pos.UpperLeftCorner.X;
-		rect.y = pos.UpperLeftCorner.Y;
-		rect.w = pos.getWidth();
-		rect.h = pos.getHeight();
-		SDL_SetTextInputRect(&rect);
-		SDL_StartTextInput();
+		core::rect<s32> *pos = new core::rect<s32>(elem->getAbsolutePosition());
+		if (lastElemPos == NULL || *lastElemPos != *pos)
+		{
+			if (lastElemPos != NULL)
+				delete lastElemPos;
+			lastElemPos = pos;
+			SDL_Rect rect;
+			rect.x = pos->UpperLeftCorner.X;
+			rect.y = pos->UpperLeftCorner.Y;
+			rect.w = pos->getWidth();
+			rect.h = pos->getHeight();
+			SDL_SetTextInputRect(&rect);
+			SDL_StartTextInput();
+		}
+		else
+		{
+			delete pos;
+		}
 	}
 	else
 	{
+		delete lastElemPos;
+		lastElemPos = NULL;
 		SDL_StopTextInput();
 	}
 }
@@ -310,6 +322,8 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters& param)
 		createGUIAndScene();
 		VideoDriver->OnResize(core::dimension2d<u32>(Width, Height));
 	}
+
+	lastElemPos = NULL;
 }
 
 
@@ -323,6 +337,9 @@ CIrrDeviceSDL::~CIrrDeviceSDL()
 		for (u32 i=0; i<numJoysticks; ++i)
 			SDL_JoystickClose(Joysticks[i]);
 #endif
+		if (lastElemPos != NULL) {
+			delete lastElemPos;
+		}
 		if (Window)
 		{
 			SDL_GL_MakeCurrent(Window, NULL);

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -219,6 +219,10 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	gui::IGUIElement *elem = GUIEnvironment->getFocus();
 	if (elem && elem->acceptsIME())
 	{
+		// IBus seems to have an issue where dead keys and compose keys do not
+		// work (specifically, the individual characters in the sequence are
+		// sent as text input events instead of the result) when
+		// SDL_StartTextInput() is called on the same input box.
 		core::rect<s32> pos = elem->getAbsolutePosition();
 		if (!lastElemPos || *lastElemPos != pos)
 		{

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -219,14 +219,14 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	gui::IGUIElement *elem = GUIEnvironment->getFocus();
 	if (elem && elem->acceptsIME())
 	{
-		SDL_StartTextInput();
 		core::rect<s32> pos = elem->getAbsolutePosition();
 		SDL_Rect rect;
 		rect.x = pos.UpperLeftCorner.X;
 		rect.y = pos.UpperLeftCorner.Y;
-		rect.w = pos.LowerRightCorner.X - rect.x;
-		rect.h = pos.LowerRightCorner.Y - rect.y;
+		rect.w = pos.getWidth();
+		rect.h = pos.getHeight();
 		SDL_SetTextInputRect(&rect);
+		SDL_StartTextInput();
 	}
 	else
 	{

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -219,29 +219,22 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	gui::IGUIElement *elem = GUIEnvironment->getFocus();
 	if (elem && elem->acceptsIME())
 	{
-		core::rect<s32> *pos = new core::rect<s32>(elem->getAbsolutePosition());
-		if (lastElemPos == NULL || *lastElemPos != *pos)
+		core::rect<s32> pos = elem->getAbsolutePosition();
+		if (!lastElemPos || *lastElemPos != pos)
 		{
-			if (lastElemPos != NULL)
-				delete lastElemPos;
 			lastElemPos = pos;
 			SDL_Rect rect;
-			rect.x = pos->UpperLeftCorner.X;
-			rect.y = pos->UpperLeftCorner.Y;
-			rect.w = pos->getWidth();
-			rect.h = pos->getHeight();
+			rect.x = pos.UpperLeftCorner.X;
+			rect.y = pos.UpperLeftCorner.Y;
+			rect.w = pos.getWidth();
+			rect.h = pos.getHeight();
 			SDL_SetTextInputRect(&rect);
 			SDL_StartTextInput();
-		}
-		else
-		{
-			delete pos;
 		}
 	}
 	else
 	{
-		delete lastElemPos;
-		lastElemPos = NULL;
+		lastElemPos.reset();
 		SDL_StopTextInput();
 	}
 }
@@ -322,8 +315,6 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters& param)
 		createGUIAndScene();
 		VideoDriver->OnResize(core::dimension2d<u32>(Width, Height));
 	}
-
-	lastElemPos = NULL;
 }
 
 
@@ -337,9 +328,6 @@ CIrrDeviceSDL::~CIrrDeviceSDL()
 		for (u32 i=0; i<numJoysticks; ++i)
 			SDL_JoystickClose(Joysticks[i]);
 #endif
-		if (lastElemPos != NULL) {
-			delete lastElemPos;
-		}
 		if (Window)
 		{
 			SDL_GL_MakeCurrent(Window, NULL);

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -224,7 +224,7 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 		// sent as text input events instead of the result) when
 		// SDL_StartTextInput() is called on the same input box.
 		core::rect<s32> pos = elem->getAbsolutePosition();
-		if (!lastElemPos || *lastElemPos != pos)
+		if (!SDL_IsTextInputActive() || lastElemPos != pos)
 		{
 			lastElemPos = pos;
 			SDL_Rect rect;
@@ -238,7 +238,6 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	}
 	else
 	{
-		lastElemPos.reset();
 		SDL_StopTextInput();
 	}
 }

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -218,9 +218,20 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(int assumedChar, EKEY_CODE key) {
 void CIrrDeviceSDL::resetReceiveTextInputEvents() {
 	gui::IGUIElement *elem = GUIEnvironment->getFocus();
 	if (elem && elem->acceptsIME())
+	{
 		SDL_StartTextInput();
+		core::rect<s32> pos = elem->getAbsolutePosition();
+		SDL_Rect rect;
+		rect.x = pos.UpperLeftCorner.X;
+		rect.y = pos.UpperLeftCorner.Y;
+		rect.w = pos.LowerRightCorner.X - rect.x;
+		rect.h = pos.LowerRightCorner.Y - rect.y;
+		SDL_SetTextInputRect(&rect);
+	}
 	else
+	{
 		SDL_StopTextInput();
+	}
 }
 
 //! constructor

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -24,6 +24,7 @@
 #include <SDL_syswm.h>
 
 #include <memory>
+#include <optional>
 
 namespace irr
 {
@@ -303,7 +304,7 @@ namespace irr
 
 		bool Resizable;
 
-		core::rect<s32> *lastElemPos;
+		std::optional<core::rect<s32>> lastElemPos;
 
 		struct SKeyMap
 		{

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -24,7 +24,6 @@
 #include <SDL_syswm.h>
 
 #include <memory>
-#include <optional>
 
 namespace irr
 {
@@ -304,7 +303,7 @@ namespace irr
 
 		bool Resizable;
 
-		std::optional<core::rect<s32>> lastElemPos;
+		core::rect<s32> lastElemPos;
 
 		struct SKeyMap
 		{

--- a/source/Irrlicht/CIrrDeviceSDL.h
+++ b/source/Irrlicht/CIrrDeviceSDL.h
@@ -303,6 +303,8 @@ namespace irr
 
 		bool Resizable;
 
+		core::rect<s32> *lastElemPos;
+
 		struct SKeyMap
 		{
 			SKeyMap() {}


### PR DESCRIPTION
This PR sets the text input rectangle when text input is used. It allows (among other things) IMEs to position the text input candidate list correctly.

The screenshots below demonstrate the difference. In both screenshots, the "World name" input box is focused.

Before:
![2024-02-07-20-50-22](https://github.com/minetest/irrlicht/assets/37980625/20bc62a2-6f1f-454d-a081-e1b22e0ab9ad)

After:
![2024-02-07-20-57-00](https://github.com/minetest/irrlicht/assets/37980625/4a762cca-b4f4-402b-b090-93c6da5acfb7)

This also (at least partially) fixes minetest/minetest#13473 (dead keys and compose keys do seem to work under IBus for me now) by not restarting text input when this is not necessary.