### PR TITLE
Allow VBO to be used for meshes all the way down to 4 vertices.

### DIFF
--- a/source/Irrlicht/CNullDriver.cpp
+++ b/source/Irrlicht/CNullDriver.cpp
@@ -45,7 +45,7 @@ IImageWriter* createImageWriterPNG();
 //! constructor
 CNullDriver::CNullDriver(io::IFileSystem* io, const core::dimension2d<u32>& screenSize)
 	: SharedRenderTarget(0), CurrentRenderTarget(0), CurrentRenderTargetSize(0, 0), FileSystem(io), MeshManipulator(0),
-	ViewPort(0, 0, 0, 0), ScreenSize(screenSize), PrimitivesDrawn(0), MinVertexCountForVBO(500),
+	ViewPort(0, 0, 0, 0), ScreenSize(screenSize), PrimitivesDrawn(0), MinVertexCountForVBO(4),
 	TextureCreationFlags(0), OverrideMaterial2DEnabled(false), AllowZWriteOnTransparent(false)
 {
 	#ifdef _DEBUG


### PR DESCRIPTION
I used linux perf and GPUView (Windows) to examine rendering performance. I discovered in both cases that Minetest was CPU-bound, with the GPU barely being used. In particular, the CPU was spending most of its time in memory operations (CPU to GPU). I measured the transfer rate to be around 30GB/sec sustained.

Looking at the code, I discovered that the vast majority (80%) of map block meshes are under 500 vertices, and were therefore not being stored in VBOs, because of this arbitrary limit. They were being retransmitted in full every frame.

This boosts worst-case FPS (in Mineclonia) around 45% on my hardware, from 65fps to 95fps. (with default rendering distance)