### PR TITLE
Remove support for GL_POINT_SMOOTH and GL_LINE_SMOOTH antialiasing

### DIFF
--- a/include/SMaterial.h
+++ b/include/SMaterial.h
@@ -193,16 +193,9 @@ namespace video
 		EAAM_SIMPLE=1,
 		//! High-quality anti-aliasing, not always supported, automatically enables SIMPLE mode
 		EAAM_QUALITY=3,
-		//! Line smoothing
-		//! Careful, enabling this can lead to software emulation under OpenGL
-		EAAM_LINE_SMOOTH=4,
-		//! point smoothing, often in software and slow, only with OpenGL
-		EAAM_POINT_SMOOTH=8,
-		//! All typical anti-alias and smooth modes
-		EAAM_FULL_BASIC=15,
 		//! Enhanced anti-aliasing for transparent materials
 		/** Usually used with EMT_TRANSPARENT_ALPHA_CHANNEL_REF and multisampling. */
-		EAAM_ALPHA_TO_COVERAGE=16
+		EAAM_ALPHA_TO_COVERAGE=4
 	};
 
 	//! These flags allow to define the interpretation of vertex color when lighting is enabled

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -1796,7 +1796,6 @@ void COGLES1Driver::setBasicRenderStates(const SMaterial& material, const SMater
 	// Anti aliasing
 	if (resetAllRenderStates || lastmaterial.AntiAliasing != material.AntiAliasing)
 	{
-//		if (FeatureAvailable[IRR_ARB_multisample]) {
 		if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
 			glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
 		else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)

--- a/source/Irrlicht/COGLESDriver.cpp
+++ b/source/Irrlicht/COGLESDriver.cpp
@@ -125,8 +125,6 @@ bool COGLES1Driver::genericDriverInit(const core::dimension2d<u32>& screenSize, 
 
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_FASTEST);
 	glHint(GL_GENERATE_MIPMAP_HINT, GL_FASTEST);
-	glHint(GL_LINE_SMOOTH_HINT, GL_FASTEST);
-	glHint(GL_POINT_SMOOTH_HINT, GL_FASTEST);
 	glDepthFunc(GL_LEQUAL);
 	glFrontFace(GL_CW);
 	glAlphaFunc(GL_GREATER, 0.f);
@@ -1798,33 +1796,16 @@ void COGLES1Driver::setBasicRenderStates(const SMaterial& material, const SMater
 	// Anti aliasing
 	if (resetAllRenderStates || lastmaterial.AntiAliasing != material.AntiAliasing)
 	{
-//		if (FeatureAvailable[IRR_ARB_multisample])
-		{
-			if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
-			else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+//		if (FeatureAvailable[IRR_ARB_multisample]) {
+		if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
+			glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE);
+		else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
+			glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE);
 
-			if ((AntiAlias >= 2) && (material.AntiAliasing & (EAAM_SIMPLE|EAAM_QUALITY)))
-				glEnable(GL_MULTISAMPLE);
-			else
-				glDisable(GL_MULTISAMPLE);
-		}
-		if ((material.AntiAliasing & EAAM_LINE_SMOOTH) != (lastmaterial.AntiAliasing & EAAM_LINE_SMOOTH))
-		{
-			if (material.AntiAliasing & EAAM_LINE_SMOOTH)
-				glEnable(GL_LINE_SMOOTH);
-			else if (lastmaterial.AntiAliasing & EAAM_LINE_SMOOTH)
-				glDisable(GL_LINE_SMOOTH);
-		}
-		if ((material.AntiAliasing & EAAM_POINT_SMOOTH) != (lastmaterial.AntiAliasing & EAAM_POINT_SMOOTH))
-		{
-			if (material.AntiAliasing & EAAM_POINT_SMOOTH)
-				// often in software, and thus very slow
-				glEnable(GL_POINT_SMOOTH);
-			else if (lastmaterial.AntiAliasing & EAAM_POINT_SMOOTH)
-				glDisable(GL_POINT_SMOOTH);
-		}
+		if ((AntiAlias >= 2) && (material.AntiAliasing & (EAAM_SIMPLE|EAAM_QUALITY)))
+			glEnable(GL_MULTISAMPLE);
+		else
+			glDisable(GL_MULTISAMPLE);
 	}
 
 	// Texture parameters

--- a/source/Irrlicht/COpenGLDriver.cpp
+++ b/source/Irrlicht/COpenGLDriver.cpp
@@ -171,8 +171,6 @@ bool COpenGLDriver::genericDriverInit()
 
 	glClearDepth(1.0);
 	glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-	glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-	glHint(GL_POINT_SMOOTH_HINT, GL_FASTEST);
 	glFrontFace(GL_CW);
 	// adjust flat coloring scheme to DirectX version
 #if defined(GL_ARB_provoking_vertex) || defined(GL_EXT_provoking_vertex)
@@ -2557,46 +2555,29 @@ void COpenGLDriver::setBasicRenderStates(const SMaterial& material, const SMater
 	}
 
 	// Anti aliasing
-	if (resetAllRenderStates || lastmaterial.AntiAliasing != material.AntiAliasing)
-	{
-		if (FeatureAvailable[IRR_ARB_multisample])
-		{
-			if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE_ARB);
-			else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
-				glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE_ARB);
+	if (resetAllRenderStates
+			|| lastmaterial.AntiAliasing != material.AntiAliasing
+			&& FeatureAvailable[IRR_ARB_multisample]) {
+		if (material.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
+			glEnable(GL_SAMPLE_ALPHA_TO_COVERAGE_ARB);
+		else if (lastmaterial.AntiAliasing & EAAM_ALPHA_TO_COVERAGE)
+			glDisable(GL_SAMPLE_ALPHA_TO_COVERAGE_ARB);
 
-			if ((AntiAlias >= 2) && (material.AntiAliasing & (EAAM_SIMPLE|EAAM_QUALITY)))
-			{
-				glEnable(GL_MULTISAMPLE_ARB);
+		if ((AntiAlias >= 2) && (material.AntiAliasing & (EAAM_SIMPLE|EAAM_QUALITY)))
+		{
+			glEnable(GL_MULTISAMPLE_ARB);
 #ifdef GL_NV_multisample_filter_hint
-				if (FeatureAvailable[IRR_NV_multisample_filter_hint])
-				{
-					if ((material.AntiAliasing & EAAM_QUALITY) == EAAM_QUALITY)
-						glHint(GL_MULTISAMPLE_FILTER_HINT_NV, GL_NICEST);
-					else
-						glHint(GL_MULTISAMPLE_FILTER_HINT_NV, GL_FASTEST);
-				}
-#endif
+			if (FeatureAvailable[IRR_NV_multisample_filter_hint])
+			{
+				if ((material.AntiAliasing & EAAM_QUALITY) == EAAM_QUALITY)
+					glHint(GL_MULTISAMPLE_FILTER_HINT_NV, GL_NICEST);
+				else
+					glHint(GL_MULTISAMPLE_FILTER_HINT_NV, GL_FASTEST);
 			}
-			else
-				glDisable(GL_MULTISAMPLE_ARB);
+#endif
 		}
-		if ((material.AntiAliasing & EAAM_LINE_SMOOTH) != (lastmaterial.AntiAliasing & EAAM_LINE_SMOOTH))
-		{
-			if (material.AntiAliasing & EAAM_LINE_SMOOTH)
-				glEnable(GL_LINE_SMOOTH);
-			else if (lastmaterial.AntiAliasing & EAAM_LINE_SMOOTH)
-				glDisable(GL_LINE_SMOOTH);
-		}
-		if ((material.AntiAliasing & EAAM_POINT_SMOOTH) != (lastmaterial.AntiAliasing & EAAM_POINT_SMOOTH))
-		{
-			if (material.AntiAliasing & EAAM_POINT_SMOOTH)
-				// often in software, and thus very slow
-				glEnable(GL_POINT_SMOOTH);
-			else if (lastmaterial.AntiAliasing & EAAM_POINT_SMOOTH)
-				glDisable(GL_POINT_SMOOTH);
-		}
+		else
+			glDisable(GL_MULTISAMPLE_ARB);
 	}
 
 	// Texture parameters


### PR DESCRIPTION
These antialiasing techniques have been removed in OpenGL 3.1, they were often executed by the CPU, and Minetest does not use them. The OpenGL wiki recommends that we do not use this functionality in our program. https://www.khronos.org/opengl/wiki/Multisampling#Smooth_antialiasing