### PR TITLE
CFileSystem: Fix signed integer conversion on MinGW

### DIFF
--- a/source/Irrlicht/CFileSystem.cpp
+++ b/source/Irrlicht/CFileSystem.cpp
@@ -745,10 +745,10 @@ IFileList* CFileSystem::createFileList()
 
 		r = new CFileList(Path, true, false);
 
-        // uintptr_t is optional but supported by MinGW since 2007 or earlier.
-		uintptr_t hFile;
+        // intptr_t is optional but supported by MinGW since 2007 or earlier.
+		intptr_t hFile;
 		struct _tfinddata_t c_file;
-		if( (hFile = _tfindfirst( _T("*"), &c_file )) != (uintptr_t)(-1L) )
+		if( (hFile = _tfindfirst( _T("*"), &c_file )) != (intptr_t)(-1L) )
 		{
 			do
 			{

--- a/source/Irrlicht/CFileSystem.cpp
+++ b/source/Irrlicht/CFileSystem.cpp
@@ -745,15 +745,10 @@ IFileList* CFileSystem::createFileList()
 
 		r = new CFileList(Path, true, false);
 
-		// TODO: Should be unified once mingw adapts the proper types
-#if defined(__GNUC__)
-		long hFile; //mingw return type declaration
-#else
-		intptr_t hFile;
-#endif
-
+        // uintptr_t is optional but supported by MinGW since 2007 or earlier.
+		uintptr_t hFile;
 		struct _tfinddata_t c_file;
-		if( (hFile = _tfindfirst( _T("*"), &c_file )) != -1L )
+		if( (hFile = _tfindfirst( _T("*"), &c_file )) != (uintptr_t)(-1L) )
 		{
 			do
 			{


### PR DESCRIPTION
Fixes https://github.com/minetest/minetest/issues/14381

How to test:

1. Reproduce the crash (on Windows or Wine)
2. After the buildbot of this PR finished compiling, do check its "Artifacts" section and overwrite the `IrrlichtMt.dll` file of a comparably recent Minetest buildbot artifact.
3. Crash no longer happens
4. ???
5. Profit
