### PR TITLE
Ensure that std::abs is used and not integer abs

### DIFF
--- a/include/irrMath.h
+++ b/include/irrMath.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "irrTypes.h"
-#include <math.h>
+#include <cmath>
 #include <float.h>
-#include <stdlib.h> // for abs() etc.
+#include <cstdlib> // for abs() etc.
 #include <limits.h> // For INT_MAX / UINT_MAX
 #include <type_traits>
 
@@ -197,7 +197,7 @@ namespace core
 	template <class T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
 	inline bool equals(const T a, const T b, const T tolerance = roundingError<T>())
 	{
-		return abs(a - b) <= tolerance;
+		return std::abs(a - b) <= tolerance;
 	}
 
 	//! returns if a equals b, taking relative error in form of factor


### PR DESCRIPTION
I have C++20 enabled in xr build for MSVC, and `abs` triggers an error here because it is trying to choose between non-std integer versions of abs:

```
irrMath.h(200,10): error C2668: 'abs': ambiguous call to overloaded function 

  C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\stdlib.h(368,22):
  could be '__int64 abs(const __int64) noexcept'
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\stdlib.h(363,17):
  or       'long abs(const long) noexcept'
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\corecrt_math.h(470,38):
  or       'int abs(int)'
```

This fixes this error by ensuring std::abs is always used.