### PR TITLE
Missing value_or() when printing std::optional

### DIFF
--- a/source/Irrlicht/CB3DMeshFileLoader.cpp
+++ b/source/Irrlicht/CB3DMeshFileLoader.cpp
@@ -158,7 +158,7 @@ bool CB3DMeshFileLoader::readChunkNODE(CSkinnedMesh::SJoint *inJoint)
 	for ( u32 i=1; i < B3dStack.size(); ++i )
 		logStr += "-";
 	logStr += "read ChunkNODE";
-	os::Printer::log(logStr.c_str(), joint->Name.c_str(), ELL_DEBUG);
+	os::Printer::log(logStr.c_str(), joint->Name.value_or("").c_str(), ELL_DEBUG);
 #endif
 
 	f32 position[3], scale[3], rotation[4];


### PR DESCRIPTION
I found a compilation error when compiling IrrlichtMT in Debug mode. Because `joint->Name` has `std::optional` type, `value_or()` needs to be called first before `c_str()` (from `std::string`).

```diff
diff --git a/source/Irrlicht/CB3DMeshFileLoader.cpp b/source/Irrlicht/CB3DMeshFileLoader.cpp
index 85f76a4..59f35fd 100644
--- a/source/Irrlicht/CB3DMeshFileLoader.cpp
+++ b/source/Irrlicht/CB3DMeshFileLoader.cpp
@@ -158,7 +158,7 @@ bool CB3DMeshFileLoader::readChunkNODE(CSkinnedMesh::SJoint *inJoint)
 	for ( u32 i=1; i < B3dStack.size(); ++i )
 		logStr += "-";
 	logStr += "read ChunkNODE";
-	os::Printer::log(logStr.c_str(), joint->Name.c_str(), ELL_DEBUG);
+	os::Printer::log(logStr.c_str(), joint->Name.value_or("").c_str(), ELL_DEBUG);
 #endif
 
 	f32 position[3], scale[3], rotation[4];
```